### PR TITLE
Fix SonarQube badge URLs to point to correct instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 ## Code Quality
 **Overall Scorecard**  
 
-[![quality gate](.badges/alert_status.svg)](http://localhost:9000/dashboard?id=sample_sonar_projectKey)
-[![bugs](.badges/bugs.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=bugs)
-[![coverage](.badges/coverage.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=coverage)
-[![reliability](.badges/reliability_rating.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=reliability_rating)
-[![security](.badges/security_rating.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=security_rating)
-[![maintainability](.badges/sqale_rating.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=sqale_rating)
+[![quality gate](.badges/alert_status.svg)](http://44.206.255.230:9000/dashboard?id=Claude-MCP)
+[![bugs](.badges/bugs.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=bugs)
+[![coverage](.badges/coverage.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=coverage)
+[![reliability](.badges/reliability_rating.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=reliability_rating)
+[![security](.badges/security_rating.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=security_rating)
+[![maintainability](.badges/sqale_rating.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=sqale_rating)
 
 **Code Quality**  
 
-[![lines of code](.badges/ncloc.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=ncloc)
-[![duplicated lines](.badges/duplicated_lines_density.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=duplicated_lines_density)
-[![code smells](.badges/code_smells.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=code_smells)
-[![technical debt](.badges/sqale_index.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=sqale_index)
+[![lines of code](.badges/ncloc.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=ncloc)
+[![duplicated lines](.badges/duplicated_lines_density.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=duplicated_lines_density)
+[![code smells](.badges/code_smells.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=code_smells)
+[![technical debt](.badges/sqale_index.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=sqale_index)
 
 **Security**  
 
-[![security hotspots](.badges/security_hotspots.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=security_hotspots)
-[![vulnerabilities](.badges/vulnerabilities.svg)](http://localhost:9000/component_measures?id=sample_sonar_projectKey&metric=vulnerabilities)
+[![security hotspots](.badges/security_hotspots.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=security_hotspots)
+[![vulnerabilities](.badges/vulnerabilities.svg)](http://44.206.255.230:9000/component_measures?id=Claude-MCP&metric=vulnerabilities)
 
 # Claude Conversation Memory System
 


### PR DESCRIPTION
## Summary
- Updated all SonarQube badge links from localhost URLs to actual SonarQube instance (http://44.206.255.230:9000/)
- Changed project key from placeholder `sample_sonar_projectKey` to correct `Claude-MCP`

## Test plan
- [ ] Verify badges display correctly in README
- [ ] Confirm badge links navigate to correct SonarQube metrics pages

🤖 Generated with [Claude Code](https://claude.ai/code)