### PR TITLE
fix: auto-sync index.json and add dev dependencies

### DIFF
--- a/data/config/pyproject.toml
+++ b/data/config/pyproject.toml
@@ -10,6 +10,14 @@ dependencies = [
     "aiofiles>=24.1.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "pytest-asyncio>=0.21",
+    "psutil>=5.9",
+]
+
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/src/conversation_memory.py
+++ b/src/conversation_memory.py
@@ -79,6 +79,9 @@ class ConversationMemoryServer:
         # Initialize index files if they don't exist
         self._init_index_files()
 
+        # Sync index.json with conversation files on disk
+        self._sync_index_from_files()
+
     def _detect_data_directory_structure(self) -> bool:
         """
         Auto-detect whether to use new data/ structure or legacy structure.
@@ -106,12 +109,71 @@ class ConversationMemoryServer:
         if not self.index_file.exists():
             with open(self.index_file, "w") as f:
                 json.dump(
-                    {"conversations": [], "last_updated": datetime.now().isoformat()}, f
+                    {
+                        "conversations": [],
+                        "last_updated": datetime.now().isoformat(),
+                    },
+                    f,
                 )
 
         if not self.topics_file.exists():
             with open(self.topics_file, "w") as f:
-                json.dump({"topics": {}, "last_updated": datetime.now().isoformat()}, f)
+                json.dump(
+                    {"topics": {}, "last_updated": datetime.now().isoformat()},
+                    f,
+                )
+
+    def _sync_index_from_files(self):
+        """Rebuild index.json from conversation files on disk if out of sync."""
+        try:
+            with open(self.index_file, "r") as f:
+                index_data = json.load(f)
+            indexed_ids = {c["id"] for c in index_data.get("conversations", [])}
+        except (OSError, ValueError, KeyError, TypeError):
+            indexed_ids = set()
+            index_data = {
+                "conversations": [],
+                "last_updated": datetime.now().isoformat(),
+            }
+
+        # Scan all conversation JSON files on disk
+        conv_files = list(self.conversations_path.rglob("conv_*.json"))
+        if len(conv_files) <= len(indexed_ids):
+            return  # Already in sync or no files to add
+
+        added = 0
+        for conv_file in conv_files:
+            try:
+                with open(conv_file, "r", encoding="utf-8") as f:
+                    conv_data = json.load(f)
+                conv_id = conv_data.get("id", "")
+                if conv_id and conv_id not in indexed_ids:
+                    relative_path = conv_file.relative_to(self.storage_path)
+                    index_data["conversations"].append(
+                        {
+                            "id": conv_id,
+                            "title": conv_data.get("title", "Untitled"),
+                            "date": conv_data.get("date", ""),
+                            "topics": conv_data.get("topics", []),
+                            "file_path": str(relative_path),
+                            "added_at": conv_data.get(
+                                "created_at", datetime.now().isoformat()
+                            ),
+                        }
+                    )
+                    indexed_ids.add(conv_id)
+                    added += 1
+            except (OSError, ValueError, KeyError, TypeError):
+                continue
+
+        if added > 0:
+            index_data["last_updated"] = datetime.now().isoformat()
+            with open(self.index_file, "w") as f:
+                json.dump(index_data, f, indent=2)
+            self.logger.info(
+                f"Synced index.json: added {added} conversations "
+                f"({len(indexed_ids)} total)"
+            )
 
     def _get_date_folder(self, date: datetime) -> Path:
         """Get the folder path for a given date"""
@@ -216,7 +278,16 @@ class ConversationMemoryServer:
                 len(word) > 2
                 and word.lower() not in found_topics
                 and word
-                not in ["The", "This", "That", "When", "Where", "How", "What", "Why"]
+                not in [
+                    "The",
+                    "This",
+                    "That",
+                    "When",
+                    "Where",
+                    "How",
+                    "What",
+                    "Why",
+                ]
             ):
                 found_topics.append(word.lower())
 
@@ -299,7 +370,11 @@ class ConversationMemoryServer:
             }
 
     def _calculate_search_score(
-        self, query_terms: List[str], content: str, title: str, topics: List[str]
+        self,
+        query_terms: List[str],
+        content: str,
+        title: str,
+        topics: List[str],
     ) -> int:
         """Calculate relevance score for a conversation based on query terms"""
         score = 0
@@ -336,7 +411,9 @@ class ConversationMemoryServer:
                     "date": conv_data["date"],
                     "topics": conv_data["topics"],
                     "score": score,
-                    "preview": content[:200] + "..." if len(content) > 200 else content,
+                    "preview": (
+                        content[:200] + "..." if len(content) > 200 else content
+                    ),
                 }
             return None
 
@@ -618,7 +695,9 @@ class ConversationMemoryServer:
         stats = {
             "sqlite_available": SQLITE_AVAILABLE,
             "sqlite_enabled": self.use_sqlite_search,
-            "search_engine": "sqlite_fts" if self.use_sqlite_search else "linear_json",
+            "search_engine": (
+                "sqlite_fts" if self.use_sqlite_search else "linear_json"
+            ),
         }
 
         if self.use_sqlite_search and self.search_db:

--- a/tests/test_100_percent_coverage.py
+++ b/tests/test_100_percent_coverage.py
@@ -115,9 +115,7 @@ class TestCompleteEdgeCaseCoverage:
             test_file.chmod(0o644)
 
     @pytest.mark.asyncio
-    async def test_add_conversation_exception_handling(
-        self, server, temp_storage
-    ):
+    async def test_add_conversation_exception_handling(self, server, temp_storage):
         """Test add conversation with various exception scenarios"""
         # Test with a read-only conversations directory
         server.conversations_path.chmod(0o444)
@@ -160,9 +158,7 @@ class TestCompleteEdgeCaseCoverage:
             server.index_file.chmod(0o644)
 
     @pytest.mark.asyncio
-    async def test_update_topics_index_exception_handling(
-        self, server, temp_storage
-    ):
+    async def test_update_topics_index_exception_handling(self, server, temp_storage):
         """Test topics index update exception handling (line 237)"""
         # Make topics file unwritable
         server.topics_file.chmod(0o444)
@@ -244,9 +240,7 @@ class TestCompleteEdgeCaseCoverage:
         assert "Learning How To" in summary
 
     @pytest.mark.asyncio
-    async def test_weekly_summary_content_read_exception(
-        self, server, temp_storage
-    ):
+    async def test_weekly_summary_content_read_exception(self, server, temp_storage):
         """Test weekly summary when conversation file read fails (lines 298-299)"""
         current_time = datetime.now()
 
@@ -321,15 +315,11 @@ class TestCompleteEdgeCaseCoverage:
         # Verify summary structure and content
         assert len(summary) > 100
         assert (
-            "Weekly Summary" in summary
-            or "## " in summary
-            or "API Design" in summary
+            "Weekly Summary" in summary or "## " in summary or "API Design" in summary
         )
 
     @pytest.mark.asyncio
-    async def test_weekly_summary_file_saving_and_path(
-        self, server, temp_storage
-    ):
+    async def test_weekly_summary_file_saving_and_path(self, server, temp_storage):
         """Test weekly summary file saving functionality"""
         current_time = datetime.now()
 
@@ -669,10 +659,7 @@ class TestMCPToolWrapperFunctions:
 
         # Should return formatted message for no results
         assert isinstance(result, str)
-        assert (
-            "Found 0 conversations" in result
-            or "No conversations found" in result
-        )
+        assert "Found 0 conversations" in result or "No conversations found" in result
 
     @pytest.mark.asyncio
     async def test_mcp_search_tool_success_formatting(self, server):
@@ -840,6 +827,115 @@ class TestConversationMemoryServerDirect:
         assert "topics" in topics_data
         assert "last_updated" in topics_data
 
+    def test_sync_index_from_files_backfills_missing(self, server):
+        """Test that _sync_index_from_files adds files missing from index"""
+        # Create a conversation file on disk without going through add_conversation
+        date_folder = server.conversations_path / "2025" / "01-january"
+        date_folder.mkdir(parents=True, exist_ok=True)
+        conv_file = date_folder / "conv_20250115_100000_1234.json"
+        conv_data = {
+            "id": "conv_20250115_100000_1234",
+            "title": "Test backfill",
+            "content": "Some content",
+            "date": "2025-01-15T10:00:00",
+            "topics": ["test"],
+            "created_at": "2025-01-15T10:00:00",
+        }
+        with open(conv_file, "w") as f:
+            json.dump(conv_data, f)
+
+        # Index should be empty before sync
+        with open(server.index_file, "r") as f:
+            before = json.load(f)
+        assert len(before["conversations"]) == 0
+
+        # Run sync
+        server._sync_index_from_files()
+
+        # Index should now have the conversation
+        with open(server.index_file, "r") as f:
+            after = json.load(f)
+        assert len(after["conversations"]) == 1
+        assert after["conversations"][0]["id"] == "conv_20250115_100000_1234"
+
+    def test_sync_index_from_files_skips_already_indexed(self, server):
+        """Test that _sync_index_from_files skips conversations already in index"""
+        # Create a file and sync it
+        date_folder = server.conversations_path / "2025" / "02-february"
+        date_folder.mkdir(parents=True, exist_ok=True)
+        conv_file = date_folder / "conv_20250201_120000_5678.json"
+        conv_data = {
+            "id": "conv_20250201_120000_5678",
+            "title": "Already indexed",
+            "content": "Content",
+            "date": "2025-02-01T12:00:00",
+            "topics": ["test"],
+            "created_at": "2025-02-01T12:00:00",
+        }
+        with open(conv_file, "w") as f:
+            json.dump(conv_data, f)
+
+        server._sync_index_from_files()
+
+        with open(server.index_file, "r") as f:
+            first_sync = json.load(f)
+        count_after_first = len(first_sync["conversations"])
+
+        # Run sync again — should not duplicate
+        server._sync_index_from_files()
+
+        with open(server.index_file, "r") as f:
+            second_sync = json.load(f)
+        assert len(second_sync["conversations"]) == count_after_first
+
+    def test_sync_index_from_files_handles_corrupt_file(self, server):
+        """Test that _sync_index_from_files skips corrupt JSON files"""
+        date_folder = server.conversations_path / "2025" / "03-march"
+        date_folder.mkdir(parents=True, exist_ok=True)
+        corrupt_file = date_folder / "conv_20250301_000000_0000.json"
+        with open(corrupt_file, "w") as f:
+            f.write("not valid json{{{")
+
+        # Should not raise
+        server._sync_index_from_files()
+
+        with open(server.index_file, "r") as f:
+            index_data = json.load(f)
+        # Corrupt file should be skipped
+        ids = [c["id"] for c in index_data["conversations"]]
+        assert "conv_20250301_000000_0000" not in ids
+
+    def test_sync_index_from_files_handles_corrupt_index(self, temp_storage):
+        """Test sync when index.json itself is corrupt"""
+        server = ConversationMemoryServer(temp_storage, enable_sqlite=False)
+        # Corrupt index.json
+        with open(server.index_file, "w") as f:
+            f.write("broken")
+
+        # Create a valid conversation file
+        date_folder = server.conversations_path / "2025" / "04-april"
+        date_folder.mkdir(parents=True, exist_ok=True)
+        conv_file = date_folder / "conv_20250401_000000_9999.json"
+        with open(conv_file, "w") as f:
+            json.dump(
+                {
+                    "id": "conv_20250401_000000_9999",
+                    "title": "After corrupt index",
+                    "content": "Content",
+                    "date": "2025-04-01T00:00:00",
+                    "topics": [],
+                    "created_at": "2025-04-01T00:00:00",
+                },
+                f,
+            )
+
+        # Sync should recover and rebuild
+        server._sync_index_from_files()
+
+        with open(server.index_file, "r") as f:
+            index_data = json.load(f)
+        assert len(index_data["conversations"]) == 1
+
     def test_get_date_folder(self, server):
         """Test date folder creation"""
         test_date = datetime(2025, 3, 15, 10, 30, 45)
@@ -949,15 +1045,11 @@ class TestConversationMemoryServerDirect:
     @pytest.mark.asyncio
     async def test_search_conversations_empty(self, server):
         """Test search with no results"""
-        results = await server.search_conversations(
-            "nonexistentterm12345", limit=5
-        )
+        results = await server.search_conversations("nonexistentterm12345", limit=5)
         assert len(results) == 0
 
     @pytest.mark.asyncio
-    async def test_search_conversations_missing_file(
-        self, server, temp_storage
-    ):
+    async def test_search_conversations_missing_file(self, server, temp_storage):
         """Test search when conversation file is missing"""
         # Add conversation
         result = await server.add_conversation(
@@ -1003,9 +1095,7 @@ Line 4: More content"""
         test_title = "Index Test"
 
         # Create a fake file path
-        fake_path = (
-            server.conversations_path / "2025" / "01-january" / "test.md"
-        )
+        fake_path = server.conversations_path / "2025" / "01-january" / "test.md"
         fake_path.parent.mkdir(parents=True, exist_ok=True)
         fake_path.touch()
 
@@ -1103,9 +1193,7 @@ Line 4: More content"""
 
         try:
             # Add a conversation so it tries to write a summary file
-            await server.add_conversation(
-                "Test", "Test", "2025-06-12T10:00:00"
-            )
+            await server.add_conversation("Test", "Test", "2025-06-12T10:00:00")
             summary = await server.generate_weekly_summary(0)
             # Should either succeed with read-only directory or fail gracefully
             assert isinstance(summary, str)
@@ -1140,9 +1228,7 @@ class TestServerExceptionCoverage:
 
             try:
                 # This should catch the SQLite exception and continue
-                server = ConversationMemoryServer(
-                    temp_storage, enable_sqlite=True
-                )
+                server = ConversationMemoryServer(temp_storage, enable_sqlite=True)
                 # Server should still be created but with SQLite disabled
                 assert not server.use_sqlite_search
             finally:
@@ -1163,9 +1249,7 @@ class TestServerExceptionCoverage:
                 # Exception handling should log and possibly continue
                 assert "JSON write failed" in str(e)
 
-    def test_index_file_creation_permission_error_lines_115_116(
-        self, temp_storage
-    ):
+    def test_index_file_creation_permission_error_lines_115_116(self, temp_storage):
         """Test index file creation permission errors"""
         from unittest.mock import patch
 
@@ -1233,9 +1317,7 @@ class TestServerExceptionCoverage:
         # The method should handle missing files gracefully
         assert isinstance(result, list)
 
-    def test_additional_error_handling_lines_507_510(
-        self, server, temp_storage
-    ):
+    def test_additional_error_handling_lines_507_510(self, server, temp_storage):
         """Test additional error handling scenarios"""
         from unittest.mock import patch
 


### PR DESCRIPTION
## Summary
- Added `_sync_index_from_files()` that rebuilds `index.json` at startup by scanning `conv_*.json` files on disk — fixes index having only 2 entries while 371 conversations existed
- Added `[project.optional-dependencies] dev` group with pytest, pytest-cov, pytest-asyncio, and psutil so `test_performance_benchmarks.py` collects in local dev environments

## Changes
- `src/conversation_memory.py`: New `_sync_index_from_files()` method called during `__init__`, scans for conversation files missing from the index and backfills them
- `data/config/pyproject.toml`: Added optional `dev` dependency group

## Test plan
- [x] 435 tests passing locally (including test_performance_benchmarks.py)
- [x] Verified sync rebuilds index from 2 → 379 entries against production data
- [x] No-op on subsequent startups when already in sync
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)