### PR TITLE
Add CODEOWNERS file for automated PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS file for claude-memory-mcp
+# This file defines who owns/reviews code in this repository
+# For more info: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global ownership - Adam White owns all files
+* @adamkwhite
+
+# Specific ownership for critical files
+/.github/ @adamkwhite
+/pyproject.toml @adamkwhite
+/src/ @adamkwhite
+/tests/ @adamkwhite


### PR DESCRIPTION
Adds CODEOWNERS file to replace deprecated dependabot.yml reviewers field