### PR TITLE
feat: add centralized configuration module (src/config.py)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,8 +104,10 @@ benchmark_data/
 /None/
 /test_*/
 /*test*/
+# Re-include the canonical tests directory (overrides /*test*/ above)
+!/tests/
 
-# Test data artifacts  
+# Test data artifacts
 test_*.db
 test_*.db-journal
 **/test_*.json

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,344 @@
+"""Centralized configuration for the Claude Memory MCP system.
+
+This module exposes a :class:`Config` dataclass that consolidates settings
+previously scattered across environment variables and module-level constants
+in ``server_fastmcp.py``, ``logging_config.py`` and ``path_utils.py``.
+
+Loading precedence (highest wins)::
+
+    1. Environment variables (``CLAUDE_MEMORY_*`` / ``CLAUDE_MCP_*``)
+    2. Configuration file (default ``~/.claude-memory/config.json``)
+    3. Built-in defaults
+
+A configuration file is optional; when absent the defaults are used. The file
+format is JSON with a flat structure mirroring the dataclass fields, e.g.::
+
+    {
+        "storage_path": "~/claude-memory",
+        "log_format": "json",
+        "log_level": "INFO",
+        "enable_sqlite": true,
+        "console_output": false,
+        "platform_profile": "default"
+    }
+
+This module is intentionally side-effect free: importing it does not read any
+files, parse any environment variables or create directories.  Call
+:meth:`Config.load` to build a config from the environment + file, and
+:meth:`Config.validate` to check the result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, fields, replace
+from pathlib import Path
+from typing import Any, ClassVar, Dict, Mapping, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Default location for the on-disk configuration file.
+DEFAULT_CONFIG_FILE: Path = Path.home() / ".claude-memory" / "config.json"
+
+#: Default location for conversation storage. Mirrors ``path_utils``.
+DEFAULT_STORAGE_PATH: str = "~/claude-memory"
+
+#: Allowed values for :attr:`Config.log_format`.
+VALID_LOG_FORMATS: tuple[str, ...] = ("text", "json")
+
+#: Allowed values for :attr:`Config.log_level`.
+VALID_LOG_LEVELS: tuple[str, ...] = (
+    "DEBUG",
+    "INFO",
+    "WARNING",
+    "ERROR",
+    "CRITICAL",
+)
+
+#: Built-in platform profiles. Each profile supplies a partial set of
+#: defaults that are layered onto the base defaults.  Users can extend this
+#: behaviour by selecting a profile via the ``platform_profile`` field.
+PLATFORM_PROFILES: Dict[str, Dict[str, Any]] = {
+    "default": {},
+    "claude": {
+        "log_format": "text",
+        "enable_sqlite": True,
+    },
+    "chatgpt": {
+        "log_format": "json",
+        "enable_sqlite": True,
+    },
+    "cursor": {
+        "log_format": "text",
+        "enable_sqlite": True,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class ConfigError(ValueError):
+    """Raised when configuration loading or validation fails."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_bool(value: Any) -> bool:
+    """Parse a value into a boolean using common truthy/falsy strings.
+
+    Accepts strings (case-insensitive: ``true``/``false``, ``1``/``0``,
+    ``yes``/``no``, ``on``/``off``) as well as native ``bool``/``int`` types.
+
+    Raises:
+        ConfigError: If ``value`` cannot be interpreted as a boolean.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise ConfigError(f"Cannot interpret value as boolean: {value!r}")
+
+
+# ---------------------------------------------------------------------------
+# Config dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Config:
+    """Application configuration.
+
+    Attributes:
+        storage_path: Directory used for conversation storage. Mirrors the
+            ``CLAUDE_MEMORY_PATH`` environment variable.
+        log_format: One of ``"text"`` or ``"json"``. Mirrors
+            ``CLAUDE_MCP_LOG_FORMAT``.
+        log_level: Standard ``logging`` level name. Mirrors
+            ``CLAUDE_MCP_LOG_LEVEL``.
+        enable_sqlite: Whether SQLite-backed search is enabled.
+        console_output: Whether logs are echoed to stdout. Mirrors
+            ``CLAUDE_MCP_CONSOLE_OUTPUT``.
+        platform_profile: Name of a profile from :data:`PLATFORM_PROFILES`
+            whose defaults are layered onto the base defaults during
+            :meth:`load`.
+    """
+
+    storage_path: str = DEFAULT_STORAGE_PATH
+    log_format: str = "text"
+    log_level: str = "INFO"
+    enable_sqlite: bool = True
+    console_output: bool = False
+    platform_profile: str = "default"
+
+    #: Mapping of dataclass field name -> environment variable name.
+    ENV_MAPPING: ClassVar[Dict[str, str]] = {
+        "storage_path": "CLAUDE_MEMORY_PATH",
+        "log_format": "CLAUDE_MCP_LOG_FORMAT",
+        "log_level": "CLAUDE_MCP_LOG_LEVEL",
+        "enable_sqlite": "CLAUDE_MCP_ENABLE_SQLITE",
+        "console_output": "CLAUDE_MCP_CONSOLE_OUTPUT",
+        "platform_profile": "CLAUDE_MCP_PLATFORM_PROFILE",
+    }
+
+    # -- Construction --------------------------------------------------
+
+    @classmethod
+    def load(
+        cls,
+        config_file: Optional[Path] = None,
+        env: Optional[Mapping[str, str]] = None,
+        validate: bool = True,
+    ) -> "Config":
+        """Construct a :class:`Config` from the environment and config file.
+
+        Loading order, lowest to highest precedence:
+
+            1. Built-in defaults
+            2. Profile defaults (driven by ``platform_profile``)
+            3. Values in ``config_file``
+            4. Environment variables
+
+        Args:
+            config_file: Path to the JSON configuration file. ``None`` uses
+                :data:`DEFAULT_CONFIG_FILE`. Missing files are ignored.
+            env: Mapping used in place of :data:`os.environ`. Primarily
+                useful for testing.
+            validate: If ``True`` (default), :meth:`validate` is invoked on
+                the result.
+
+        Raises:
+            ConfigError: If the file is malformed or contains invalid values,
+                or if ``validate`` is ``True`` and validation fails.
+        """
+        env_map: Mapping[str, str] = os.environ if env is None else env
+        cfg_path = DEFAULT_CONFIG_FILE if config_file is None else config_file
+
+        # Layer 1: built-in defaults via dataclass instantiation.
+        cfg = cls()
+
+        # Layer 2: profile defaults. Resolve the profile from env > file >
+        # default so a profile chosen at any layer can still influence the
+        # remaining fields. We only consume the ``platform_profile`` value
+        # here; everything else is applied below.
+        file_data = _load_file_data(cfg_path)
+        profile_name = (
+            env_map.get(cls.ENV_MAPPING["platform_profile"])
+            or file_data.get("platform_profile")
+            or cfg.platform_profile
+        )
+        cfg = _apply_profile(cfg, profile_name)
+
+        # Layer 3: configuration file overrides.
+        cfg = _apply_overrides(cfg, file_data, source="config file")
+
+        # Layer 4: environment variable overrides.
+        env_overrides = {
+            field_name: env_map[env_name]
+            for field_name, env_name in cls.ENV_MAPPING.items()
+            if env_name in env_map and env_map[env_name] != ""
+        }
+        cfg = _apply_overrides(cfg, env_overrides, source="environment")
+
+        if validate:
+            cfg.validate()
+        return cfg
+
+    # -- Validation ----------------------------------------------------
+
+    def validate(self) -> None:
+        """Validate field values and (best-effort) the storage path.
+
+        Raises:
+            ConfigError: If any field is invalid.
+        """
+        if self.log_format not in VALID_LOG_FORMATS:
+            raise ConfigError(
+                f"Invalid log_format {self.log_format!r}; "
+                f"must be one of {sorted(VALID_LOG_FORMATS)}"
+            )
+        if self.log_level.upper() not in VALID_LOG_LEVELS:
+            raise ConfigError(
+                f"Invalid log_level {self.log_level!r}; "
+                f"must be one of {sorted(VALID_LOG_LEVELS)}"
+            )
+        if self.platform_profile not in PLATFORM_PROFILES:
+            raise ConfigError(
+                f"Unknown platform_profile {self.platform_profile!r}; "
+                f"must be one of {sorted(PLATFORM_PROFILES)}"
+            )
+        # Normalise log_level to upper-case so downstream consumers don't
+        # need to repeat the call.
+        object.__setattr__(self, "log_level", self.log_level.upper())
+
+        self._validate_storage_path()
+
+    def _validate_storage_path(self) -> None:
+        """Ensure the storage path is non-empty and writable.
+
+        The directory is created if it does not exist.  Failure to create or
+        write to the directory raises :class:`ConfigError`.
+        """
+        if not self.storage_path or not str(self.storage_path).strip():
+            raise ConfigError("storage_path must be a non-empty string")
+
+        path = self.resolved_storage_path()
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise ConfigError(f"storage_path {path!s} is not writable: {exc}") from exc
+
+        if not os.access(path, os.W_OK):
+            raise ConfigError(f"storage_path {path!s} is not writable")
+
+    # -- Convenience ---------------------------------------------------
+
+    def resolved_storage_path(self) -> Path:
+        """Return :attr:`storage_path` with ``~`` and env vars expanded."""
+        expanded = os.path.expanduser(os.path.expandvars(str(self.storage_path)))
+        return Path(expanded).resolve()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a plain-dict representation suitable for serialisation."""
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_file_data(path: Path) -> Dict[str, Any]:
+    """Read and parse the JSON configuration file.
+
+    Returns an empty dict when ``path`` does not exist. Raises
+    :class:`ConfigError` on malformed JSON or non-mapping top-level values.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        raise ConfigError(f"Could not read config file {path}: {exc}") from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"Invalid JSON in config file {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ConfigError(
+            f"Config file {path} must contain a JSON object at the top level"
+        )
+    return data
+
+
+def _apply_profile(cfg: Config, profile_name: str) -> Config:
+    """Return a new :class:`Config` with the profile's defaults applied."""
+    if profile_name not in PLATFORM_PROFILES:
+        raise ConfigError(
+            f"Unknown platform_profile {profile_name!r}; "
+            f"must be one of {sorted(PLATFORM_PROFILES)}"
+        )
+    profile_defaults = PLATFORM_PROFILES[profile_name]
+    return replace(cfg, platform_profile=profile_name, **profile_defaults)
+
+
+_BOOL_FIELDS = {"enable_sqlite", "console_output"}
+_VALID_FIELD_NAMES = {f.name for f in fields(Config)}
+
+
+def _apply_overrides(cfg: Config, overrides: Mapping[str, Any], source: str) -> Config:
+    """Return a new :class:`Config` with the given overrides applied.
+
+    Unknown keys raise :class:`ConfigError` so typos aren't silently ignored.
+    Values are coerced where appropriate (booleans from strings, etc.).
+    """
+    if not overrides:
+        return cfg
+
+    coerced: Dict[str, Any] = {}
+    for key, value in overrides.items():
+        if key not in _VALID_FIELD_NAMES:
+            raise ConfigError(f"Unknown configuration key {key!r} in {source}")
+        if key in _BOOL_FIELDS:
+            coerced[key] = _parse_bool(value)
+        elif key == "log_level" and isinstance(value, str):
+            coerced[key] = value.upper()
+        else:
+            coerced[key] = value
+    return replace(cfg, **coerced)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,482 @@
+"""Tests for ``src.config`` (centralized configuration module)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest  # type: ignore[import-not-found]
+
+# Make ``src/`` importable when tests are run via pytest from repo root.
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from config import (  # type: ignore[import-not-found]  # noqa: E402
+    DEFAULT_CONFIG_FILE,
+    DEFAULT_STORAGE_PATH,
+    PLATFORM_PROFILES,
+    VALID_LOG_FORMATS,
+    VALID_LOG_LEVELS,
+    Config,
+    ConfigError,
+    _parse_bool,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def writable_storage(tmp_path: Path) -> Path:
+    """Provide a writable directory for use as ``storage_path``."""
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    return storage
+
+
+@pytest.fixture
+def empty_env() -> dict:
+    """Return an empty environment dict (so env vars don't leak in)."""
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    def test_dataclass_defaults(self) -> None:
+        cfg = Config()
+        assert cfg.storage_path == DEFAULT_STORAGE_PATH
+        assert cfg.log_format == "text"
+        assert cfg.log_level == "INFO"
+        assert cfg.enable_sqlite is True
+        assert cfg.console_output is False
+        assert cfg.platform_profile == "default"
+
+    def test_load_defaults_when_no_env_no_file(
+        self, tmp_path: Path, empty_env: dict, writable_storage: Path
+    ) -> None:
+        # Use a missing config-file path and override storage to a tmp dir
+        # so validation doesn't try to write to the real ~/claude-memory.
+        missing_file = tmp_path / "absent.json"
+        empty_env["CLAUDE_MEMORY_PATH"] = str(writable_storage)
+        cfg = Config.load(config_file=missing_file, env=empty_env)
+        assert cfg.log_format == "text"
+        assert cfg.log_level == "INFO"
+        assert cfg.platform_profile == "default"
+        assert cfg.resolved_storage_path() == writable_storage.resolve()
+
+    def test_default_config_file_path(self) -> None:
+        # Sanity-check the documented default.
+        assert DEFAULT_CONFIG_FILE == Path.home() / ".claude-memory" / "config.json"
+
+
+# ---------------------------------------------------------------------------
+# Environment variable overrides
+# ---------------------------------------------------------------------------
+
+
+class TestEnvOverrides:
+    def test_env_overrides_all_fields(
+        self, tmp_path: Path, writable_storage: Path
+    ) -> None:
+        env = {
+            "CLAUDE_MEMORY_PATH": str(writable_storage),
+            "CLAUDE_MCP_LOG_FORMAT": "json",
+            "CLAUDE_MCP_LOG_LEVEL": "debug",
+            "CLAUDE_MCP_ENABLE_SQLITE": "false",
+            "CLAUDE_MCP_CONSOLE_OUTPUT": "true",
+            "CLAUDE_MCP_PLATFORM_PROFILE": "claude",
+        }
+        cfg = Config.load(config_file=tmp_path / "no.json", env=env)
+        assert cfg.log_format == "json"
+        assert cfg.log_level == "DEBUG"  # normalised
+        assert cfg.enable_sqlite is False
+        assert cfg.console_output is True
+        assert cfg.platform_profile == "claude"
+        assert cfg.resolved_storage_path() == writable_storage.resolve()
+
+    def test_monkeypatched_environ(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        writable_storage: Path,
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_MEMORY_PATH", str(writable_storage))
+        monkeypatch.setenv("CLAUDE_MCP_LOG_FORMAT", "json")
+        # Use the real os.environ via env=None.
+        cfg = Config.load(config_file=tmp_path / "no.json")
+        assert cfg.log_format == "json"
+        assert cfg.resolved_storage_path() == writable_storage.resolve()
+
+    def test_empty_env_value_is_ignored(
+        self, tmp_path: Path, writable_storage: Path
+    ) -> None:
+        env = {
+            "CLAUDE_MEMORY_PATH": str(writable_storage),
+            "CLAUDE_MCP_LOG_FORMAT": "",
+        }
+        cfg = Config.load(config_file=tmp_path / "no.json", env=env)
+        assert cfg.log_format == "text"  # default kept
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("true", True),
+            ("False", False),
+            ("1", True),
+            ("0", False),
+            ("yes", True),
+            ("NO", False),
+            ("on", True),
+            ("off", False),
+        ],
+    )
+    def test_bool_env_parsing(
+        self,
+        value: str,
+        expected: bool,
+        tmp_path: Path,
+        writable_storage: Path,
+    ) -> None:
+        env = {
+            "CLAUDE_MEMORY_PATH": str(writable_storage),
+            "CLAUDE_MCP_ENABLE_SQLITE": value,
+        }
+        cfg = Config.load(config_file=tmp_path / "no.json", env=env)
+        assert cfg.enable_sqlite is expected
+
+
+# ---------------------------------------------------------------------------
+# Config file loading
+# ---------------------------------------------------------------------------
+
+
+class TestFileLoading:
+    def test_loads_values_from_json_file(
+        self, tmp_path: Path, writable_storage: Path, empty_env: dict
+    ) -> None:
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(
+            json.dumps(
+                {
+                    "storage_path": str(writable_storage),
+                    "log_format": "json",
+                    "log_level": "WARNING",
+                    "enable_sqlite": False,
+                    "console_output": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        cfg = Config.load(config_file=cfg_file, env=empty_env)
+        assert cfg.log_format == "json"
+        assert cfg.log_level == "WARNING"
+        assert cfg.enable_sqlite is False
+        assert cfg.console_output is True
+        assert cfg.resolved_storage_path() == writable_storage.resolve()
+
+    def test_missing_file_uses_defaults(
+        self, tmp_path: Path, empty_env: dict, writable_storage: Path
+    ) -> None:
+        empty_env["CLAUDE_MEMORY_PATH"] = str(writable_storage)
+        cfg = Config.load(config_file=tmp_path / "absent.json", env=empty_env)
+        # Defaults preserved.
+        assert cfg.log_format == "text"
+        assert cfg.log_level == "INFO"
+
+    def test_invalid_json_raises(self, tmp_path: Path, empty_env: dict) -> None:
+        cfg_file = tmp_path / "broken.json"
+        cfg_file.write_text("{ not valid json", encoding="utf-8")
+        with pytest.raises(ConfigError, match="Invalid JSON"):
+            Config.load(config_file=cfg_file, env=empty_env)
+
+    def test_non_mapping_top_level_raises(
+        self, tmp_path: Path, empty_env: dict
+    ) -> None:
+        cfg_file = tmp_path / "list.json"
+        cfg_file.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        with pytest.raises(ConfigError, match="JSON object"):
+            Config.load(config_file=cfg_file, env=empty_env)
+
+    def test_unknown_field_in_file_raises(
+        self, tmp_path: Path, empty_env: dict, writable_storage: Path
+    ) -> None:
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(
+            json.dumps(
+                {
+                    "storage_path": str(writable_storage),
+                    "totally_made_up": "value",
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ConfigError, match="Unknown configuration key"):
+            Config.load(config_file=cfg_file, env=empty_env)
+
+    def test_unreadable_file_raises(
+        self, tmp_path: Path, empty_env: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg_file = tmp_path / "secret.json"
+        cfg_file.write_text("{}", encoding="utf-8")
+
+        # Force read_text to raise OSError other than FileNotFoundError.
+        original_read_text = Path.read_text
+
+        def _raise(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if self == cfg_file:
+                raise PermissionError("denied")
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", _raise)
+        with pytest.raises(ConfigError, match="Could not read config file"):
+            Config.load(config_file=cfg_file, env=empty_env)
+
+
+# ---------------------------------------------------------------------------
+# Precedence
+# ---------------------------------------------------------------------------
+
+
+class TestPrecedence:
+    def test_env_beats_file(self, tmp_path: Path, writable_storage: Path) -> None:
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(
+            json.dumps(
+                {
+                    "storage_path": str(writable_storage),
+                    "log_format": "text",
+                    "log_level": "INFO",
+                }
+            ),
+            encoding="utf-8",
+        )
+        env = {"CLAUDE_MCP_LOG_FORMAT": "json", "CLAUDE_MCP_LOG_LEVEL": "ERROR"}
+        cfg = Config.load(config_file=cfg_file, env=env)
+        assert cfg.log_format == "json"  # env wins
+        assert cfg.log_level == "ERROR"  # env wins
+        # File-only fields still applied.
+        assert cfg.resolved_storage_path() == writable_storage.resolve()
+
+    def test_file_beats_default(
+        self, tmp_path: Path, writable_storage: Path, empty_env: dict
+    ) -> None:
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(
+            json.dumps(
+                {
+                    "storage_path": str(writable_storage),
+                    "log_format": "json",
+                }
+            ),
+            encoding="utf-8",
+        )
+        cfg = Config.load(config_file=cfg_file, env=empty_env)
+        assert cfg.log_format == "json"
+
+    def test_profile_beats_default_but_loses_to_file_and_env(
+        self, tmp_path: Path, writable_storage: Path
+    ) -> None:
+        # ``chatgpt`` profile defaults to log_format=json. File then forces
+        # text; env then forces json again.
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(
+            json.dumps(
+                {
+                    "platform_profile": "chatgpt",
+                    "storage_path": str(writable_storage),
+                    "log_format": "text",
+                }
+            ),
+            encoding="utf-8",
+        )
+        # Without env override, file wins over profile.
+        cfg = Config.load(config_file=cfg_file, env={})
+        assert cfg.log_format == "text"
+        assert cfg.platform_profile == "chatgpt"
+
+        # With env override, env wins over file and profile.
+        cfg2 = Config.load(
+            config_file=cfg_file,
+            env={"CLAUDE_MCP_LOG_FORMAT": "json"},
+        )
+        assert cfg2.log_format == "json"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_invalid_log_format(self, writable_storage: Path) -> None:
+        cfg = Config(storage_path=str(writable_storage), log_format="xml")
+        with pytest.raises(ConfigError, match="Invalid log_format"):
+            cfg.validate()
+
+    def test_invalid_log_level(self, writable_storage: Path) -> None:
+        cfg = Config(storage_path=str(writable_storage), log_level="LOUD")
+        with pytest.raises(ConfigError, match="Invalid log_level"):
+            cfg.validate()
+
+    def test_invalid_platform_profile_via_validate(
+        self, writable_storage: Path
+    ) -> None:
+        cfg = Config(storage_path=str(writable_storage), platform_profile="bogus")
+        with pytest.raises(ConfigError, match="Unknown platform_profile"):
+            cfg.validate()
+
+    def test_invalid_platform_profile_via_load(
+        self, tmp_path: Path, writable_storage: Path
+    ) -> None:
+        env = {
+            "CLAUDE_MEMORY_PATH": str(writable_storage),
+            "CLAUDE_MCP_PLATFORM_PROFILE": "bogus",
+        }
+        with pytest.raises(ConfigError, match="Unknown platform_profile"):
+            Config.load(config_file=tmp_path / "no.json", env=env)
+
+    def test_empty_storage_path(self) -> None:
+        cfg = Config(storage_path="   ")
+        with pytest.raises(ConfigError, match="non-empty"):
+            cfg.validate()
+
+    def test_unwritable_storage_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "unwritable"
+        target.mkdir()
+
+        # Force os.access to claim the dir is not writable.
+        real_access = os.access
+
+        def fake_access(path, mode):  # type: ignore[no-untyped-def]
+            if Path(path).resolve() == target.resolve() and mode == os.W_OK:
+                return False
+            return real_access(path, mode)
+
+        monkeypatch.setattr(os, "access", fake_access)
+        # Patch the symbol used inside src.config too.
+        import config as config_module
+
+        monkeypatch.setattr(config_module.os, "access", fake_access)
+
+        cfg = Config(storage_path=str(target))
+        with pytest.raises(ConfigError, match="not writable"):
+            cfg.validate()
+
+    def test_storage_path_mkdir_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "mkdir-blocked"
+
+        def boom(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if self.resolve() == target.resolve():
+                raise PermissionError("nope")
+            return None
+
+        monkeypatch.setattr(Path, "mkdir", boom)
+        cfg = Config(storage_path=str(target))
+        with pytest.raises(ConfigError, match="not writable"):
+            cfg.validate()
+
+    def test_load_skips_validation_when_disabled(self, tmp_path: Path) -> None:
+        env = {"CLAUDE_MCP_LOG_FORMAT": "xml"}  # bogus
+        # Should not raise because validate=False.
+        cfg = Config.load(config_file=tmp_path / "no.json", env=env, validate=False)
+        assert cfg.log_format == "xml"
+
+
+# ---------------------------------------------------------------------------
+# Profiles
+# ---------------------------------------------------------------------------
+
+
+class TestProfiles:
+    def test_known_profiles_present(self) -> None:
+        for name in ("default", "claude", "chatgpt", "cursor"):
+            assert name in PLATFORM_PROFILES
+
+    def test_chatgpt_profile_defaults(
+        self, tmp_path: Path, writable_storage: Path
+    ) -> None:
+        env = {
+            "CLAUDE_MEMORY_PATH": str(writable_storage),
+            "CLAUDE_MCP_PLATFORM_PROFILE": "chatgpt",
+        }
+        cfg = Config.load(config_file=tmp_path / "no.json", env=env)
+        assert cfg.platform_profile == "chatgpt"
+        assert cfg.log_format == "json"
+
+    def test_claude_profile_defaults(
+        self, tmp_path: Path, writable_storage: Path
+    ) -> None:
+        env = {
+            "CLAUDE_MEMORY_PATH": str(writable_storage),
+            "CLAUDE_MCP_PLATFORM_PROFILE": "claude",
+        }
+        cfg = Config.load(config_file=tmp_path / "no.json", env=env)
+        assert cfg.platform_profile == "claude"
+        assert cfg.log_format == "text"
+
+
+# ---------------------------------------------------------------------------
+# Helpers / misc
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_to_dict_roundtrip(self, writable_storage: Path) -> None:
+        cfg = Config(
+            storage_path=str(writable_storage),
+            log_format="json",
+            log_level="DEBUG",
+            enable_sqlite=False,
+            console_output=True,
+            platform_profile="claude",
+        )
+        data = cfg.to_dict()
+        assert data["log_format"] == "json"
+        assert data["enable_sqlite"] is False
+        # Reconstruct via Config(**data) (sanity check).
+        rebuilt = Config(**data)
+        assert rebuilt == cfg
+
+    def test_resolved_storage_path_expands(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        cfg = Config(storage_path="~/abc")
+        assert cfg.resolved_storage_path() == (tmp_path / "abc").resolve()
+
+    def test_resolved_storage_path_expands_envvar(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("MY_DATA_DIR", str(tmp_path / "envroot"))
+        cfg = Config(storage_path="$MY_DATA_DIR/sub")
+        assert cfg.resolved_storage_path() == (tmp_path / "envroot" / "sub").resolve()
+
+    def test_parse_bool_native_types(self) -> None:
+        assert _parse_bool(True) is True
+        assert _parse_bool(False) is False
+        assert _parse_bool(1) is True
+        assert _parse_bool(0) is False
+
+    def test_parse_bool_invalid_raises(self) -> None:
+        with pytest.raises(ConfigError):
+            _parse_bool("maybe")
+        with pytest.raises(ConfigError):
+            _parse_bool(object())
+
+    def test_valid_constants_exposed(self) -> None:
+        # Defensive: external callers may import these.
+        assert "text" in VALID_LOG_FORMATS
+        assert "json" in VALID_LOG_FORMATS
+        assert "INFO" in VALID_LOG_LEVELS

--- a/todos.md
+++ b/todos.md
@@ -121,7 +121,12 @@ This file maintains persistent todos across Claude Code sessions.
   - Merge test_final_2_lines.py into appropriate existing test files
   - Remove duplicate test coverage that already exists in other files
   - Aim to reduce from 17 test files to ~12-13 focused test files
-- [ ] Implement centralized configuration management system
+- [~] Implement centralized configuration management system (in progress)
+  - [x] `src/config.py` module with `Config` dataclass, platform profiles, env+file loading, validation (PR: feature/central-config-module)
+  - [ ] Wire `Config.load()` into `server_fastmcp.py` / `logging_config.py` / `path_utils.py` (replace direct `os.getenv` calls) — follow-up
+  - [ ] CLI commands for config management (`get`, `set`, `show`, `init`) — follow-up (todos 3.2.2)
+  - [ ] Per-platform topic extraction patterns and date-format handling (todos 3.1.2 / 3.1.3) — follow-up
+  - [ ] Document configuration file format in README — follow-up
 - [x] **Add proper logging throughout the application** ✅ COMPLETED
   - ✅ PR #13: Implemented comprehensive logging system
   - ✅ Security-focused logging with log injection prevention


### PR DESCRIPTION
## Summary

Adds a `Config` dataclass at `src/config.py` that consolidates settings previously scattered across:

- env vars: `CLAUDE_MEMORY_PATH`, `CLAUDE_MCP_LOG_FORMAT`, `CLAUDE_MCP_LOG_LEVEL`, `CLAUDE_MCP_CONSOLE_OUTPUT`
- module-level constants in `server_fastmcp.py`, `logging_config.py`, `path_utils.py`

This is **Stream B** of the parallel-streams effort to address todos.md "Implement centralized configuration management system" (medium-priority section + 3.1.1, 3.2.1, 3.2.3, 3.2.4).

## What's included

- **`src/config.py`** (105 stmts, 100% covered)
  - `Config` dataclass: `storage_path`, `log_format`, `log_level`, `enable_sqlite`, `console_output`, `platform_profile`
  - `Config.load(config_file=..., env=..., validate=True)` reads:
    1. built-in defaults
    2. profile defaults (driven by `platform_profile`)
    3. JSON config file (default `~/.claude-memory/config.json`)
    4. env-var overrides
  - `Config.validate()` raises `ConfigError` on bad `log_format`, `log_level`, `platform_profile`, or non-writable `storage_path` (with mkdir attempt).
  - `PLATFORM_PROFILES`: stub registry for `default`/`claude`/`chatgpt`/`cursor` profiles with partial defaults (extension point for 3.1.2 / 3.1.3 follow-ups).
  - Strict unknown-key handling for both file and env overrides catches typos.
  - Side-effect free import: no env reads or filesystem access at module load.
- **`tests/test_config.py`** (40 tests, 100% coverage on `src/config.py`)
  - Defaults, env overrides, file loading, precedence, validation, profiles, helpers.
- **`.gitignore` fix**: re-include `tests/` so new test files aren't silently hidden by the existing `/*test*/` rule.
- **`todos.md`**: marked the medium-priority entry in-progress and listed the deferred follow-ups.

## What's NOT included (intentional follow-ups)

- Wiring `Config.load()` into `server_fastmcp.py` / `logging_config.py` / `path_utils.py` (replace direct `os.getenv` calls). Deferred to keep this PR focused and risk-free.
- CLI commands for config management (`get`, `set`, `show`, `init`) — todos.md 3.2.2.
- Per-platform topic extraction patterns and date-format handling — todos.md 3.1.2 / 3.1.3.
- README documentation for the new config file format.

## Test plan

- [x] `pytest tests/ --ignore=tests/standalone_test.py --ignore=tests/test_performance_benchmarks.py` → 467 passed, 1 skipped (was 427 before).
- [x] `pytest tests/test_config.py --cov=src --cov-report=term-missing` → `src/config.py` 105/105 = **100%**.
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, bandit, trailing-whitespace, eof-fixer, black via legacy hook, isort, flake8).
- [ ] CI (build.yml + SonarCloud) green.
- [ ] SonarCloud "coverage on new code" >= 80% (expected 100% on the new module).

@claude please review.