### PR TITLE
Bulk import: auto-detect format and dispatch to importers

### DIFF
--- a/scripts/bulk_import_enhanced.py
+++ b/scripts/bulk_import_enhanced.py
@@ -1,351 +1,637 @@
 #!/usr/bin/env python3
-
-# Add src directory to path
-import sys
-import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 """
 Enhanced Bulk Conversation Import Script for Claude Memory System
-Handles Claude conversation exports and provides detailed progress tracking
+
+Auto-detects export format (Claude/ChatGPT/Cursor/Generic) using
+``src.format_detector.FormatDetector`` and dispatches to the matching
+importer in ``src.importers``. Falls back to the original hand-rolled
+extraction logic when detection confidence is low or when an importer
+cannot parse the file, preserving backward compatibility with prior
+Claude exports.
+
+Features:
+    * ``--format <claude|chatgpt|cursor|generic|auto>`` (default ``auto``).
+    * ``--dry-run`` previews work without writing.
+    * Periodic progress reporting (every N conversations) for large imports.
+    * Aggregated import statistics with per-format counts.
 """
 
+# Add src directory to path before importing project modules.
 import os
-import json
-from datetime import datetime, timezone
-from pathlib import Path
-import asyncio
-import argparse
-from typing import Dict, List, Any, Optional
-import re
+import sys
 
-# Import ConversationMemoryServer from src directory (already in path)
-from server_fastmcp import ConversationMemoryServer
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# The ``noqa: E402`` markers below are intentional: project-local modules
+# under ``src/`` are only importable after the ``sys.path`` insertion above.
+import argparse  # noqa: E402
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import tempfile  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+from pathlib import Path  # noqa: E402
+from typing import Any, Dict, List, Optional, Tuple  # noqa: E402
+
+# ``ConversationMemoryServer`` lives in ``conversation_memory``; the older
+# script imported from ``server_fastmcp`` which now exports it under a
+# different name (``FastMCPConversationMemoryServer``).
+# Note: these are project-local modules added to ``sys.path`` above; mypy
+# can't follow them without a ``py.typed`` marker on the ``src`` package.
+from conversation_memory import (  # type: ignore[import-not-found]  # noqa: E402
+    ConversationMemoryServer,
+)
+from format_detector import (  # type: ignore[import-not-found]  # noqa: E402
+    FormatDetector,
+    PlatformType,
+)
+from importers import (  # type: ignore[import-not-found]  # noqa: E402
+    ChatGPTImporter,
+    ClaudeImporter,
+    CursorImporter,
+    GenericImporter,
+)
+
+logger = logging.getLogger(__name__)
+
+# Confidence below this threshold triggers the legacy fallback path.
+DEFAULT_CONFIDENCE_THRESHOLD = 0.6
+
+# Emit a progress message every N conversations during large imports.
+PROGRESS_REPORT_INTERVAL = 25
+
+# Mapping from CLI ``--format`` value to ``PlatformType``.
+FORMAT_CHOICES = ("auto", "claude", "chatgpt", "cursor", "generic")
+FORMAT_TO_PLATFORM = {
+    "chatgpt": PlatformType.CHATGPT,
+    "cursor": PlatformType.CURSOR,
+    "claude": PlatformType.CLAUDE_WEB,  # Treated as a Claude-family hint
+    "generic": PlatformType.GENERIC_JSON,
+}
+
 
 class EnhancedBulkImporter:
-    def __init__(self, dry_run: bool = False):
-        self.memory_server = ConversationMemoryServer() if not dry_run else None
+    """Bulk import driver with format auto-detection and legacy fallback."""
+
+    def __init__(
+        self,
+        dry_run: bool = False,
+        confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+        progress_interval: int = PROGRESS_REPORT_INTERVAL,
+        memory_server: Optional[ConversationMemoryServer] = None,
+        detector: Optional[FormatDetector] = None,
+    ):
+        self.dry_run = dry_run
+        self.confidence_threshold = confidence_threshold
+        self.progress_interval = max(1, int(progress_interval))
+
+        # Allow tests to inject collaborators; otherwise build them lazily so
+        # ``--dry-run`` does not require write access to the storage path.
+        self.memory_server = memory_server
+        if self.memory_server is None and not dry_run:
+            self.memory_server = ConversationMemoryServer()
+
+        self.detector = detector or FormatDetector()
+
+        # Aggregate counters and bookkeeping.
         self.imported_count = 0
         self.failed_count = 0
         self.skipped_count = 0
-        self.errors = []
-        self.dry_run = dry_run
-        self.conversation_titles = set()  # Track titles to avoid duplicates
-    
-    def extract_conversation_content(self, conversation: Dict[str, Any]) -> Optional[Dict[str, str]]:
-        """Extract content, title, and date from various conversation formats"""
-        
-        # Common fields to check for content
-        content_fields = ['content', 'text', 'body', 'conversation', 'messages']
-        title_fields = ['title', 'name', 'subject', 'conversation_title']
-        date_fields = ['date', 'created_at', 'timestamp', 'created', 'date_created']
-        
-        # Extract content
-        content = None
+        self.errors: List[str] = []
+        self.platform_counts: Dict[str, int] = {}
+        self.detection_result: Optional[Dict[str, Any]] = None
+        self.format_used: Optional[str] = None
+        self.fallback_used: bool = False
+        self.conversation_titles: set = set()
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+    async def run(self, json_file: Path, requested_format: str = "auto") -> None:
+        """Drive the import for ``json_file`` using ``requested_format``.
+
+        ``requested_format`` may be ``auto`` (detect) or any of the explicit
+        platform keys in :data:`FORMAT_CHOICES`. The detection result is
+        always stored on ``self.detection_result`` for reporting.
+        """
+        if not json_file.exists():
+            self.errors.append(f"File does not exist: {json_file}")
+            print(f"File does not exist: {json_file}")
+            return
+
+        self.detection_result = self.detector.detect_format(json_file)
+        detected_platform = self.detection_result.get(
+            "platform", PlatformType.UNKNOWN.value
+        )
+        confidence = float(self.detection_result.get("confidence", 0.0))
+
+        print(
+            "Detection: platform={platform} confidence={confidence:.2f} ({message})".format(
+                platform=detected_platform,
+                confidence=confidence,
+                message=self.detection_result.get("message", ""),
+            )
+        )
+
+        platform_to_use, used_fallback = self._resolve_platform(
+            requested_format, detected_platform, confidence
+        )
+        self.format_used = platform_to_use
+        self.fallback_used = used_fallback
+
+        print(
+            "Importer selected: {p} (requested={r}, fallback={f})".format(
+                p=platform_to_use,
+                r=requested_format,
+                f="yes" if used_fallback else "no",
+            )
+        )
+
+        if used_fallback:
+            await self._import_with_legacy(json_file)
+        else:
+            await self._import_with_importer(json_file, platform_to_use)
+
+    # ------------------------------------------------------------------
+    # Platform resolution
+    # ------------------------------------------------------------------
+    def _resolve_platform(
+        self,
+        requested_format: str,
+        detected_platform: str,
+        confidence: float,
+    ) -> Tuple[str, bool]:
+        """Decide which importer (or legacy path) to dispatch to.
+
+        Returns a tuple of ``(platform_label, fallback_used)`` where
+        ``platform_label`` is either ``"legacy"`` or one of the importer
+        keys (``chatgpt``/``cursor``/``claude``/``generic``).
+        """
+        # Explicit override always wins.
+        if requested_format != "auto":
+            if requested_format == "claude":
+                return "claude", False
+            if requested_format in {"chatgpt", "cursor", "generic"}:
+                return requested_format, False
+            # Defensive: argparse should already have rejected this.
+            return "legacy", True
+
+        # Auto path: low confidence drops back to legacy.
+        if confidence < self.confidence_threshold:
+            return "legacy", True
+
+        if detected_platform == PlatformType.CHATGPT.value:
+            return "chatgpt", False
+        if detected_platform == PlatformType.CURSOR.value:
+            return "cursor", False
+        if detected_platform in {
+            PlatformType.CLAUDE_WEB.value,
+            PlatformType.CLAUDE_DESKTOP.value,
+            PlatformType.CLAUDE_MEMORY.value,
+        }:
+            return "claude", False
+        if detected_platform == PlatformType.GENERIC_JSON.value:
+            return "generic", False
+
+        # Unknown / unsupported - use legacy hand-rolled extraction.
+        return "legacy", True
+
+    # ------------------------------------------------------------------
+    # Importer-based path
+    # ------------------------------------------------------------------
+    def _build_importer(self, platform_label: str, storage_path: Path):
+        """Instantiate the correct importer for ``platform_label``."""
+        if platform_label == "chatgpt":
+            return ChatGPTImporter(storage_path)
+        if platform_label == "cursor":
+            return CursorImporter(storage_path)
+        if platform_label == "claude":
+            return ClaudeImporter(storage_path)
+        if platform_label == "generic":
+            return GenericImporter(storage_path)
+        raise ValueError(f"Unknown importer label: {platform_label}")
+
+    async def _import_with_importer(self, json_file: Path, platform_label: str) -> None:
+        """Parse via importer, then persist via ``ConversationMemoryServer``.
+
+        Importers normally save to their own staging directory in their own
+        on-disk format. We reuse the parsing logic but route the resulting
+        universal conversations through the memory server so the existing
+        index, topics file and SQLite FTS database all stay consistent.
+        """
+        with tempfile.TemporaryDirectory(prefix="bulk-import-stage-") as tmpdir:
+            importer = self._build_importer(platform_label, Path(tmpdir))
+
+            try:
+                result = importer.import_file(json_file)
+            except Exception as exc:  # pragma: no cover - defensive
+                msg = f"Importer error ({platform_label}): {exc}"
+                self.errors.append(msg)
+                print(msg)
+                return
+
+            # Surface importer-level errors to the operator.
+            for err in result.errors:
+                self.errors.append(f"[{platform_label}] {err}")
+
+            staged_paths = self._collect_staged_files(Path(tmpdir))
+            if not staged_paths:
+                if result.conversations_imported == 0:
+                    print(
+                        "Importer produced no conversations; falling back to "
+                        "legacy extraction."
+                    )
+                    self.fallback_used = True
+                    self.format_used = "legacy"
+                    await self._import_with_legacy(json_file)
+                return
+
+            total = len(staged_paths)
+            print(f"Parsed {total} conversation(s) from {platform_label} format")
+
+            for index, path in enumerate(staged_paths, start=1):
+                await self._persist_staged_conversation(path, platform_label)
+                self._maybe_print_progress(index, total)
+
+    def _collect_staged_files(self, staging_dir: Path) -> List[Path]:
+        """Return all conversation JSON files written by an importer."""
+        return sorted(staging_dir.rglob("*.json"))
+
+    async def _persist_staged_conversation(
+        self, conversation_file: Path, platform_label: str
+    ) -> None:
+        """Load a staged universal conversation and forward to the memory server."""
+        try:
+            data = json.loads(conversation_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            self.failed_count += 1
+            self.errors.append(
+                f"Failed to read staged conversation {conversation_file}: {exc}"
+            )
+            return
+
+        title = self._unique_title(data.get("title") or "Imported Conversation")
+        content = data.get("content") or ""
+        date_str = data.get("date") or datetime.now(timezone.utc).isoformat()
+
+        if not content.strip():
+            self.skipped_count += 1
+            return
+
+        await self._save_conversation(
+            content=content,
+            title=title,
+            date=date_str,
+            platform_label=platform_label,
+        )
+
+    # ------------------------------------------------------------------
+    # Legacy hand-rolled path (preserved for backward compatibility)
+    # ------------------------------------------------------------------
+    async def _import_with_legacy(self, json_file: Path) -> None:
+        """Original hand-rolled Claude export extraction logic."""
+        try:
+            print(f"Reading {json_file} (legacy extractor)...")
+
+            with open(json_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            msg = f"Error reading JSON file: {exc}"
+            print(msg)
+            self.errors.append(msg)
+            return
+
+        conversations = self._collect_legacy_conversations(data)
+        if not conversations:
+            print("No conversations found in the JSON file")
+            return
+
+        total = len(conversations)
+        print(f"Starting legacy import of {total} conversations...")
+
+        for index, conv in enumerate(conversations, start=1):
+            try:
+                conversation_data = self.extract_conversation_content(conv)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.failed_count += 1
+                self.errors.append(f"Error processing conversation {index}: {exc}")
+                continue
+
+            if not conversation_data:
+                self.skipped_count += 1
+                continue
+
+            await self._save_conversation(
+                content=conversation_data["content"],
+                title=self._unique_title(conversation_data["title"]),
+                date=conversation_data["date"],
+                platform_label="legacy",
+            )
+
+            self._maybe_print_progress(index, total)
+
+    def _collect_legacy_conversations(self, data: Any) -> List[Dict[str, Any]]:
+        """Extract a list of conversations from common Claude export shapes."""
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            for key in ("conversations", "chats", "data"):
+                value = data.get(key)
+                if isinstance(value, list):
+                    return value
+            return [data]
+        return []
+
+    def extract_conversation_content(
+        self, conversation: Dict[str, Any]
+    ) -> Optional[Dict[str, str]]:
+        """Extract content/title/date from a heterogeneous conversation dict."""
+        content_fields = ["content", "text", "body", "conversation", "messages"]
+        title_fields = ["title", "name", "subject", "conversation_title"]
+        date_fields = ["date", "created_at", "timestamp", "created", "date_created"]
+
+        content: Any = None
         for field in content_fields:
             if field in conversation and conversation[field]:
                 content = conversation[field]
                 break
-        
-        # If content is a list (like messages), join them
+
         if isinstance(content, list):
-            if len(content) > 0 and isinstance(content[0], dict):
-                # Handle message format: [{"role": "user", "content": "..."}, ...]
-                content_parts = []
-                for msg in content:
-                    role = msg.get('role', msg.get('sender', 'unknown'))
-                    text = msg.get('content', msg.get('text', msg.get('message', '')))
-                    content_parts.append(f"**{role.title()}**: {text}")
-                content = '\n\n'.join(content_parts)
-            else:
-                # Simple list of strings
-                content = '\n\n'.join(str(item) for item in content)
-        
+            content = self._stringify_message_list(content)
+
         if not content:
             return None
-        
-        # Extract title
-        title = None
-        for field in title_fields:
-            if field in conversation and conversation[field]:
-                title = str(conversation[field]).strip()
-                break
-        
-        # Generate title from content if not found
-        if not title:
-            # Extract first meaningful line or sentence
-            lines = content.split('\n')
-            for line in lines:
-                line = line.strip()
-                if len(line) > 10 and not line.startswith('**'):
-                    title = line[:80] + "..." if len(line) > 80 else line
-                    break
-            
-            if not title:
-                title = f"Conversation {self.imported_count + 1}"
-        
-        # Extract date
-        date_str = None
-        for field in date_fields:
-            if field in conversation and conversation[field]:
-                date_str = conversation[field]
-                break
-        
-        # Parse and normalize date
-        if date_str:
-            try:
-                # Handle various date formats
-                if isinstance(date_str, (int, float)):
-                    # Unix timestamp
-                    date_str = datetime.fromtimestamp(date_str, tz=timezone.utc).isoformat()
-                elif isinstance(date_str, str):
-                    # Try to parse ISO format or convert other formats
-                    try:
-                        parsed_date = datetime.fromisoformat(date_str.replace('Z', '+00:00'))
-                        date_str = parsed_date.isoformat()
-                    except:
-                        # Try other common formats
-                        try:
-                            parsed_date = datetime.strptime(date_str, '%Y-%m-%d %H:%M:%S')
-                            date_str = parsed_date.isoformat()
-                        except:
-                            # Keep original if can't parse
-                            pass
-            except:
-                date_str = None
-        
-        # Use current time if no date found
-        if not date_str:
-            date_str = datetime.now(timezone.utc).isoformat()
-        
+
+        title = self._first_present(conversation, title_fields)
+        if title is None:
+            title = self._derive_title_from_content(str(content))
+
+        date_str = self._first_present(conversation, date_fields)
+        date_str = self._normalize_date(date_str)
+
         return {
-            'content': content,
-            'title': title,
-            'date': date_str
+            "content": str(content),
+            "title": (
+                str(title).strip()
+                if title
+                else f"Conversation {self.imported_count + 1}"
+            ),
+            "date": date_str,
         }
-    
-    def generate_unique_title(self, base_title: str) -> str:
-        """Generate a unique title by adding a number if needed"""
-        original_title = base_title
+
+    @staticmethod
+    def _first_present(mapping: Dict[str, Any], keys: List[str]) -> Optional[Any]:
+        for key in keys:
+            value = mapping.get(key)
+            if value:
+                return value
+        return None
+
+    @staticmethod
+    def _stringify_message_list(messages: List[Any]) -> str:
+        if messages and isinstance(messages[0], dict):
+            parts: List[str] = []
+            for msg in messages:
+                role = msg.get("role", msg.get("sender", "unknown"))
+                text = msg.get("content", msg.get("text", msg.get("message", "")))
+                parts.append(f"**{str(role).title()}**: {text}")
+            return "\n\n".join(parts)
+        return "\n\n".join(str(item) for item in messages)
+
+    @staticmethod
+    def _derive_title_from_content(content: str) -> Optional[str]:
+        for line in content.split("\n"):
+            stripped = line.strip()
+            if len(stripped) > 10 and not stripped.startswith("**"):
+                return (stripped[:80] + "...") if len(stripped) > 80 else stripped
+        return None
+
+    @staticmethod
+    def _normalize_date(date_value: Any) -> str:
+        if date_value is None:
+            return datetime.now(timezone.utc).isoformat()
+
+        if isinstance(date_value, (int, float)):
+            try:
+                return datetime.fromtimestamp(
+                    float(date_value), tz=timezone.utc
+                ).isoformat()
+            except (OverflowError, OSError, ValueError):
+                return datetime.now(timezone.utc).isoformat()
+
+        if isinstance(date_value, str):
+            try:
+                return datetime.fromisoformat(
+                    date_value.replace("Z", "+00:00")
+                ).isoformat()
+            except ValueError:
+                pass
+            try:
+                return datetime.strptime(date_value, "%Y-%m-%d %H:%M:%S").isoformat()
+            except ValueError:
+                return date_value  # Pass through unparseable strings.
+
+        return datetime.now(timezone.utc).isoformat()
+
+    # ------------------------------------------------------------------
+    # Persistence + bookkeeping helpers
+    # ------------------------------------------------------------------
+    def _unique_title(self, base_title: str) -> str:
+        original = base_title
         counter = 1
-        
         while base_title in self.conversation_titles:
-            base_title = f"{original_title} ({counter})"
+            base_title = f"{original} ({counter})"
             counter += 1
-        
         self.conversation_titles.add(base_title)
         return base_title
-    
-    async def import_conversation(self, conversation_data: Dict[str, str]) -> bool:
-        """Import a single conversation"""
-        try:
-            title = self.generate_unique_title(conversation_data['title'])
-            content = conversation_data['content']
-            date = conversation_data['date']
-            
-            if self.dry_run:
-                print(f"🔍 [DRY RUN] Would import: {title[:60]}...")
-                print(f"   📅 Date: {date}")
-                print(f"   📝 Content length: {len(content)} characters")
-                self.imported_count += 1
-                return True
-            
-            result = await self.memory_server.add_conversation(content, title, date)
-            
-            if result.get('status') == 'success':
-                self.imported_count += 1
-                print(f"✅ Imported: {title}")
-                return True
-            else:
-                self.failed_count += 1
-                error_msg = f"Failed to import '{title}': {result.get('message', 'Unknown error')}"
-                self.errors.append(error_msg)
-                print(f"❌ {error_msg}")
-                return False
-                
-        except Exception as e:
-            self.failed_count += 1
-            error_msg = f"Exception importing conversation: {str(e)}"
-            self.errors.append(error_msg)
-            print(f"❌ {error_msg}")
-            return False
-    
-    async def import_claude_export(self, json_file: Path) -> None:
-        """Import from Claude conversation export JSON"""
-        try:
-            print(f"📂 Reading {json_file}...")
-            
-            with open(json_file, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-            
-            print(f"📊 File loaded successfully")
-            
-            # Handle different JSON structures
-            conversations = []
-            
-            if isinstance(data, list):
-                conversations = data
-                print(f"📋 Found {len(conversations)} conversations in array format")
-            elif isinstance(data, dict):
-                if 'conversations' in data:
-                    conversations = data['conversations']
-                    print(f"📋 Found {len(conversations)} conversations in 'conversations' key")
-                elif 'chats' in data:
-                    conversations = data['chats']
-                    print(f"📋 Found {len(conversations)} conversations in 'chats' key")
-                elif 'data' in data:
-                    conversations = data['data']
-                    print(f"📋 Found {len(conversations)} conversations in 'data' key")
-                else:
-                    # Treat the whole object as a single conversation
-                    conversations = [data]
-                    print(f"📋 Treating entire object as single conversation")
-            
-            if not conversations:
-                print("❌ No conversations found in the JSON file")
-                return
-            
-            print(f"🚀 Starting import of {len(conversations)} conversations...")
-            
-            # Process conversations in batches for better progress feedback
-            batch_size = 10
-            total_conversations = len(conversations)
-            
-            for i in range(0, total_conversations, batch_size):
-                batch = conversations[i:i + batch_size]
-                batch_end = min(i + batch_size, total_conversations)
-                
-                print(f"\n📦 Processing batch {i//batch_size + 1} ({i+1}-{batch_end} of {total_conversations})")
-                
-                for j, conv in enumerate(batch):
-                    current_index = i + j + 1
-                    print(f"  📝 [{current_index}/{total_conversations}] Processing conversation...")
-                    
-                    try:
-                        conversation_data = self.extract_conversation_content(conv)
-                        
-                        if not conversation_data:
-                            self.skipped_count += 1
-                            print(f"  ⏭️  Skipped: No valid content found")
-                            continue
-                        
-                        success = await self.import_conversation(conversation_data)
-                        
-                        # Small delay to avoid overwhelming the system
-                        if not self.dry_run:
-                            await asyncio.sleep(0.1)
-                            
-                    except Exception as e:
-                        self.failed_count += 1
-                        error_msg = f"Error processing conversation {current_index}: {e}"
-                        self.errors.append(error_msg)
-                        print(f"  ❌ {error_msg}")
-                
-                # Progress update
-                processed = min(batch_end, total_conversations)
-                progress = (processed / total_conversations) * 100
-                print(f"📊 Progress: {processed}/{total_conversations} ({progress:.1f}%)")
-                
-                # Brief pause between batches
-                if not self.dry_run and batch_end < total_conversations:
-                    await asyncio.sleep(0.5)
-                    
-        except Exception as e:
-            print(f"❌ Error reading JSON file: {e}")
-            self.errors.append(f"JSON file error: {e}")
-    
-    def print_summary(self):
-        """Print detailed import summary"""
-        print(f"\n" + "="*60)
-        print(f"📊 IMPORT SUMMARY")
-        print(f"="*60)
-        
+
+    async def _save_conversation(
+        self,
+        content: str,
+        title: str,
+        date: str,
+        platform_label: str,
+    ) -> None:
+        """Persist via the memory server, or simulate when ``dry_run``."""
         if self.dry_run:
-            print(f"🔍 DRY RUN RESULTS:")
-            print(f"   ✅ Would import: {self.imported_count}")
-            print(f"   ⏭️  Would skip: {self.skipped_count}")
-            print(f"   ❌ Would fail: {self.failed_count}")
+            self.imported_count += 1
+            self.platform_counts[platform_label] = (
+                self.platform_counts.get(platform_label, 0) + 1
+            )
+            print(
+                f"[DRY RUN] Would import via {platform_label}: {title[:60]} "
+                f"(date={date}, len={len(content)})"
+            )
+            return
+
+        try:
+            assert self.memory_server is not None  # for mypy/readers
+            result = await self.memory_server.add_conversation(content, title, date)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.failed_count += 1
+            self.errors.append(f"Exception importing '{title}': {exc}")
+            return
+
+        if result.get("status") == "success":
+            self.imported_count += 1
+            self.platform_counts[platform_label] = (
+                self.platform_counts.get(platform_label, 0) + 1
+            )
         else:
-            print(f"✅ Successfully imported: {self.imported_count}")
-            print(f"⏭️  Skipped (no content): {self.skipped_count}")
-            print(f"❌ Failed imports: {self.failed_count}")
-        
+            self.failed_count += 1
+            self.errors.append(
+                f"Failed to import '{title}': {result.get('message', 'Unknown error')}"
+            )
+
+    def _maybe_print_progress(self, processed: int, total: int) -> None:
+        """Emit a periodic progress line (every ``progress_interval``)."""
+        if total <= 0:
+            return
+        if processed == total or processed % self.progress_interval == 0:
+            pct = (processed / total) * 100
+            print(f"Progress: {processed}/{total} ({pct:.1f}%)")
+
+    # ------------------------------------------------------------------
+    # Reporting
+    # ------------------------------------------------------------------
+    def print_summary(self) -> None:
+        print()
+        print("=" * 60)
+        print("IMPORT SUMMARY")
+        print("=" * 60)
+
+        if self.detection_result is not None:
+            print(
+                "Detected format: {p} (confidence={c:.2f})".format(
+                    p=self.detection_result.get("platform"),
+                    c=float(self.detection_result.get("confidence", 0.0)),
+                )
+            )
+        if self.format_used:
+            print(
+                "Importer used: {f}{fb}".format(
+                    f=self.format_used,
+                    fb=" (legacy fallback)" if self.fallback_used else "",
+                )
+            )
+
+        if self.dry_run:
+            print(f"Would import: {self.imported_count}")
+            print(f"Would skip:   {self.skipped_count}")
+            print(f"Would fail:   {self.failed_count}")
+        else:
+            print(f"Imported: {self.imported_count}")
+            print(f"Skipped:  {self.skipped_count}")
+            print(f"Failed:   {self.failed_count}")
+
         total_processed = self.imported_count + self.skipped_count + self.failed_count
         if total_processed > 0:
             success_rate = (self.imported_count / total_processed) * 100
-            print(f"📈 Success rate: {success_rate:.1f}%")
-        
-        if self.errors:
-            print(f"\n⚠️  Errors encountered ({len(self.errors)}):")
-            for i, error in enumerate(self.errors[:5], 1):
-                print(f"  {i}. {error}")
-            if len(self.errors) > 5:
-                print(f"  ... and {len(self.errors) - 5} more errors")
-                print(f"  💡 Run with --verbose to see all errors")
-        
-        if not self.dry_run and self.imported_count > 0:
-            print(f"\n🎉 Import completed! Your conversations are now searchable.")
-            print(f"💡 Try: search_conversations(\"<topic>\") to find relevant discussions")
+            print(f"Success rate: {success_rate:.1f}%")
 
-async def main():
+        if self.platform_counts:
+            print("Per-format counts:")
+            for label, count in sorted(self.platform_counts.items()):
+                print(f"  {label}: {count}")
+
+        if self.errors:
+            print(f"Errors encountered ({len(self.errors)}):")
+            for index, err in enumerate(self.errors[:5], start=1):
+                print(f"  {index}. {err}")
+            if len(self.errors) > 5:
+                print(f"  ... and {len(self.errors) - 5} more error(s)")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description='Enhanced bulk import for Claude conversation exports',
+        description=(
+            "Bulk import AI conversation exports with auto-detection of "
+            "Claude / ChatGPT / Cursor / Generic formats."
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Dry run to preview import
-  python bulk_import_enhanced.py /path/to/conversations.json --dry-run
-  
-  # Import conversations
-  python bulk_import_enhanced.py /path/to/conversations.json
-  
-  # Import with custom title prefix
-  python bulk_import_enhanced.py /path/to/conversations.json --title-prefix "Archive"
-        """
+  # Auto-detect format and dry-run (no writes)
+  python bulk_import_enhanced.py /path/to/export.json --dry-run
+
+  # Force ChatGPT importer
+  python bulk_import_enhanced.py export.json --format chatgpt
+
+  # Use legacy hand-rolled extractor explicitly
+  python bulk_import_enhanced.py export.json --format generic
+        """,
     )
-    
-    parser.add_argument('json_file', help='Path to Claude conversation export JSON file')
-    parser.add_argument('--dry-run', action='store_true', 
-                       help='Preview import without actually importing')
-    parser.add_argument('--title-prefix', help='Prefix to add to all conversation titles')
-    parser.add_argument('--verbose', action='store_true', 
-                       help='Show detailed error messages')
-    
+    parser.add_argument(
+        "json_file",
+        help="Path to the conversation export JSON file",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the import without writing any data",
+    )
+    parser.add_argument(
+        "--format",
+        choices=FORMAT_CHOICES,
+        default="auto",
+        help="Force a specific importer (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=DEFAULT_CONFIDENCE_THRESHOLD,
+        help=(
+            "Minimum detection confidence required to use an importer in "
+            "auto mode; below this the legacy extractor runs"
+        ),
+    )
+    parser.add_argument(
+        "--progress-interval",
+        type=int,
+        default=PROGRESS_REPORT_INTERVAL,
+        help="Emit a progress line every N conversations (default: 25)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging output",
+    )
+    return parser
+
+
+async def main() -> int:
+    parser = _build_arg_parser()
     args = parser.parse_args()
-    
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
     json_path = Path(args.json_file)
-    
-    if not json_path.exists():
-        print(f"❌ File does not exist: {json_path}")
-        return 1
-    
-    if not json_path.suffix.lower() == '.json':
-        print(f"⚠️  Warning: File doesn't have .json extension: {json_path}")
-    
-    print(f"🚀 Claude Conversation Import Tool")
-    print(f"📂 Source: {json_path}")
-    print(f"🔍 Mode: {'DRY RUN' if args.dry_run else 'IMPORT'}")
-    
-    if args.dry_run:
-        print(f"💡 This is a dry run - no data will be imported")
-    
-    print(f"\n" + "-"*60)
-    
-    importer = EnhancedBulkImporter(dry_run=args.dry_run)
-    
+
+    print("Claude Memory bulk import")
+    print(f"Source: {json_path}")
+    print(f"Mode:   {'DRY RUN' if args.dry_run else 'IMPORT'}")
+    print(f"Format: {args.format}")
+    print("-" * 60)
+
+    importer = EnhancedBulkImporter(
+        dry_run=args.dry_run,
+        confidence_threshold=args.confidence_threshold,
+        progress_interval=args.progress_interval,
+    )
+
     try:
-        await importer.import_claude_export(json_path)
+        await importer.run(json_path, requested_format=args.format)
     except KeyboardInterrupt:
-        print(f"\n⏹️  Import interrupted by user")
-    except Exception as e:
-        print(f"\n❌ Unexpected error: {e}")
+        print("Import interrupted by user")
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Unexpected error: {exc}")
+        importer.print_summary()
         return 1
-    
+
     importer.print_summary()
-    
-    if args.dry_run:
-        print(f"\n💡 Run without --dry-run to perform the actual import")
-    
     return 0
 
+
 if __name__ == "__main__":
-    exit(asyncio.run(main()))
+    sys.exit(asyncio.run(main()))

--- a/tests/test_bulk_import_enhanced.py
+++ b/tests/test_bulk_import_enhanced.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Tests for ``scripts/bulk_import_enhanced.py``.
+
+These tests focus on the refactored auto-detection / dispatch logic:
+
+    * Auto-detect picks the right importer per detected platform.
+    * Explicit ``--format`` overrides detection.
+    * Low-confidence detection triggers the legacy fallback.
+    * ``--dry-run`` does not invoke the memory server's writes.
+    * Empty / malformed input is handled gracefully.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest  # type: ignore[import-not-found]
+
+# ---------------------------------------------------------------------------
+# Module loading: bulk_import_enhanced lives under scripts/ and isn't on the
+# default import path. Load it explicitly so tests can exercise its classes.
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "bulk_import_enhanced.py"
+
+# Ensure ``src`` is importable for the side-effect imports inside the script.
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+_spec = importlib.util.spec_from_file_location("bulk_import_enhanced", SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+bulk_import_enhanced: Any = importlib.util.module_from_spec(_spec)
+sys.modules["bulk_import_enhanced"] = bulk_import_enhanced
+_spec.loader.exec_module(bulk_import_enhanced)
+
+EnhancedBulkImporter = bulk_import_enhanced.EnhancedBulkImporter
+PlatformType = bulk_import_enhanced.PlatformType
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def fake_memory_server():
+    """Async memory server stub returning success."""
+    server = MagicMock()
+    server.add_conversation = AsyncMock(
+        return_value={"status": "success", "message": "ok"}
+    )
+    return server
+
+
+def _make_detector(platform: Any, confidence: float):
+    detector = MagicMock()
+    detector.detect_format.return_value = {
+        "platform": platform.value,
+        "confidence": confidence,
+        "message": f"mock detection: {platform.value}",
+        "timestamp": 0,
+    }
+    return detector
+
+
+def _write_json(path: Path, payload) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Platform resolution unit tests
+# ---------------------------------------------------------------------------
+class TestResolvePlatform:
+    def setup_method(self):
+        self.importer = EnhancedBulkImporter(
+            dry_run=True,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+
+    def test_explicit_format_overrides_detection(self):
+        for fmt in ("chatgpt", "cursor", "claude", "generic"):
+            label, fallback = self.importer._resolve_platform(
+                requested_format=fmt,
+                detected_platform=PlatformType.UNKNOWN.value,
+                confidence=0.0,
+            )
+            assert label == fmt
+            assert fallback is False
+
+    def test_auto_dispatches_to_chatgpt(self):
+        label, fallback = self.importer._resolve_platform(
+            "auto", PlatformType.CHATGPT.value, 0.95
+        )
+        assert label == "chatgpt"
+        assert fallback is False
+
+    def test_auto_dispatches_to_cursor(self):
+        label, fallback = self.importer._resolve_platform(
+            "auto", PlatformType.CURSOR.value, 0.95
+        )
+        assert label == "cursor"
+        assert fallback is False
+
+    @pytest.mark.parametrize(
+        "platform",
+        [
+            PlatformType.CLAUDE_WEB,
+            PlatformType.CLAUDE_DESKTOP,
+            PlatformType.CLAUDE_MEMORY,
+        ],
+    )
+    def test_auto_dispatches_to_claude_variants(self, platform):
+        label, fallback = self.importer._resolve_platform("auto", platform.value, 0.95)
+        assert label == "claude"
+        assert fallback is False
+
+    def test_auto_dispatches_to_generic(self):
+        label, fallback = self.importer._resolve_platform(
+            "auto", PlatformType.GENERIC_JSON.value, 0.7
+        )
+        assert label == "generic"
+        assert fallback is False
+
+    def test_low_confidence_falls_back_to_legacy(self):
+        label, fallback = self.importer._resolve_platform(
+            "auto", PlatformType.CHATGPT.value, 0.1
+        )
+        assert label == "legacy"
+        assert fallback is True
+
+    def test_unknown_platform_falls_back_to_legacy(self):
+        label, fallback = self.importer._resolve_platform(
+            "auto", PlatformType.UNKNOWN.value, 0.99
+        )
+        assert label == "legacy"
+        assert fallback is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end dispatch tests using temp files
+# ---------------------------------------------------------------------------
+class TestRunDispatch:
+    @pytest.mark.asyncio
+    async def test_auto_detect_uses_chatgpt_importer(
+        self, tmp_path, fake_memory_server
+    ):
+        # ChatGPT-shaped data so that even if the detector mock is bypassed
+        # the parser succeeds.
+        chatgpt_payload = {
+            "conversations": [
+                {
+                    "id": "conv-1",
+                    "title": "Hello",
+                    "create_time": "2025-01-01T12:00:00Z",
+                    "messages": [
+                        {
+                            "id": "m1",
+                            "role": "user",
+                            "content": "Hi there",
+                            "create_time": "2025-01-01T12:00:00Z",
+                        },
+                        {
+                            "id": "m2",
+                            "role": "assistant",
+                            "content": "Hello human",
+                            "create_time": "2025-01-01T12:00:01Z",
+                        },
+                    ],
+                }
+            ]
+        }
+        export = _write_json(tmp_path / "chatgpt.json", chatgpt_payload)
+
+        importer = EnhancedBulkImporter(
+            dry_run=False,
+            memory_server=fake_memory_server,
+            detector=_make_detector(PlatformType.CHATGPT, 0.95),
+        )
+        await importer.run(export, requested_format="auto")
+
+        assert importer.format_used == "chatgpt"
+        assert importer.fallback_used is False
+        assert importer.imported_count == 1
+        assert importer.platform_counts == {"chatgpt": 1}
+        fake_memory_server.add_conversation.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_explicit_format_overrides_detection(
+        self, tmp_path, fake_memory_server
+    ):
+        chatgpt_payload = {
+            "conversations": [
+                {
+                    "id": "conv-1",
+                    "title": "Force",
+                    "create_time": "2025-01-01T12:00:00Z",
+                    "messages": [
+                        {
+                            "id": "m1",
+                            "role": "user",
+                            "content": "ping",
+                            "create_time": "2025-01-01T12:00:00Z",
+                        },
+                        {
+                            "id": "m2",
+                            "role": "assistant",
+                            "content": "pong",
+                            "create_time": "2025-01-01T12:00:01Z",
+                        },
+                    ],
+                }
+            ]
+        }
+        export = _write_json(tmp_path / "force.json", chatgpt_payload)
+
+        # Detector says UNKNOWN, but explicit ``--format chatgpt`` should win.
+        importer = EnhancedBulkImporter(
+            dry_run=False,
+            memory_server=fake_memory_server,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        await importer.run(export, requested_format="chatgpt")
+
+        assert importer.format_used == "chatgpt"
+        assert importer.fallback_used is False
+        assert importer.imported_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_falls_back_to_legacy(
+        self, tmp_path, fake_memory_server
+    ):
+        # Legacy-shaped Claude export (list of conversations with content).
+        legacy_payload = [
+            {
+                "title": "Legacy chat",
+                "content": "Some legacy content body",
+                "date": "2025-01-01T12:00:00",
+            }
+        ]
+        export = _write_json(tmp_path / "legacy.json", legacy_payload)
+
+        importer = EnhancedBulkImporter(
+            dry_run=False,
+            memory_server=fake_memory_server,
+            detector=_make_detector(PlatformType.CHATGPT, 0.1),
+        )
+        await importer.run(export, requested_format="auto")
+
+        assert importer.format_used == "legacy"
+        assert importer.fallback_used is True
+        assert importer.imported_count == 1
+        assert importer.platform_counts == {"legacy": 1}
+
+    @pytest.mark.asyncio
+    async def test_dry_run_does_not_invoke_memory_server(
+        self, tmp_path, fake_memory_server
+    ):
+        legacy_payload = [
+            {
+                "title": "Dry chat",
+                "content": "Body content " * 5,
+                "date": "2025-01-01T12:00:00",
+            }
+        ]
+        export = _write_json(tmp_path / "dry.json", legacy_payload)
+
+        importer = EnhancedBulkImporter(
+            dry_run=True,
+            memory_server=fake_memory_server,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        await importer.run(export, requested_format="auto")
+
+        assert importer.imported_count == 1
+        # Most importantly: the memory server is never called in dry-run.
+        fake_memory_server.add_conversation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_file_records_error(self, tmp_path, fake_memory_server):
+        importer = EnhancedBulkImporter(
+            dry_run=True,
+            memory_server=fake_memory_server,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        await importer.run(tmp_path / "does_not_exist.json", requested_format="auto")
+
+        assert importer.imported_count == 0
+        assert any("does not exist" in err for err in importer.errors)
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_falls_back_and_records_error(
+        self, tmp_path, fake_memory_server
+    ):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{this is not json", encoding="utf-8")
+
+        # Detector will report an error/UNKNOWN -> legacy path which then
+        # also fails to parse, so we expect an error and zero imports.
+        importer = EnhancedBulkImporter(
+            dry_run=False,
+            memory_server=fake_memory_server,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        await importer.run(bad, requested_format="auto")
+
+        assert importer.imported_count == 0
+        assert any("Error reading JSON" in err for err in importer.errors)
+
+    @pytest.mark.asyncio
+    async def test_empty_conversations_list_reports_no_work(
+        self, tmp_path, fake_memory_server
+    ):
+        export = _write_json(tmp_path / "empty.json", [])
+
+        importer = EnhancedBulkImporter(
+            dry_run=True,
+            memory_server=fake_memory_server,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        await importer.run(export, requested_format="auto")
+
+        # No errors, but nothing imported either.
+        assert importer.imported_count == 0
+        assert importer.failed_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Helper-method tests (legacy extraction utilities)
+# ---------------------------------------------------------------------------
+class TestLegacyExtractors:
+    def setup_method(self):
+        self.importer = EnhancedBulkImporter(
+            dry_run=True,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+
+    def test_extract_conversation_from_messages_list(self):
+        conv = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello back"},
+            ],
+            "title": "Greeting",
+            "date": "2025-01-01T00:00:00",
+        }
+        result = self.importer.extract_conversation_content(conv)
+        assert result is not None
+        assert "Hello back" in result["content"] or "hello back" in result["content"]
+        assert result["title"] == "Greeting"
+
+    def test_extract_conversation_returns_none_when_empty(self):
+        assert self.importer.extract_conversation_content({}) is None
+
+    def test_unique_title_appends_counter(self):
+        first = self.importer._unique_title("Same")
+        second = self.importer._unique_title("Same")
+        third = self.importer._unique_title("Same")
+        assert first == "Same"
+        assert second == "Same (1)"
+        assert third == "Same (2)"
+
+    def test_normalize_date_handles_iso_string(self):
+        result = EnhancedBulkImporter._normalize_date("2025-01-01T12:00:00Z")
+        assert result.startswith("2025-01-01T12:00:00")
+
+    def test_normalize_date_handles_unix_timestamp(self):
+        result = EnhancedBulkImporter._normalize_date(0)
+        assert "1970" in result
+
+    def test_normalize_date_falls_back_for_unparseable_string(self):
+        # Should pass through untouched (caller may still accept it)
+        result = EnhancedBulkImporter._normalize_date("not a date")
+        assert result == "not a date"
+
+    def test_collect_legacy_conversations_dict_with_known_keys(self):
+        data = {"chats": [{"content": "x"}]}
+        result = self.importer._collect_legacy_conversations(data)
+        assert result == [{"content": "x"}]
+
+    def test_collect_legacy_conversations_single_dict(self):
+        data = {"content": "single"}
+        result = self.importer._collect_legacy_conversations(data)
+        assert result == [data]
+
+    def test_collect_legacy_conversations_unsupported_type(self):
+        assert self.importer._collect_legacy_conversations("not a dict") == []
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+class TestArgParser:
+    def test_default_format_is_auto(self):
+        parser = bulk_import_enhanced._build_arg_parser()
+        args = parser.parse_args(["some.json"])
+        assert args.format == "auto"
+        assert args.dry_run is False
+
+    def test_format_choice_validation(self):
+        parser = bulk_import_enhanced._build_arg_parser()
+        args = parser.parse_args(["x.json", "--format", "chatgpt", "--dry-run"])
+        assert args.format == "chatgpt"
+        assert args.dry_run is True
+
+    def test_invalid_format_rejected(self):
+        parser = bulk_import_enhanced._build_arg_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["x.json", "--format", "nope"])
+
+
+# ---------------------------------------------------------------------------
+# Persistence + reporting helpers
+# ---------------------------------------------------------------------------
+class TestSaveAndReport:
+    @pytest.mark.asyncio
+    async def test_save_conversation_records_failure(self, tmp_path):
+        memory = MagicMock()
+        memory.add_conversation = AsyncMock(
+            return_value={"status": "error", "message": "boom"}
+        )
+        importer = EnhancedBulkImporter(
+            dry_run=False,
+            memory_server=memory,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        await importer._save_conversation(
+            content="hello",
+            title="t",
+            date="2025-01-01T00:00:00",
+            platform_label="legacy",
+        )
+        assert importer.failed_count == 1
+        assert importer.imported_count == 0
+        assert any("boom" in err for err in importer.errors)
+
+    @pytest.mark.asyncio
+    async def test_save_conversation_dry_run_increments_counts(self):
+        importer = EnhancedBulkImporter(
+            dry_run=True,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        await importer._save_conversation(
+            content="payload",
+            title="dry title",
+            date="2025-01-01T00:00:00",
+            platform_label="chatgpt",
+        )
+        assert importer.imported_count == 1
+        assert importer.platform_counts == {"chatgpt": 1}
+
+    def test_print_summary_with_no_run(self, capsys):
+        importer = EnhancedBulkImporter(
+            dry_run=True,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        importer.print_summary()
+        out = capsys.readouterr().out
+        assert "IMPORT SUMMARY" in out
+        # When nothing has run, success rate line is skipped (total_processed = 0).
+        assert "Success rate" not in out
+
+    def test_print_summary_includes_per_format_and_truncated_errors(self, capsys):
+        importer = EnhancedBulkImporter(
+            dry_run=False,
+            memory_server=MagicMock(),
+            detector=_make_detector(PlatformType.CHATGPT, 0.95),
+        )
+        importer.detection_result = {
+            "platform": "chatgpt",
+            "confidence": 0.95,
+            "message": "ok",
+        }
+        importer.format_used = "chatgpt"
+        importer.fallback_used = False
+        importer.imported_count = 7
+        importer.skipped_count = 1
+        importer.failed_count = 2
+        importer.platform_counts = {"chatgpt": 7}
+        importer.errors = [f"err {i}" for i in range(7)]
+
+        importer.print_summary()
+        out = capsys.readouterr().out
+
+        assert "Imported: 7" in out
+        assert "Per-format counts:" in out
+        assert "chatgpt: 7" in out
+        # First 5 errors listed, then "and N more" line.
+        assert "err 0" in out
+        assert "err 4" in out
+        assert "and 2 more" in out
+
+    def test_maybe_print_progress_zero_total(self, capsys):
+        importer = EnhancedBulkImporter(
+            dry_run=True,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        importer._maybe_print_progress(processed=0, total=0)
+        assert capsys.readouterr().out == ""
+
+    def test_maybe_print_progress_emits_at_interval(self, capsys):
+        importer = EnhancedBulkImporter(
+            dry_run=True,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+            progress_interval=2,
+        )
+        importer._maybe_print_progress(processed=2, total=10)
+        importer._maybe_print_progress(processed=3, total=10)  # no print
+        out = capsys.readouterr().out
+        assert "Progress: 2/10" in out
+        assert "Progress: 3/10" not in out
+
+    def test_build_importer_unknown_label_raises(self, tmp_path):
+        importer = EnhancedBulkImporter(
+            dry_run=True,
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        with pytest.raises(ValueError):
+            importer._build_importer("not-a-real-format", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Importer-staging fallback path
+# ---------------------------------------------------------------------------
+class TestStagingFallback:
+    @pytest.mark.asyncio
+    async def test_importer_with_no_output_falls_back_to_legacy(
+        self, tmp_path, fake_memory_server
+    ):
+        """If the importer parses nothing, we fall back to the legacy extractor."""
+        # ChatGPT importer requires "conversations" key. Provide a payload that
+        # is valid Claude-legacy (list of dicts with content) but NOT valid
+        # ChatGPT, so the ChatGPT importer produces zero conversations and
+        # the runner should fall back.
+        legacy_payload = [
+            {
+                "title": "Fallback me",
+                "content": "body content here",
+                "date": "2025-01-01",
+            }
+        ]
+        export = _write_json(tmp_path / "fallback.json", legacy_payload)
+
+        importer = EnhancedBulkImporter(
+            dry_run=False,
+            memory_server=fake_memory_server,
+            # Force ChatGPT explicitly even though file isn't ChatGPT format.
+            detector=_make_detector(PlatformType.UNKNOWN, 0.0),
+        )
+        await importer.run(export, requested_format="chatgpt")
+
+        # The runner started in chatgpt, the importer produced nothing,
+        # so it fell back to legacy and imported via the hand-rolled path.
+        assert importer.fallback_used is True
+        assert importer.format_used == "legacy"
+        assert importer.imported_count == 1
+
+
+# ---------------------------------------------------------------------------
+# main() entry point
+# ---------------------------------------------------------------------------
+class TestMain:
+    @pytest.mark.asyncio
+    async def test_main_dry_run_returns_zero(self, tmp_path, monkeypatch):
+        legacy_payload = [
+            {"title": "Main test", "content": "main body", "date": "2025-01-01"}
+        ]
+        export = _write_json(tmp_path / "main.json", legacy_payload)
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["bulk_import_enhanced.py", str(export), "--dry-run", "--format", "auto"],
+        )
+
+        rc = await bulk_import_enhanced.main()
+        assert rc == 0


### PR DESCRIPTION
## Summary

Refactors `scripts/bulk_import_enhanced.py` so it auto-detects the export
format using `src/format_detector.py` and dispatches to the matching
importer in `src/importers/` (Claude / ChatGPT / Cursor / Generic). Falls
back to the original hand-rolled extraction when detection confidence is
low or an importer cannot parse the file.

Closes the implementation portion of `todos.md` 2.4.1, with partial
coverage of 2.4.2 (progress reporting) and 2.4.4 (import statistics).
2.4.3 (rollback) is intentionally deferred.

## Changes

- **`scripts/bulk_import_enhanced.py`** (rewritten):
  - New `--format <claude|chatgpt|cursor|generic|auto>` flag (default `auto`).
  - New `--confidence-threshold` and `--progress-interval` knobs.
  - `--dry-run` preserved.
  - Importers parse into a `tempfile.TemporaryDirectory` staging area and
    every conversation is then written through
    `ConversationMemoryServer.add_conversation()` so the existing index,
    topics file, and SQLite FTS database remain authoritative.
  - Periodic progress lines (default every 25 conversations) replace the
    old batch-print logic.
  - Per-format counts and an aggregated summary report.
  - Bug fix: previously imported `ConversationMemoryServer` from
    `server_fastmcp` where the class is now `FastMCPConversationMemoryServer`;
    switched to `from conversation_memory import ConversationMemoryServer`.

- **`tests/test_bulk_import_enhanced.py`** (new, 37 tests):
  - Platform-resolution unit tests for every supported platform + low-
    confidence + unknown-platform paths.
  - End-to-end dispatch tests using temp files and mocked memory server.
  - `--dry-run` does not write; explicit `--format` overrides detection;
    low-confidence detection falls back to legacy.
  - Helper coverage for `_normalize_date`, `_collect_legacy_conversations`,
    `_unique_title`, the staging-fallback path, and the `main()` entry.
  - 90% line coverage on the changed file.

## Test plan

- [x] `pytest tests/test_bulk_import_enhanced.py -v` (37 passed)
- [x] `pytest tests/ --ignore=tests/standalone_test.py` (476 passed, 1 skipped)
- [x] `python scripts/bulk_import_enhanced.py --help` (renders new flags)
- [x] Pre-commit hooks: ruff lint + format, mypy, bandit, isort, black, flake8 — all pass

## Follow-ups

Tracked separately, not part of this PR:

1. **Progress UX** (2.4.2): Add `tqdm`-based progress bar once we decide
   whether to add it as a dependency. Current periodic prints work but a
   proper progress bar would be nicer for very large imports.
2. **Import rollback** (2.4.3): Design a rollback mechanism so a partial
   batch can be reverted on failure. Likely needs transactional writes
   in `ConversationMemoryServer.add_conversation`.
3. **Validation report** (2.4.4 expansion): Persist a JSON validation
   report alongside the import for downstream auditing.
4. **Unify with `bulk_import.py`**: The older `scripts/bulk_import.py`
   and `scripts/simple_bulk_import.py` are now redundant with the
   enhanced script. Plan a cleanup pass.

@claude please review.