### PR TITLE
fix(tests): unshadow duplicate test_get_preview_exception_handling and close test-consolidation todo

### DIFF
--- a/tests/test_100_percent_coverage.py
+++ b/tests/test_100_percent_coverage.py
@@ -101,8 +101,15 @@ class TestCompleteEdgeCaseCoverage:
             assert any("error" in str(result) for result in results)
         # If empty, that's also valid error handling behavior
 
-    def test_get_preview_exception_handling(self, server, temp_storage):
-        """Test preview generation exception handling (lines 139-140)"""
+    def test_get_preview_exception_handling_unreadable_file(self, server, temp_storage):
+        """Test _get_preview exception path via unreadable file (lines 139-140).
+
+        Renamed from test_get_preview_exception_handling: the original name
+        collided with the async test at line 429 (same class), so Python
+        silently shadowed this method and it never ran. The unreadable-file
+        exception path is distinct from the nonexistent-file path covered by
+        test_get_preview_exception_handling_private.
+        """
         # Create a file that will cause an exception when reading
         test_file = Path(temp_storage) / "bad_file.md"
         test_file.touch()
@@ -489,7 +496,9 @@ class TestCompleteEdgeCaseCoverage:
         # Test with no title provided to trigger auto-generation
         long_content = "This is a very long first line that should be truncated when used as a title because it exceeds fifty characters in length"
         await server.add_conversation(
-            long_content, None, "2025-06-02T10:00:00Z"  # No title provided
+            long_content,
+            None,
+            "2025-06-02T10:00:00Z",  # No title provided
         )
 
         # Check that title was auto-generated and truncated
@@ -1225,7 +1234,6 @@ class TestServerExceptionCoverage:
             "conversation_memory.SearchDatabase",
             side_effect=Exception("SQLite initialization failed"),
         ):
-
             try:
                 # This should catch the SQLite exception and continue
                 server = ConversationMemoryServer(temp_storage, enable_sqlite=True)

--- a/todos.md
+++ b/todos.md
@@ -116,11 +116,11 @@ This file maintains persistent todos across Claude Code sessions.
   - ✅ Added 24 security tests with 100% validation coverage
   - ✅ Custom exceptions with clear error messages
   - ✅ Maintains zero security hotspots in SonarQube
-- [ ] **Consolidate redundant test files** - Address PR review feedback
-  - Merge test_final_100_percent_coverage.py into test_100_percent_coverage.py
-  - Merge test_final_2_lines.py into appropriate existing test files
-  - Remove duplicate test coverage that already exists in other files
-  - Aim to reduce from 17 test files to ~12-13 focused test files
+- [x] **Consolidate redundant test files** - Address PR review feedback ✅ COMPLETED (April 18, 2026)
+  - ✅ test_final_100_percent_coverage.py and test_final_2_lines.py were already merged in earlier work (no longer present)
+  - ✅ Audit (April 18, 2026) confirmed current layout is 13 top-level test files + 6 importer/schema files in subpackages, matching the original "12-13 focused" target
+  - ✅ Cross-file name overlaps (e.g. test_add_conversation, test_search_conversations, test_extract_topics_basic) verified as legitimate — they exercise different layers (functional server, FastMCP wrapper, SQLite, performance, importers) or different objects (ConversationMemoryServer vs BaseImporter), not duplicate coverage
+  - ✅ Found and fixed one real bug surfaced by the audit: `test_get_preview_exception_handling` in `TestCompleteEdgeCaseCoverage` was defined twice in the same class (lines 104 and 429), so Python silently shadowed the first method and the unreadable-file branch never ran. Renamed to `test_get_preview_exception_handling_unreadable_file`; both branches now run (440 → 441 collected tests)
 - [ ] Implement centralized configuration management system
 - [x] **Add proper logging throughout the application** ✅ COMPLETED
   - ✅ PR #13: Implemented comprehensive logging system


### PR DESCRIPTION
## Summary

Audit of the medium-priority "Consolidate redundant test files" todo. The literal items in the todo (merging `test_final_100_percent_coverage.py` and `test_final_2_lines.py`) are stale — those files were merged in earlier work and no longer exist. The current layout (13 top-level test files + 6 importer/schema files in subpackages) already matches the original "12-13 focused" target.

While auditing for actual cross-file duplication, I found a real bug worth shipping:

- `tests/test_100_percent_coverage.py` defined `test_get_preview_exception_handling` **twice** in the same class (`TestCompleteEdgeCaseCoverage`), at lines 104 and 429. Python silently bound only the second, so the line-104 test (covering the unreadable-file branch of `_get_preview`) never ran. mypy on `main` even reports this: `Name "test_get_preview_exception_handling" already defined on line 104 [no-redef]`.
- Renamed the line-104 sync test to `test_get_preview_exception_handling_unreadable_file`, so both exception paths (unreadable file vs nonexistent file) are now collected and executed.
- Local suite: **439 → 440 passing** (1 previously-shadowed test now runs).
- `todos.md` updated to mark the consolidation item complete with an audit summary.

## Audit findings (no further consolidation needed)

I checked all 26 test names that appear in more than one file. The cross-file overlaps are legitimate, not duplication:

- **Importer "duplicates"** (e.g. `test_importer_initialization`, `test_save_conversation`, `test_import_file_nonexistent` in 4–5 files): each importer test file independently exercises the same `BaseImporter` interface against a different concrete subclass (chatgpt/claude/cursor/generic). Correct pattern.
- **`test_add_conversation`** in 5 files: tests different layers — `ConversationMemoryServer` (functional), FastMCP wrapper, performance benchmarks, SQLite storage layer.
- **`test_search_conversations`** in 3 files: functional vs SQLite vs error-path coverage.
- **`test_extract_topics_basic`/`_quoted_terms`** in 2 files: tests `ConversationMemoryServer._extract_topics` vs `BaseImporter._extract_topics` — different methods on different classes.
- **`test_dangerous_characters_removed`** twice in `test_input_validation.py`: in different classes (`TestTitleValidation` vs `TestQueryValidation`), testing different validators. Fine.

## Other issues surfaced (filed as separate todos, not fixed here)

1. **Pre-existing mypy errors on test files**: tests use runtime `sys.path` manipulation that mypy can't follow, so `import pytest` / `import conversation_memory` / `import server_fastmcp` all fail mypy. Pre-existing on `main`, not blocking CI. Needs a separate type-config PR.
2. **Broken `pre-commit.legacy` chain on this dev machine**: the new pre-commit framework chains to an old custom hook that calls `black --check`, but local `black` is broken (`ModuleNotFoundError: pathspec.patterns.gitignore`). Local-only, not in CI. The configured ruff-format check (project source of truth) passed.

## Test plan

- [x] `pytest tests/ --ignore=tests/standalone_test.py` — 440 passed, 1 skipped (was 439 passed before fix)
- [x] Verified the previously-shadowed test now collects: `pytest -k test_get_preview_exception_handling -v` shows 3 tests (was 2)
- [x] Coverage unchanged (62% same as baseline)
- [x] Confirmed the renamed test still exercises the same code path (`_get_preview` with unreadable file → "Preview unavailable")