### PR TITLE
Fix: Add missing sonar multicriteria declaration

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,5 +9,6 @@ sonar.exclusions=**/*test*/**,**/__pycache__/**,htmlcov/**,archive/**,scripts/**
 sonar.qualitygate.wait=true
 
 # Exclude python:S5852 (ReDoS vulnerabilities) - personal project with trusted input sources
+sonar.issue.ignore.multicriteria=e1
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S5852
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.py


### PR DESCRIPTION
## Problem
The `sonar.issue.ignore.multicriteria=e1` declaration line was missing from sonar-project.properties.

Without this line, the python:S5852 exclusion rules won't be applied by SonarCloud.

## Solution
Add the required declaration line:
```
sonar.issue.ignore.multicriteria=e1
```

## Impact
- ✅ python:S5852 (ReDoS) exclusion will now work correctly  
- ✅ Quality gate should remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)