### PR TITLE
Skip secret-dependent CI steps for Dependabot PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,11 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))) &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip SonarCloud/SonarQube and Claude Code Review CI steps for Dependabot PRs
- GitHub does not expose repository secrets to Dependabot PRs, causing these steps to fail
- Non-secret-dependent steps (lint, tests, security scans) still run normally

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Verify Dependabot PRs no longer fail on secret-dependent steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)