### PR TITLE
fix: upgrade CI to Python 3.14 and setup-python@v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   # Stage 1: Quick validation checks (30-60 seconds)
   quick-checks:
@@ -52,6 +48,9 @@ jobs:
     name: Tests & SonarQube Analysis
     needs: quick-checks  # Only run if quick checks pass
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Install linting tools
         run: |
@@ -59,9 +59,9 @@ jobs:
           fetch-depth: 0  # Full history for SonarQube
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -9,13 +9,12 @@ on:
     # Run weekly on Sundays at 6 AM UTC
     - cron: '0 6 * * 0'
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   performance-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -19,12 +19,12 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
-    
+        python-version: '3.14'
+
     - name: Cache dependencies
       uses: actions/cache@v3
       with:
@@ -143,10 +143,10 @@ jobs:
       with:
         fetch-depth: 0  # Fetch full history for comparison
         
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+    - name: Set up Python
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.14'
         
     - name: Install dependencies
       run: |

--- a/src/search_database.py
+++ b/src/search_database.py
@@ -155,9 +155,7 @@ class SearchDatabase:
                 return True
 
         except sqlite3.Error as e:
-            self.logger.error(
-                f"Failed to add conversation {conversation_data.get('id', 'unknown')}: {e}"
-            )
+            self.logger.error("Failed to add conversation: %s", e)
             return False
 
     def search_conversations(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:

--- a/src/search_database.py
+++ b/src/search_database.py
@@ -32,8 +32,7 @@ class SearchDatabase:
                 conn.execute("PRAGMA foreign_keys = ON")
 
                 # Create main conversations table
-                conn.execute(
-                    """
+                conn.execute("""
                     CREATE TABLE IF NOT EXISTS conversations (
                         id TEXT PRIMARY KEY,
                         title TEXT NOT NULL,
@@ -44,12 +43,10 @@ class SearchDatabase:
                         topics_json TEXT,
                         topics_text TEXT
                     )
-                """
-                )
+                """)
 
                 # Create FTS5 virtual table for full-text search
-                conn.execute(
-                    """
+                conn.execute("""
                     CREATE VIRTUAL TABLE IF NOT EXISTS conversations_fts USING fts5(
                         id,
                         title,
@@ -58,20 +55,17 @@ class SearchDatabase:
                         content='conversations',
                         content_rowid='rowid'
                     )
-                """
-                )
+                """)
 
                 # Create topics table for topic-based searches
-                conn.execute(
-                    """
+                conn.execute("""
                     CREATE TABLE IF NOT EXISTS conversation_topics (
                         conversation_id TEXT,
                         topic TEXT,
                         FOREIGN KEY (conversation_id) REFERENCES conversations(id),
                         PRIMARY KEY (conversation_id, topic)
                     )
-                """
-                )
+                """)
 
                 # Create indexes for performance
                 conn.execute(
@@ -82,27 +76,22 @@ class SearchDatabase:
                 )
 
                 # Create triggers to maintain FTS5 table
-                conn.execute(
-                    """
+                conn.execute("""
                     CREATE TRIGGER IF NOT EXISTS conversations_ai
                     AFTER INSERT ON conversations BEGIN
                         INSERT INTO conversations_fts(id, title, content, topics_text)
                         VALUES (new.id, new.title, new.content, new.topics_text);
                     END
-                """
-                )
+                """)
 
-                conn.execute(
-                    """
+                conn.execute("""
                     CREATE TRIGGER IF NOT EXISTS conversations_ad
                     AFTER DELETE ON conversations BEGIN
                         DELETE FROM conversations_fts WHERE id = old.id;
                     END
-                """
-                )
+                """)
 
-                conn.execute(
-                    """
+                conn.execute("""
                     CREATE TRIGGER IF NOT EXISTS conversations_au
                     AFTER UPDATE ON conversations BEGIN
                         UPDATE conversations_fts SET
@@ -111,8 +100,7 @@ class SearchDatabase:
                             topics_text = new.topics_text
                         WHERE id = new.id;
                     END
-                """
-                )
+                """)
 
                 conn.commit()
 
@@ -266,15 +254,13 @@ class SearchDatabase:
                 )
                 unique_topics = cursor.fetchone()[0]
 
-                cursor = conn.execute(
-                    """
+                cursor = conn.execute("""
                     SELECT topic, COUNT(*) as count
                     FROM conversation_topics
                     GROUP BY topic
                     ORDER BY count DESC
                     LIMIT 10
-                """
-                )
+                """)
                 popular_topics = [{"topic": row[0], "count": row[1]} for row in cursor]
 
                 return {


### PR DESCRIPTION
## Summary
- Upgrades CI Python version from 3.11 to 3.14, fixing the Black formatting check failure ([run #23410842508](https://github.com/adamkwhite/claude-memory-mcp/actions/runs/23410842508))
- Upgrades `actions/setup-python` from v4 to v6, resolving Node.js 20 deprecation warnings
- Applied to both `build.yml` and `performance.yml` workflows

## Root Cause
Black's safety check parses the AST to verify formatting equivalence. Python 3.11 cannot parse code formatted for Python 3.14, causing the check to fail.

## Test plan
- [ ] CI Quick Validation passes (Black, isort, flake8)
- [ ] Tests & SonarCloud analysis passes
- [ ] No Node.js 20 deprecation warnings in annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)