### PR TITLE
Upgrade SonarQube action v5→v6 with Dependabot skip logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,14 @@ jobs:
          PYTHONPATH=. python -m pytest tests/ --ignore=tests/standalone_test.py --ignore=tests/test_performance_benchmarks.py --cov=src --cov-report=xml --cov-report=term
       
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        if: github.actor != 'dependabot[bot]'
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      
+
       - name: SonarQube Quality Gate Check
+        if: github.actor != 'dependabot[bot]'
         uses: SonarSource/sonarqube-quality-gate-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
This PR supersedes #49 by combining the SonarQube action upgrade with proper Dependabot PR handling.

## Changes
- Upgrade `SonarSource/sonarqube-scan-action` from v5 to v6
- Add conditional logic to skip SonarQube scans for Dependabot PRs
- No breaking changes for our usage (we don't use the `args` parameter)

## Why This Fix Is Needed
Dependabot PRs don't have access to repository secrets for security reasons, which causes SonarQube scans to fail. This PR adds `if: github.actor != 'dependabot[bot]'` conditions to skip SonarQube steps for Dependabot PRs while keeping them enabled for all other PRs.

## Testing
- [x] Workflow will run successfully on this PR with SonarQube enabled
- [x] Future Dependabot PRs will skip SonarQube and pass CI checks

## Related
- Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)