### PR TITLE
feat(importers): add universal conversation metadata fields (5.1.3-5.2.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,14 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
+
+# Minimal mypy config: tests import ``src.importers.X`` (via the project
+# root being on ``sys.path``) so we anchor mypy at the repo root. Without
+# ``explicit_package_bases`` mypy refuses to type-check ``src/`` and
+# ``tests/`` in the same invocation — the pre-commit hook does that every
+# time both buckets change in a single commit.
+[tool.mypy]
+explicit_package_bases = true
+namespace_packages = true
+ignore_missing_imports = true
+exclude = "^(build|dist|htmlcov|\\.scannerwork)/"

--- a/src/importers/base_importer.py
+++ b/src/importers/base_importer.py
@@ -90,6 +90,11 @@ class BaseImporter(ABC):
         model: Optional[str] = None,
         session_context: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        conversation_type: Optional[str] = None,
+        custom_fields: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Create a conversation in universal internal format.
@@ -103,6 +108,16 @@ class BaseImporter(ABC):
             model: AI model used (if available)
             session_context: Optional session/workspace context
             metadata: Additional platform-specific metadata
+            session_id: Identifier for grouping related conversations within
+                a session (e.g., a Cursor session, ChatGPT conversation_id).
+            user_id: Identifier for the user that owns the conversation
+                (reserved for future multi-user support).
+            tags: Platform-specific categorization tags. Defaults to an
+                empty list when not provided.
+            conversation_type: High-level classification such as "chat",
+                "code", "analysis", etc. Free-form string.
+            custom_fields: Open extensibility bucket for arbitrary
+                platform/user-defined metadata. Defaults to an empty dict.
 
         Returns:
             Conversation in universal format
@@ -126,6 +141,14 @@ class BaseImporter(ABC):
             ),
             "topics": topics,
             "session_context": session_context or {},
+            # Universal metadata fields (todos 5.1.3, 5.1.4, 5.2.1, 5.2.3, 5.2.4).
+            # All optional with sensible defaults so existing callers and
+            # stored conversations remain valid without these fields.
+            "session_id": session_id,
+            "user_id": user_id,
+            "tags": list(tags) if tags else [],
+            "conversation_type": conversation_type,
+            "custom_fields": dict(custom_fields) if custom_fields else {},
             "import_metadata": {
                 "imported_at": datetime.now().isoformat(),
                 "source_format": self.platform_name,

--- a/src/importers/chatgpt_importer.py
+++ b/src/importers/chatgpt_importer.py
@@ -206,6 +206,18 @@ class ChatGPTImporter(BaseImporter):
         # Extract model information if available
         model = self._extract_model_info(raw_data)
 
+        # Universal metadata extraction.
+        # ChatGPT exports use ``conversation_id`` (and sometimes ``id``)
+        # as the stable identifier — treat this as the session_id so
+        # multiple imports of the same conversation can be grouped.
+        session_id = raw_data.get("conversation_id") or raw_data.get("id") or None
+        # ChatGPT exports rarely include a user identifier, but if a
+        # caller has injected one we preserve it.
+        user_id = raw_data.get("user_id") or None
+        tags = self._extract_chatgpt_tags(raw_data)
+        conversation_type = self._classify_conversation_type(raw_data, content)
+        custom_fields = self._extract_chatgpt_custom_fields(raw_data)
+
         # Create universal conversation
         return self.create_universal_conversation(
             platform_id=platform_id,
@@ -224,7 +236,69 @@ class ChatGPTImporter(BaseImporter):
                 "original_update_time": update_time_str,
                 "message_count": len(messages),
             },
+            session_id=session_id,
+            user_id=user_id,
+            tags=tags,
+            conversation_type=conversation_type,
+            custom_fields=custom_fields,
         )
+
+    def _extract_chatgpt_tags(self, raw_data: Dict[str, Any]) -> List[str]:
+        """Build tags list from ChatGPT-specific signals (starred, archived, gizmo)."""
+        tags: List[str] = []
+        if raw_data.get("is_starred"):
+            tags.append("starred")
+        if raw_data.get("is_archived"):
+            tags.append("archived")
+        gizmo_id = raw_data.get("gizmo_id")
+        if gizmo_id:
+            tags.append(f"gizmo:{gizmo_id}")
+        # Allow callers to inject explicit tags
+        explicit = raw_data.get("tags")
+        if isinstance(explicit, list):
+            tags.extend(str(t) for t in explicit if t)
+        return tags
+
+    def _classify_conversation_type(
+        self, raw_data: Dict[str, Any], content: str
+    ) -> str:
+        """Classify a ChatGPT conversation as chat/code/analysis/etc.
+
+        Uses lightweight heuristics — explicit hints win, otherwise content
+        is inspected for code-fence density.
+        """
+        explicit = raw_data.get("conversation_type")
+        if isinstance(explicit, str) and explicit:
+            return explicit
+        # Heuristic: lots of code fences => code conversation
+        if content and content.count("```") >= 4:
+            return "code"
+        return "chat"
+
+    def _extract_chatgpt_custom_fields(
+        self, raw_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Capture optional ChatGPT-specific fields into custom_fields.
+
+        Only populates entries that are actually present in the source so the
+        default empty dict is preserved for typical exports.
+        """
+        custom: Dict[str, Any] = {}
+        for key in (
+            "default_model_slug",
+            "conversation_template_id",
+            "gizmo_id",
+            "gizmo_type",
+            "memory_scope",
+        ):
+            value = raw_data.get(key)
+            if value is not None:
+                custom[key] = value
+        # Pass through any caller-supplied custom_fields dict.
+        extra = raw_data.get("custom_fields")
+        if isinstance(extra, dict):
+            custom.update(extra)
+        return custom
 
     def _validate_chatgpt_format(self, data: Any) -> bool:
         """Validate that data is in ChatGPT export format."""

--- a/src/importers/claude_importer.py
+++ b/src/importers/claude_importer.py
@@ -319,6 +319,15 @@ class ClaudeImporter(BaseImporter):
             "original_format": "claude_json",
         }
 
+        # Universal metadata extraction.
+        session_id = (
+            data.get("session_id") or data.get("conversation_id") or platform_id or None
+        )
+        user_id = data.get("user_id") or data.get("account_id") or None
+        tags = self._extract_claude_tags(data, session_context["claude_variant"])
+        conversation_type = self._classify_claude_conversation_type(data, content)
+        custom_fields = self._extract_claude_custom_fields(data)
+
         # Create universal conversation
         return self.create_universal_conversation(
             platform_id=platform_id or f"claude_{int(date.timestamp())}",
@@ -332,7 +341,47 @@ class ClaudeImporter(BaseImporter):
                 "original_data_keys": list(data.keys()),
                 "claude_variant": session_context["claude_variant"],
             },
+            session_id=session_id,
+            user_id=user_id,
+            tags=tags,
+            conversation_type=conversation_type,
+            custom_fields=custom_fields,
         )
+
+    def _extract_claude_tags(
+        self, data: Dict[str, Any], claude_variant: str
+    ) -> List[str]:
+        """Build tag list for a Claude conversation (variant + caller-supplied)."""
+        tags: List[str] = []
+        if claude_variant:
+            tags.append(f"variant:{claude_variant}")
+        explicit = data.get("tags")
+        if isinstance(explicit, list):
+            tags.extend(str(t) for t in explicit if t)
+        return tags
+
+    def _classify_claude_conversation_type(
+        self, data: Dict[str, Any], content: str
+    ) -> str:
+        """Classify a Claude conversation as chat/code/analysis/etc."""
+        explicit = data.get("conversation_type")
+        if isinstance(explicit, str) and explicit:
+            return explicit
+        if content and content.count("```") >= 4:
+            return "code"
+        return "chat"
+
+    def _extract_claude_custom_fields(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Capture optional Claude extras into custom_fields."""
+        custom: Dict[str, Any] = {}
+        for key in ("project_id", "organization_id", "workspace_id"):
+            value = data.get(key)
+            if value is not None:
+                custom[key] = value
+        extra = data.get("custom_fields")
+        if isinstance(extra, dict):
+            custom.update(extra)
+        return custom
 
     def _parse_markdown_conversation(
         self, content: str, file_path: Optional[Path] = None

--- a/src/importers/cursor_importer.py
+++ b/src/importers/cursor_importer.py
@@ -183,6 +183,20 @@ class CursorImporter(BaseImporter):
             "interaction_count": len(messages),
         }
 
+        # Universal metadata extraction.
+        # Cursor sessions map naturally onto session_id.
+        files_involved = self._extract_files_from_interactions(interactions)
+        tags = self._extract_cursor_tags(workspace, files_involved, raw_data)
+        custom_fields = self._extract_cursor_custom_fields(
+            raw_data, workspace, files_involved
+        )
+        explicit_type = raw_data.get("conversation_type")
+        conversation_type = (
+            explicit_type
+            if isinstance(explicit_type, str) and explicit_type
+            else "code"
+        )
+
         # Create universal conversation
         return self.create_universal_conversation(
             platform_id=session_id,
@@ -197,9 +211,50 @@ class CursorImporter(BaseImporter):
                 "workspace_path": workspace,
                 "session_timestamp": session_timestamp,
                 "interaction_count": len(interactions),
-                "files_involved": self._extract_files_from_interactions(interactions),
+                "files_involved": files_involved,
             },
+            session_id=session_id or None,
+            user_id=raw_data.get("user_id") or None,
+            tags=tags,
+            conversation_type=conversation_type,
+            custom_fields=custom_fields,
         )
+
+    def _extract_cursor_tags(
+        self,
+        workspace: str,
+        files_involved: List[str],
+        raw_data: Dict[str, Any],
+    ) -> List[str]:
+        """Build tag list for a Cursor session (workspace + caller-supplied)."""
+        tags: List[str] = []
+        if workspace:
+            workspace_name = Path(workspace).name
+            if workspace_name:
+                tags.append(f"workspace:{workspace_name}")
+        if files_involved:
+            tags.append("has-file-changes")
+        explicit = raw_data.get("tags")
+        if isinstance(explicit, list):
+            tags.extend(str(t) for t in explicit if t)
+        return tags
+
+    def _extract_cursor_custom_fields(
+        self,
+        raw_data: Dict[str, Any],
+        workspace: str,
+        files_involved: List[str],
+    ) -> Dict[str, Any]:
+        """Capture Cursor-specific extras into custom_fields."""
+        custom: Dict[str, Any] = {}
+        if workspace:
+            custom["workspace_path"] = workspace
+        if files_involved:
+            custom["files_involved"] = files_involved
+        extra = raw_data.get("custom_fields")
+        if isinstance(extra, dict):
+            custom.update(extra)
+        return custom
 
     def _process_interactions(
         self,

--- a/src/importers/generic_importer.py
+++ b/src/importers/generic_importer.py
@@ -687,6 +687,28 @@ class GenericImporter(BaseImporter):
         if not content and messages:
             content = self._combine_messages_to_content(messages)
 
+        # Pass-through universal metadata extraction.
+        # Generic importer accepts arbitrary dicts so we forward any
+        # known universal-metadata keys directly.
+        session_id = self._extract_field(data, ["session_id", "conversation_id"])
+        user_id = self._extract_field(data, ["user_id", "account_id", "owner_id"])
+        explicit_tags = self._extract_field(data, ["tags", "labels"])
+        tags = (
+            [str(t) for t in explicit_tags if t]
+            if isinstance(explicit_tags, list)
+            else []
+        )
+        explicit_type = self._extract_field(
+            data, ["conversation_type", "type", "category"]
+        )
+        conversation_type = (
+            explicit_type if isinstance(explicit_type, str) and explicit_type else None
+        )
+        explicit_custom = self._extract_field(
+            data, ["custom_fields", "extra", "extras"]
+        )
+        custom_fields = explicit_custom if isinstance(explicit_custom, dict) else {}
+
         return self.create_universal_conversation(
             platform_id=f"generic_{int(datetime.now().timestamp())}",
             title=title,
@@ -695,6 +717,11 @@ class GenericImporter(BaseImporter):
             date=datetime.now(),
             model="unknown",
             metadata={"original_keys": list(data.keys())},
+            session_id=session_id if isinstance(session_id, str) else None,
+            user_id=user_id if isinstance(user_id, str) else None,
+            tags=tags,
+            conversation_type=conversation_type,
+            custom_fields=custom_fields,
         )
 
     def _parse_list_as_conversation(self, data: List[Any]) -> Dict[str, Any]:

--- a/tests/test_importers/test_base_importer.py
+++ b/tests/test_importers/test_base_importer.py
@@ -30,7 +30,7 @@ class TestImporter(BaseImporter):
             conversations_failed=0,
             errors=[],
             imported_ids=["test_id"],
-            metadata={"test": True}
+            metadata={"test": True},
         )
 
     def parse_conversation(self, raw_data: Any) -> Dict[str, Any]:
@@ -41,7 +41,7 @@ class TestImporter(BaseImporter):
             content="Test content",
             messages=[],
             date=datetime.now(),
-            model="test-model"
+            model="test-model",
         )
 
 
@@ -56,7 +56,7 @@ class TestImportResult:
             conversations_failed=2,
             errors=["Error 1", "Error 2"],
             imported_ids=["id1", "id2", "id3"],
-            metadata={"source": "test"}
+            metadata={"source": "test"},
         )
 
         assert result.success is True
@@ -74,7 +74,7 @@ class TestImportResult:
             conversations_failed=2,
             errors=[],
             imported_ids=[],
-            metadata={}
+            metadata={},
         )
 
         assert result.success_rate == 0.8  # 8/(8+2) = 0.8
@@ -87,7 +87,7 @@ class TestImportResult:
             conversations_failed=0,
             errors=[],
             imported_ids=[],
-            metadata={}
+            metadata={},
         )
 
         assert result.success_rate == 0.0
@@ -100,7 +100,7 @@ class TestImportResult:
             conversations_failed=0,
             errors=[],
             imported_ids=[],
-            metadata={}
+            metadata={},
         )
 
         assert result.success_rate == 1.0
@@ -129,7 +129,7 @@ class TestBaseImporter:
                 "role": "user",
                 "content": "Hello",
                 "timestamp": date.isoformat(),
-                "metadata": {}
+                "metadata": {},
             }
         ]
 
@@ -141,7 +141,7 @@ class TestBaseImporter:
             date=date,
             model="gpt-4",
             session_context={"session_id": "abc123"},
-            metadata={"test_key": "test_value"}
+            metadata={"test_key": "test_value"},
         )
 
         # Verify required fields
@@ -183,7 +183,7 @@ class TestBaseImporter:
             content="Hello world",
             timestamp=timestamp,
             message_id="msg_123",
-            metadata={"source": "test"}
+            metadata={"source": "test"},
         )
 
         assert message["role"] == "user"
@@ -196,7 +196,7 @@ class TestBaseImporter:
         """Test message creation with auto-generated ID."""
         message = self.importer._create_message(
             role="ASSISTANT",  # Test case conversion
-            content="Hello back"
+            content="Hello back",
         )
 
         assert message["role"] == "assistant"  # Should be lowercased
@@ -270,12 +270,14 @@ class TestBaseImporter:
         messages = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there!"},
-            {"role": "user", "content": "How are you?"}
+            {"role": "user", "content": "How are you?"},
         ]
 
         content = self.importer._combine_messages_to_content(messages)
 
-        expected = "**Human**: Hello\n\n**Assistant**: Hi there!\n\n**Human**: How are you?"
+        expected = (
+            "**Human**: Hello\n\n**Assistant**: Hi there!\n\n**Human**: How are you?"
+        )
         assert content == expected
 
     def test_validate_conversation_valid(self):
@@ -293,7 +295,7 @@ class TestBaseImporter:
             "topics": ["test"],
             "session_context": {},
             "import_metadata": {},
-            "created_at": datetime.now().isoformat()
+            "created_at": datetime.now().isoformat(),
         }
 
         assert self.importer._validate_conversation(conversation) is True
@@ -302,7 +304,7 @@ class TestBaseImporter:
         """Test conversation validation with missing required fields."""
         conversation = {
             "id": "conv_123",
-            "title": "Test"
+            "title": "Test",
             # Missing required fields
         }
 
@@ -316,7 +318,7 @@ class TestBaseImporter:
             "content": "Test content",
             "date": datetime.now().isoformat(),
             "platform": "test",
-            "messages": "not_a_list"  # Should be list
+            "messages": "not_a_list",  # Should be list
         }
 
         assert self.importer._validate_conversation(conversation) is False
@@ -374,7 +376,7 @@ class TestBaseImporterEdgeCases:
             title="Minimal",
             content="Content",
             messages=[],
-            date=datetime.now()
+            date=datetime.now(),
         )
 
         # Should have sensible defaults
@@ -385,17 +387,12 @@ class TestBaseImporterEdgeCases:
     def test_create_message_edge_cases(self):
         """Test message creation edge cases."""
         # Empty content
-        message = self.importer._create_message(
-            role="user",
-            content=""
-        )
+        message = self.importer._create_message(role="user", content="")
         assert message["content"] == ""
 
         # None timestamp (should use current time)
         message = self.importer._create_message(
-            role="user",
-            content="test",
-            timestamp=None
+            role="user", content="test", timestamp=None
         )
         assert "timestamp" in message
 
@@ -423,3 +420,135 @@ class TestBaseImporterEdgeCases:
         # Invalid format returns current time
         result = self.importer._parse_timestamp("not-a-date")
         assert isinstance(result, datetime)
+
+
+class TestUniversalMetadataFields:
+    """Test the universal conversation metadata fields (todos 5.1.3-5.2.4).
+
+    These cover ``session_id``, ``user_id``, ``tags``, ``conversation_type``
+    and ``custom_fields`` on ``create_universal_conversation``. All five
+    are optional with sensible defaults to preserve backward compat.
+    """
+
+    def setup_method(self):
+        """Set up test environment."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage_path = Path(self.temp_dir)
+        self.importer = TestImporter(self.storage_path)
+
+    def _build(self, **kwargs):
+        """Build a minimal universal conversation with overrides."""
+        defaults = dict(
+            platform_id="meta_test",
+            title="Meta",
+            content="content",
+            messages=[],
+            date=datetime(2026, 4, 18, 10, 0, 0),
+        )
+        defaults.update(kwargs)
+        return self.importer.create_universal_conversation(**defaults)
+
+    def test_defaults_present_when_omitted(self):
+        """All new metadata fields appear with sensible defaults."""
+        conv = self._build()
+
+        # Field presence — keys MUST exist so downstream code can rely on them.
+        assert "session_id" in conv
+        assert "user_id" in conv
+        assert "tags" in conv
+        assert "conversation_type" in conv
+        assert "custom_fields" in conv
+
+        # Sensible defaults
+        assert conv["session_id"] is None
+        assert conv["user_id"] is None
+        assert conv["tags"] == []
+        assert conv["conversation_type"] is None
+        assert conv["custom_fields"] == {}
+
+    def test_session_id_populated(self):
+        """session_id (5.1.3) flows through when provided."""
+        conv = self._build(session_id="sess-abc-123")
+        assert conv["session_id"] == "sess-abc-123"
+
+    def test_user_id_populated(self):
+        """user_id (5.1.4) flows through when provided."""
+        conv = self._build(user_id="user-42")
+        assert conv["user_id"] == "user-42"
+
+    def test_tags_populated_and_isolated(self):
+        """tags (5.2.1) is stored as a *copy* (mutation isolation)."""
+        original_tags = ["work", "important"]
+        conv = self._build(tags=original_tags)
+        assert conv["tags"] == ["work", "important"]
+
+        # Mutating the input list should NOT affect the stored conversation —
+        # this protects against accidental cross-conversation mutation when
+        # callers reuse a tags list.
+        original_tags.append("oops")
+        assert conv["tags"] == ["work", "important"]
+
+    def test_conversation_type_populated(self):
+        """conversation_type (5.2.3) flows through when provided."""
+        conv = self._build(conversation_type="analysis")
+        assert conv["conversation_type"] == "analysis"
+
+    def test_custom_fields_populated_and_isolated(self):
+        """custom_fields (5.2.4) is stored as a *copy* (mutation isolation)."""
+        original = {"project": "alpha", "priority": 1}
+        conv = self._build(custom_fields=original)
+        assert conv["custom_fields"] == {"project": "alpha", "priority": 1}
+
+        # Mutating the input dict should NOT affect the stored conversation.
+        original["leaked"] = True
+        assert "leaked" not in conv["custom_fields"]
+
+    def test_validate_conversation_does_not_require_new_fields(self):
+        """Existing conversations without the new fields still validate."""
+        legacy_conv = {
+            "id": "conv_legacy",
+            "platform": "test",
+            "title": "Legacy",
+            "content": "legacy content",
+            "date": datetime.now().isoformat(),
+            "messages": [],
+            # Intentionally missing: session_id, user_id, tags,
+            # conversation_type, custom_fields
+        }
+        assert self.importer._validate_conversation(legacy_conv) is True
+
+    def test_backward_compat_call_signature(self):
+        """Callers that don't pass the new params still work unchanged."""
+        # Old-style call — only the original parameters.
+        conv = self.importer.create_universal_conversation(
+            platform_id="legacy",
+            title="Legacy",
+            content="legacy content",
+            messages=[],
+            date=datetime(2025, 1, 1),
+            model="legacy-model",
+            session_context={"foo": "bar"},
+            metadata={"baz": "qux"},
+        )
+
+        # Pre-existing behavior preserved
+        assert conv["model"] == "legacy-model"
+        assert conv["session_context"] == {"foo": "bar"}
+        assert conv["platform_metadata"] == {"baz": "qux"}
+
+        # New fields default cleanly
+        assert conv["session_id"] is None
+        assert conv["user_id"] is None
+        assert conv["tags"] == []
+        assert conv["conversation_type"] is None
+        assert conv["custom_fields"] == {}
+
+    def test_empty_tags_list_yields_empty_list(self):
+        """Passing an empty list explicitly should produce an empty list."""
+        conv = self._build(tags=[])
+        assert conv["tags"] == []
+
+    def test_empty_custom_fields_dict_yields_empty_dict(self):
+        """Passing an empty dict explicitly should produce an empty dict."""
+        conv = self._build(custom_fields={})
+        assert conv["custom_fields"] == {}

--- a/tests/test_importers/test_chatgpt_importer.py
+++ b/tests/test_importers/test_chatgpt_importer.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+import pytest  # type: ignore[import-not-found]
 
 from src.importers.chatgpt_importer import ChatGPTImporter
 
@@ -44,8 +44,7 @@ class TestChatGPTImporter:
 
     def test_validate_chatgpt_format_valid(self):
         """Test ChatGPT format validation with valid data."""
-        assert self.importer._validate_chatgpt_format(
-            self.valid_export) is True
+        assert self.importer._validate_chatgpt_format(self.valid_export) is True
 
     def test_validate_chatgpt_format_invalid_structure(self):
         """Test ChatGPT format validation with invalid structure."""
@@ -80,7 +79,9 @@ class TestChatGPTImporter:
         conversation = self.importer.parse_conversation(conv_data)
 
         # Check basic fields
-        assert conversation["platform_id"] == "conv-123e4567-e89b-12d3-a456-426614174000"
+        assert (
+            conversation["platform_id"] == "conv-123e4567-e89b-12d3-a456-426614174000"
+        )
         assert conversation["title"] == "Python Programming Help"
         assert conversation["platform"] == "chatgpt"
         assert conversation["model"] == "gpt-4"  # Default assumption
@@ -110,9 +111,9 @@ class TestChatGPTImporter:
                     "id": "msg1",
                     "role": "assistant",
                     "content": "I'm GPT-3.5 and I can help you with this task.",
-                    "create_time": "2025-01-15T10:01:00Z"
+                    "create_time": "2025-01-15T10:01:00Z",
                 }
-            ]
+            ],
         }
 
         conversation = self.importer.parse_conversation(conv_data)
@@ -120,7 +121,9 @@ class TestChatGPTImporter:
 
     def test_parse_conversation_invalid_data(self):
         """Test parsing invalid conversation data."""
-        with pytest.raises(ValueError, match="ChatGPT conversation data must be a dictionary"):
+        with pytest.raises(
+            ValueError, match="ChatGPT conversation data must be a dictionary"
+        ):
             self.importer.parse_conversation("not a dict")
 
     def test_parse_conversation_missing_messages(self):
@@ -128,7 +131,7 @@ class TestChatGPTImporter:
         conv_data = {
             "id": "test_conv",
             "title": "Test",
-            "create_time": "2025-01-15T10:00:00Z"
+            "create_time": "2025-01-15T10:00:00Z",
             # No messages field
         }
 
@@ -145,8 +148,8 @@ class TestChatGPTImporter:
             "messages": [
                 {"role": "user", "content": ""},
                 {"role": "user", "content": "   "},  # Whitespace only
-                {"role": "user", "content": "Valid message"}
-            ]
+                {"role": "user", "content": "Valid message"},
+            ],
         }
 
         conversation = self.importer.parse_conversation(conv_data)
@@ -182,9 +185,8 @@ class TestChatGPTImporter:
         test_file = self.storage_path / "test.json"
 
         # Mock save method to avoid file I/O
-        with patch.object(self.importer, '_save_conversation') as mock_save:
-            result = self.importer._process_conversations(
-                conversations, test_file)
+        with patch.object(self.importer, "_save_conversation") as mock_save:
+            result = self.importer._process_conversations(conversations, test_file)
 
         assert result.success is True
         assert result.conversations_imported == 2
@@ -199,12 +201,11 @@ class TestChatGPTImporter:
         test_file = self.storage_path / "test.json"
 
         # Mock validation to fail for second conversation
-        with patch.object(self.importer, '_validate_conversation') as mock_validate:
+        with patch.object(self.importer, "_validate_conversation") as mock_validate:
             # First succeeds, second fails
             mock_validate.side_effect = [True, False]
-            with patch.object(self.importer, '_save_conversation'):
-                result = self.importer._process_conversations(
-                    conversations, test_file)
+            with patch.object(self.importer, "_save_conversation"):
+                result = self.importer._process_conversations(conversations, test_file)
 
         assert result.conversations_imported == 1
         assert result.conversations_failed == 1
@@ -216,10 +217,9 @@ class TestChatGPTImporter:
         test_file = self.storage_path / "test.json"
 
         # Mock parse_conversation to raise exception
-        with patch.object(self.importer, 'parse_conversation') as mock_parse:
+        with patch.object(self.importer, "parse_conversation") as mock_parse:
             mock_parse.side_effect = Exception("Parse error")
-            result = self.importer._process_conversations(
-                conversations, test_file)
+            result = self.importer._process_conversations(conversations, test_file)
 
         assert result.conversations_imported == 0
         assert result.conversations_failed == 1
@@ -281,7 +281,7 @@ class TestChatGPTImporter:
         valid_file.write_text(json.dumps(self.valid_export))
 
         # Mock to raise general exception
-        with patch.object(self.importer, '_validate_chatgpt_format') as mock_validate:
+        with patch.object(self.importer, "_validate_chatgpt_format") as mock_validate:
             mock_validate.side_effect = Exception("General error")
             result = self.importer.import_file(valid_file)
 
@@ -294,7 +294,7 @@ class TestChatGPTImporter:
             "id": "conv_test_123",
             "title": "Test Conversation",
             "date": "2025-01-15T10:30:00Z",
-            "content": "Test content"
+            "content": "Test content",
         }
 
         file_path = self.importer._save_conversation(conversation)
@@ -352,7 +352,7 @@ class TestChatGPTImporterEdgeCases:
         conv_data = {
             "id": "test_conv",
             "create_time": "2025-01-15T10:00:00Z",
-            "messages": []
+            "messages": [],
         }
 
         conversation = self.importer.parse_conversation(conv_data)
@@ -369,9 +369,9 @@ class TestChatGPTImporterEdgeCases:
                     "id": "msg1",
                     "role": "user",
                     "content": "Test",
-                    "create_time": "also-invalid"
+                    "create_time": "also-invalid",
                 }
-            ]
+            ],
         }
 
         conversation = self.importer.parse_conversation(conv_data)
@@ -390,14 +390,14 @@ class TestChatGPTImporterEdgeCases:
                 {
                     "role": "user",
                     "content": "Valid message",
-                    "create_time": "2025-01-15T10:01:00Z"
+                    "create_time": "2025-01-15T10:01:00Z",
                 },
                 {
                     "role": "assistant",
                     "content": "",  # Empty content - should be skipped
-                    "create_time": "2025-01-15T10:02:00Z"
-                }
-            ]
+                    "create_time": "2025-01-15T10:02:00Z",
+                },
+            ],
         }
 
         conversation = self.importer.parse_conversation(conv_data)
@@ -408,11 +408,7 @@ class TestChatGPTImporterEdgeCases:
     def test_validate_chatgpt_format_edge_cases(self):
         """Test ChatGPT format validation edge cases."""
         # Empty messages array is valid
-        data = {
-            "conversations": [
-                {"messages": []}
-            ]
-        }
+        data = {"conversations": [{"messages": []}]}
         assert self.importer._validate_chatgpt_format(data) is True
 
         # Message without role/content should fail
@@ -426,3 +422,127 @@ class TestChatGPTImporterEdgeCases:
             ]
         }
         assert self.importer._validate_chatgpt_format(data) is False
+
+
+class TestChatGPTUniversalMetadata:
+    """ChatGPT importer populates universal metadata fields (5.1.3-5.2.4)."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage_path = Path(self.temp_dir)
+        self.importer = ChatGPTImporter(self.storage_path)
+
+    def _base_payload(self, **overrides):
+        payload = {
+            "id": "fallback-id",
+            "title": "Test",
+            "create_time": "2025-01-15T10:30:00Z",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "hi",
+                    "create_time": "2025-01-15T10:30:00Z",
+                },
+                {
+                    "role": "assistant",
+                    "content": "hello",
+                    "create_time": "2025-01-15T10:31:00Z",
+                },
+            ],
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_session_id_uses_conversation_id_when_available(self):
+        """ChatGPT's conversation_id maps to universal session_id."""
+        payload = self._base_payload(conversation_id="conv-real-uuid")
+        conv = self.importer.parse_conversation(payload)
+        assert conv["session_id"] == "conv-real-uuid"
+
+    def test_session_id_falls_back_to_id(self):
+        """When conversation_id is absent the legacy 'id' becomes session_id."""
+        payload = self._base_payload()  # only 'id', no 'conversation_id'
+        conv = self.importer.parse_conversation(payload)
+        assert conv["session_id"] == "fallback-id"
+
+    def test_user_id_passes_through_when_present(self):
+        """A caller-injected user_id flows through to the universal field."""
+        payload = self._base_payload(user_id="user-123")
+        conv = self.importer.parse_conversation(payload)
+        assert conv["user_id"] == "user-123"
+
+    def test_user_id_default_none(self):
+        """Standard ChatGPT exports omit user_id; default is None."""
+        conv = self.importer.parse_conversation(self._base_payload())
+        assert conv["user_id"] is None
+
+    def test_tags_include_starred_archived_and_gizmo(self):
+        """Starred/archived/gizmo signals become tags."""
+        payload = self._base_payload(
+            is_starred=True, is_archived=True, gizmo_id="g-abc"
+        )
+        conv = self.importer.parse_conversation(payload)
+        assert "starred" in conv["tags"]
+        assert "archived" in conv["tags"]
+        assert "gizmo:g-abc" in conv["tags"]
+
+    def test_tags_explicit_tags_appended(self):
+        """Caller-supplied tags are merged in."""
+        payload = self._base_payload(tags=["work", "ml"])
+        conv = self.importer.parse_conversation(payload)
+        assert "work" in conv["tags"]
+        assert "ml" in conv["tags"]
+
+    def test_tags_default_empty(self):
+        """No tag-worthy signals => empty tags list."""
+        conv = self.importer.parse_conversation(self._base_payload())
+        assert conv["tags"] == []
+
+    def test_conversation_type_explicit_wins(self):
+        payload = self._base_payload(conversation_type="analysis")
+        conv = self.importer.parse_conversation(payload)
+        assert conv["conversation_type"] == "analysis"
+
+    def test_conversation_type_code_heuristic(self):
+        """Heavy code-fence content triggers the 'code' classification."""
+        code_blob = "```python\nprint('x')\n```\n```bash\nls\n```"
+        payload = self._base_payload(
+            messages=[
+                {
+                    "role": "user",
+                    "content": code_blob,
+                    "create_time": "2025-01-15T10:30:00Z",
+                },
+                {
+                    "role": "assistant",
+                    "content": code_blob,
+                    "create_time": "2025-01-15T10:31:00Z",
+                },
+            ],
+        )
+        conv = self.importer.parse_conversation(payload)
+        assert conv["conversation_type"] == "code"
+
+    def test_conversation_type_default_chat(self):
+        """Plain chat content defaults to 'chat'."""
+        conv = self.importer.parse_conversation(self._base_payload())
+        assert conv["conversation_type"] == "chat"
+
+    def test_custom_fields_capture_extras(self):
+        """Optional ChatGPT-specific keys are captured into custom_fields."""
+        payload = self._base_payload(
+            default_model_slug="gpt-4o",
+            gizmo_id="g-1",
+            memory_scope="user_memory",
+            custom_fields={"experiment": "alpha"},
+        )
+        conv = self.importer.parse_conversation(payload)
+        assert conv["custom_fields"]["default_model_slug"] == "gpt-4o"
+        assert conv["custom_fields"]["gizmo_id"] == "g-1"
+        assert conv["custom_fields"]["memory_scope"] == "user_memory"
+        assert conv["custom_fields"]["experiment"] == "alpha"
+
+    def test_custom_fields_default_empty(self):
+        """Standard exports without optional keys produce an empty dict."""
+        conv = self.importer.parse_conversation(self._base_payload())
+        assert conv["custom_fields"] == {}

--- a/tests/test_importers/test_claude_importer.py
+++ b/tests/test_importers/test_claude_importer.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+import pytest  # type: ignore[import-not-found]
 
 from src.importers.claude_importer import ClaudeImporter
 
@@ -53,7 +53,9 @@ class TestClaudeImporter:
         test_file = self.storage_path / "test.json"
         test_file.write_text('{"test": "data"}')
 
-        with patch.object(self.importer, '_import_json_format', side_effect=Exception("Test error")):
+        with patch.object(
+            self.importer, "_import_json_format", side_effect=Exception("Test error")
+        ):
             result = self.importer.import_file(test_file)
 
         assert result.success is False
@@ -82,17 +84,17 @@ class TestClaudeImporterJSONFormat:
                 {
                     "role": "user",
                     "content": "Hello Claude",
-                    "timestamp": "2025-01-15T12:00:00Z"
+                    "timestamp": "2025-01-15T12:00:00Z",
                 },
                 {
                     "role": "assistant",
                     "content": "Hello! How can I help you?",
-                    "timestamp": "2025-01-15T12:01:00Z"
-                }
+                    "timestamp": "2025-01-15T12:01:00Z",
+                },
             ],
             "date": "2025-01-15T12:00:00Z",
             "topics": ["greeting"],
-            "created_at": "2025-01-15T12:00:00Z"
+            "created_at": "2025-01-15T12:00:00Z",
         }
 
         test_file = self.storage_path / "claude_memory.json"
@@ -156,7 +158,7 @@ class TestClaudeImporterTextFormat:
         test_file = self.storage_path / "claude_web.md"
         test_file.write_text(markdown_content)
 
-        with patch.object(self.importer, '_save_conversation') as mock_save:
+        with patch.object(self.importer, "_save_conversation") as mock_save:
             result = self.importer.import_file(test_file)
 
         assert result.success is True
@@ -169,7 +171,9 @@ class TestClaudeImporterTextFormat:
         test_file = self.storage_path / "test.txt"
         test_file.write_text("Test content")
 
-        with patch.object(self.importer, '_import_text_format', side_effect=Exception("Parse error")):
+        with patch.object(
+            self.importer, "_import_text_format", side_effect=Exception("Parse error")
+        ):
             result = self.importer.import_file(test_file)
 
         assert result.success is False
@@ -192,7 +196,7 @@ class TestClaudeImporterParsingMethods:
         data = {
             "title": "Test Conv",
             "content": "Test content",
-            "messages": [{"role": "user", "content": "Hello"}]
+            "messages": [{"role": "user", "content": "Hello"}],
         }
 
         result = self.importer.parse_conversation(data)
@@ -214,7 +218,7 @@ class TestClaudeImporterParsingMethods:
             "content": "test",
             "messages": [],
             "topics": [],
-            "created_at": "2025-01-15"
+            "created_at": "2025-01-15",
         }
 
         result = self.importer._is_claude_memory_format(data)
@@ -244,7 +248,7 @@ class TestClaudeImporterSaveConversation:
             "date": "2025-01-15T12:00:00",
             "title": "Test Claude Conversation",
             "content": "Test content",
-            "platform": "claude"
+            "platform": "claude",
         }
 
         file_path = self.importer._save_conversation(conversation)
@@ -256,7 +260,7 @@ class TestClaudeImporterSaveConversation:
         assert file_path.name.endswith(".json")
 
         # Verify content
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             saved_data = json.load(f)
 
         assert saved_data["id"] == conversation["id"]
@@ -274,20 +278,27 @@ class TestClaudeImporterIntegration:
 
     def test_end_to_end_claude_memory_import(self):
         """Test complete end-to-end Claude Memory import workflow."""
-        claude_data = {"id": "conv_20250115_090000_e2etest",
-                       "platform": "claude",
-                       "title": "E2E Claude Memory Test",
-                       "content": "**Human**: Test the Claude importer\n\n**Claude**: Testing the Claude Memory import functionality.",
-                       "messages": [{"role": "user",
-                                     "content": "Test the Claude importer",
-                                     "timestamp": "2025-01-15T09:00:00Z"},
-                                    {"role": "assistant",
-                                     "content": "Testing the Claude Memory import functionality.",
-                                     "timestamp": "2025-01-15T09:01:00Z"}],
-                       "date": "2025-01-15T09:00:00Z",
-                       "topics": ["testing",
-                                  "import"],
-                       "created_at": "2025-01-15T09:00:00Z"}
+        claude_data = {
+            "id": "conv_20250115_090000_e2etest",
+            "platform": "claude",
+            "title": "E2E Claude Memory Test",
+            "content": "**Human**: Test the Claude importer\n\n**Claude**: Testing the Claude Memory import functionality.",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Test the Claude importer",
+                    "timestamp": "2025-01-15T09:00:00Z",
+                },
+                {
+                    "role": "assistant",
+                    "content": "Testing the Claude Memory import functionality.",
+                    "timestamp": "2025-01-15T09:01:00Z",
+                },
+            ],
+            "date": "2025-01-15T09:00:00Z",
+            "topics": ["testing", "import"],
+            "created_at": "2025-01-15T09:00:00Z",
+        }
 
         test_file = self.storage_path / "claude_e2e_test.json"
         test_file.write_text(json.dumps(claude_data))
@@ -313,10 +324,107 @@ class TestClaudeImporterIntegration:
         # (no separate conversation file is created)
         assert test_file.exists()
 
-        with open(test_file, 'r') as f:
+        with open(test_file, "r") as f:
             original_data = json.load(f)
 
         assert original_data["platform"] == "claude"
         assert original_data["id"] == "conv_20250115_090000_e2etest"
         assert len(original_data["messages"]) == 2
         assert "Claude Memory import" in original_data["content"]
+
+
+class TestClaudeUniversalMetadata:
+    """Claude importer populates universal metadata fields (5.1.3-5.2.4)."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage_path = Path(self.temp_dir)
+        self.importer = ClaudeImporter(self.storage_path)
+
+    def _base_payload(self, **overrides):
+        payload = {
+            "id": "claude-conv-9",
+            "title": "Claude Test",
+            "date": "2025-03-01T09:00:00",
+            "content": "Hello world",
+            "messages": [
+                {"role": "user", "content": "ping"},
+                {"role": "assistant", "content": "pong"},
+            ],
+            "model": "claude-3.5-sonnet",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_session_id_uses_explicit_session_id(self):
+        conv = self.importer._parse_claude_json(
+            self._base_payload(session_id="claude-sess-1")
+        )
+        assert conv["session_id"] == "claude-sess-1"
+
+    def test_session_id_falls_back_to_conversation_id(self):
+        conv = self.importer._parse_claude_json(
+            self._base_payload(conversation_id="claude-conv-2")
+        )
+        assert conv["session_id"] == "claude-conv-2"
+
+    def test_session_id_falls_back_to_platform_id(self):
+        """When neither session_id nor conversation_id present, 'id' is used."""
+        conv = self.importer._parse_claude_json(self._base_payload())
+        assert conv["session_id"] == "claude-conv-9"
+
+    def test_user_id_passes_through(self):
+        conv = self.importer._parse_claude_json(
+            self._base_payload(user_id="claude-user-x")
+        )
+        assert conv["user_id"] == "claude-user-x"
+
+    def test_user_id_falls_back_to_account_id(self):
+        conv = self.importer._parse_claude_json(self._base_payload(account_id="acct-7"))
+        assert conv["user_id"] == "acct-7"
+
+    def test_tags_include_variant(self):
+        """The detected Claude variant is exposed as a tag."""
+        conv = self.importer._parse_claude_json(self._base_payload())
+        # variant detection from generic data => 'claude_generic'
+        assert any(t.startswith("variant:") for t in conv["tags"])
+
+    def test_tags_explicit_appended(self):
+        conv = self.importer._parse_claude_json(
+            self._base_payload(tags=["research", "deep-dive"])
+        )
+        assert "research" in conv["tags"]
+        assert "deep-dive" in conv["tags"]
+
+    def test_conversation_type_default_chat(self):
+        conv = self.importer._parse_claude_json(self._base_payload())
+        assert conv["conversation_type"] == "chat"
+
+    def test_conversation_type_code_heuristic(self):
+        code = "```py\nx=1\n```\n```py\ny=2\n```"
+        conv = self.importer._parse_claude_json(self._base_payload(content=code))
+        assert conv["conversation_type"] == "code"
+
+    def test_conversation_type_explicit_overrides(self):
+        conv = self.importer._parse_claude_json(
+            self._base_payload(conversation_type="creative")
+        )
+        assert conv["conversation_type"] == "creative"
+
+    def test_custom_fields_capture_optional_keys(self):
+        conv = self.importer._parse_claude_json(
+            self._base_payload(
+                project_id="proj-1",
+                organization_id="org-2",
+                workspace_id="ws-3",
+                custom_fields={"flow": "ad-hoc"},
+            )
+        )
+        assert conv["custom_fields"]["project_id"] == "proj-1"
+        assert conv["custom_fields"]["organization_id"] == "org-2"
+        assert conv["custom_fields"]["workspace_id"] == "ws-3"
+        assert conv["custom_fields"]["flow"] == "ad-hoc"
+
+    def test_custom_fields_default_empty(self):
+        conv = self.importer._parse_claude_json(self._base_payload())
+        assert conv["custom_fields"] == {}

--- a/tests/test_importers/test_cursor_importer.py
+++ b/tests/test_importers/test_cursor_importer.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+import pytest  # type: ignore[import-not-found]
 
 from src.importers.cursor_importer import CursorImporter
 
@@ -86,20 +86,20 @@ class TestCursorImporter:
                     "type": "user_input",
                     "content": "Help me with this code",
                     "timestamp": "2025-01-15T10:00:00Z",
-                    "files": ["main.py"]
+                    "files": ["main.py"],
                 },
                 {
                     "type": "ai_response",
                     "content": "I can help you with your code",
-                    "timestamp": "2025-01-15T10:01:00Z"
-                }
-            ]
+                    "timestamp": "2025-01-15T10:01:00Z",
+                },
+            ],
         }
 
         test_file = self.storage_path / "cursor_session.json"
         test_file.write_text(json.dumps(cursor_data))
 
-        with patch.object(self.importer, '_save_conversation') as mock_save:
+        with patch.object(self.importer, "_save_conversation") as mock_save:
             result = self.importer.import_file(test_file)
 
         assert result.success is True
@@ -114,7 +114,11 @@ class TestCursorImporter:
         test_file = self.storage_path / "test.json"
         test_file.write_text('{"session_id": "test"}')
 
-        with patch.object(self.importer, '_validate_cursor_format', side_effect=Exception("Test error")):
+        with patch.object(
+            self.importer,
+            "_validate_cursor_format",
+            side_effect=Exception("Test error"),
+        ):
             result = self.importer.import_file(test_file)
 
         assert result.success is False
@@ -137,12 +141,7 @@ class TestCursorImporterValidation:
         data = {
             "session_id": "test-session",
             "workspace": "/path/to/project",
-            "interactions": [
-                {
-                    "type": "user_input",
-                    "content": "Hello"
-                }
-            ]
+            "interactions": [{"type": "user_input", "content": "Hello"}],
         }
 
         result = self.importer._validate_cursor_format(data)
@@ -170,7 +169,7 @@ class TestCursorImporterValidation:
         data = {
             "session_id": "test",
             "workspace": "/path",
-            "interactions": "not an array"
+            "interactions": "not an array",
         }
 
         result = self.importer._validate_cursor_format(data)
@@ -198,15 +197,15 @@ class TestCursorImporterParsing:
                     "type": "user_input",
                     "content": "Write a function",
                     "timestamp": "2025-01-15T10:00:00Z",
-                    "files": ["utils.py", "main.py"]
+                    "files": ["utils.py", "main.py"],
                 },
                 {
                     "type": "ai_response",
                     "content": "Here's a function for you",
                     "timestamp": "2025-01-15T10:01:00Z",
-                    "changes": ["modified utils.py"]
-                }
-            ]
+                    "changes": ["modified utils.py"],
+                },
+            ],
         }
 
         conversation = self.importer.parse_conversation(data)
@@ -238,7 +237,7 @@ class TestCursorImporterParsing:
         data = {
             "session_id": "minimal-test",
             "workspace": "/project",
-            "interactions": []
+            "interactions": [],
         }
 
         conversation = self.importer.parse_conversation(data)
@@ -252,14 +251,16 @@ class TestCursorImporterParsing:
         """Test parsing invalid conversation data."""
         data = "not a dictionary"
 
-        with pytest.raises(ValueError, match="Cursor session data must be a dictionary"):
+        with pytest.raises(
+            ValueError, match="Cursor session data must be a dictionary"
+        ):
             self.importer.parse_conversation(data)
 
     def test_parse_conversation_missing_interactions(self):
         """Test parsing session without interactions."""
         data = {
             "session_id": "no-interactions",
-            "workspace": "/project"
+            "workspace": "/project",
             # Missing interactions
         }
 
@@ -275,12 +276,8 @@ class TestCursorImporterParsing:
             "workspace": "/project",
             "created_at": "invalid-date",
             "interactions": [
-                {
-                    "type": "user_input",
-                    "content": "Hello",
-                    "timestamp": "also-invalid"
-                }
-            ]
+                {"type": "user_input", "content": "Hello", "timestamp": "also-invalid"}
+            ],
         }
 
         # Should handle gracefully with current time fallbacks
@@ -303,7 +300,8 @@ class TestCursorImporterHelperMethods:
         """Test _add_session_header method."""
         content_parts = []
         self.importer._add_session_header(
-            content_parts, "/my/project", "claude-3", "session-123")
+            content_parts, "/my/project", "claude-3", "session-123"
+        )
 
         assert "# Cursor AI Session" in content_parts
         assert "**Workspace**: /my/project" in content_parts
@@ -316,7 +314,7 @@ class TestCursorImporterHelperMethods:
             "type": "user_input",
             "content": "Help me debug this",
             "timestamp": "2025-01-15T10:00:00Z",
-            "files": ["debug.py"]
+            "files": ["debug.py"],
         }
         date = datetime.now()
 
@@ -335,7 +333,7 @@ class TestCursorImporterHelperMethods:
             "type": "ai_response",
             "content": "Here's the solution",
             "timestamp": "2025-01-15T10:01:00Z",
-            "changes": ["modified debug.py", "added test.py"]
+            "changes": ["modified debug.py", "added test.py"],
         }
         date = datetime.now()
 
@@ -353,7 +351,7 @@ class TestCursorImporterHelperMethods:
         interaction = {
             "type": "user_input",
             "content": "",
-            "timestamp": "2025-01-15T10:00:00Z"
+            "timestamp": "2025-01-15T10:00:00Z",
         }
         date = datetime.now()
 
@@ -382,12 +380,11 @@ class TestCursorImporterHelperMethods:
         """Test _enhance_interaction_content method."""
         interaction = {
             "files": ["main.py", "utils.py"],
-            "changes": ["modified main.py"]
+            "changes": ["modified main.py"],
         }
         content = "Original content"
 
-        enhanced = self.importer._enhance_interaction_content(
-            interaction, content)
+        enhanced = self.importer._enhance_interaction_content(interaction, content)
 
         assert "Original content" in enhanced
         assert "Files: main.py, utils.py" in enhanced
@@ -398,8 +395,7 @@ class TestCursorImporterHelperMethods:
         interaction = {}
         content = "Just content"
 
-        enhanced = self.importer._enhance_interaction_content(
-            interaction, content)
+        enhanced = self.importer._enhance_interaction_content(interaction, content)
 
         assert enhanced == "Just content"
 
@@ -408,7 +404,7 @@ class TestCursorImporterHelperMethods:
         interaction = {
             "type": "user_input",
             "files": ["test.py"],
-            "changes": ["added feature"]
+            "changes": ["added feature"],
         }
 
         metadata = self.importer._create_interaction_metadata(interaction)
@@ -446,7 +442,7 @@ class TestCursorImporterSaveConversation:
             "date": "2025-01-15T12:00:00",
             "title": "Test Cursor Session",
             "content": "Test content",
-            "platform": "cursor"
+            "platform": "cursor",
         }
 
         file_path = self.importer._save_conversation(conversation)
@@ -458,7 +454,7 @@ class TestCursorImporterSaveConversation:
         assert file_path.name.endswith(".json")
 
         # Verify content
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             saved_data = json.load(f)
 
         assert saved_data["id"] == conversation["id"]
@@ -476,26 +472,38 @@ class TestCursorImporterIntegration:
 
     def test_end_to_end_import(self):
         """Test complete end-to-end import workflow."""
-        cursor_data = {"session_id": "e2e-test-session",
-                       "workspace": "/my/coding/project",
-                       "model": "claude-3.5-sonnet",
-                       "created_at": "2025-01-15T09:00:00Z",
-                       "interactions": [{"type": "user_input",
-                                         "content": "I need help implementing a binary search algorithm",
-                                         "timestamp": "2025-01-15T09:00:00Z",
-                                         "files": ["algorithms.py"]},
-                                        {"type": "ai_response",
-                                         "content": "I'll help you implement a binary search. Here's an efficient implementation...",
-                                         "timestamp": "2025-01-15T09:01:30Z",
-                                         "changes": ["modified algorithms.py"]},
-                                        {"type": "user_input",
-                                         "content": "Can you add unit tests for this function?",
-                                         "timestamp": "2025-01-15T09:05:00Z",
-                                         "files": ["algorithms.py"]},
-                                        {"type": "ai_response",
-                                         "content": "Absolutely! Here are comprehensive unit tests...",
-                                         "timestamp": "2025-01-15T09:07:15Z",
-                                         "changes": ["created test_algorithms.py"]}]}
+        cursor_data = {
+            "session_id": "e2e-test-session",
+            "workspace": "/my/coding/project",
+            "model": "claude-3.5-sonnet",
+            "created_at": "2025-01-15T09:00:00Z",
+            "interactions": [
+                {
+                    "type": "user_input",
+                    "content": "I need help implementing a binary search algorithm",
+                    "timestamp": "2025-01-15T09:00:00Z",
+                    "files": ["algorithms.py"],
+                },
+                {
+                    "type": "ai_response",
+                    "content": "I'll help you implement a binary search. Here's an efficient implementation...",
+                    "timestamp": "2025-01-15T09:01:30Z",
+                    "changes": ["modified algorithms.py"],
+                },
+                {
+                    "type": "user_input",
+                    "content": "Can you add unit tests for this function?",
+                    "timestamp": "2025-01-15T09:05:00Z",
+                    "files": ["algorithms.py"],
+                },
+                {
+                    "type": "ai_response",
+                    "content": "Absolutely! Here are comprehensive unit tests...",
+                    "timestamp": "2025-01-15T09:07:15Z",
+                    "changes": ["created test_algorithms.py"],
+                },
+            ],
+        }
 
         test_file = self.storage_path / "complete_session.json"
         test_file.write_text(json.dumps(cursor_data))
@@ -514,12 +522,15 @@ class TestCursorImporterIntegration:
         assert result.metadata["import_format"] == "cursor_session"
 
         # Verify conversation file was created (exclude source file)
-        conversation_files = [f for f in self.storage_path.rglob(
-            "*.json") if f.name != "complete_session.json"]
+        conversation_files = [
+            f
+            for f in self.storage_path.rglob("*.json")
+            if f.name != "complete_session.json"
+        ]
         assert len(conversation_files) == 1
 
         # Verify conversation content
-        with open(conversation_files[0], 'r') as f:
+        with open(conversation_files[0], "r") as f:
             saved_conversation = json.load(f)
 
         assert saved_conversation["platform"] == "cursor"
@@ -540,20 +551,20 @@ class TestCursorImporterIntegration:
                     "type": "user_input",
                     "content": "Review this code for security issues",
                     "files": ["auth.py", "user_model.py", "config.py"],
-                    "metadata": {"review_type": "security"}
+                    "metadata": {"review_type": "security"},
                 },
                 {
                     "type": "ai_response",
                     "content": "I've identified several security concerns...",
                     "changes": ["modified auth.py", "added security_utils.py"],
-                    "metadata": {"confidence": "high"}
+                    "metadata": {"confidence": "high"},
                 },
                 {
                     "type": "system_event",
                     "content": "Code analysis completed",
-                    "metadata": {"duration": "45s"}
-                }
-            ]
+                    "metadata": {"duration": "45s"},
+                },
+            ],
         }
 
         test_file = self.storage_path / "complex_session.json"
@@ -565,9 +576,12 @@ class TestCursorImporterIntegration:
         assert result.conversations_imported == 1
 
         # Verify complex interactions were processed (exclude source file)
-        conversation_files = [f for f in self.storage_path.rglob(
-            "*.json") if f.name != "complex_session.json"]
-        with open(conversation_files[0], 'r') as f:
+        conversation_files = [
+            f
+            for f in self.storage_path.rglob("*.json")
+            if f.name != "complex_session.json"
+        ]
+        with open(conversation_files[0], "r") as f:
             conversation = json.load(f)
 
         assert "messages" in conversation
@@ -583,3 +597,94 @@ class TestCursorImporterIntegration:
         assert "auth.py" in conversation["messages"][0]["content"]
         assert "security concerns" in conversation["messages"][1]["content"]
         assert "modified" in conversation["messages"][1]["content"]
+
+
+class TestCursorUniversalMetadata:
+    """Cursor importer populates universal metadata fields (5.1.3-5.2.4)."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage_path = Path(self.temp_dir)
+        self.importer = CursorImporter(self.storage_path)
+
+    def _base_session(self, **overrides):
+        session = {
+            "session_id": "sess-cursor-001",
+            "workspace": "/home/dev/myproject",
+            "timestamp": "2025-02-01T08:00:00Z",
+            "model": "claude-3.5-sonnet",
+            "interactions": [
+                {
+                    "type": "user_input",
+                    "content": "Refactor this function",
+                    "files": ["src/main.py"],
+                    "timestamp": "2025-02-01T08:00:00Z",
+                },
+                {
+                    "type": "ai_response",
+                    "content": "Done.",
+                    "changes": [{"file": "src/main.py", "diff": "..."}],
+                    "timestamp": "2025-02-01T08:00:30Z",
+                },
+            ],
+        }
+        session.update(overrides)
+        return session
+
+    def test_session_id_from_cursor_session(self):
+        """Cursor's native session_id maps directly to universal session_id."""
+        conv = self.importer.parse_conversation(self._base_session())
+        assert conv["session_id"] == "sess-cursor-001"
+
+    def test_session_id_none_when_blank(self):
+        """Empty/blank session_id collapses to None (not empty string)."""
+        conv = self.importer.parse_conversation(self._base_session(session_id=""))
+        assert conv["session_id"] is None
+
+    def test_user_id_passes_through(self):
+        conv = self.importer.parse_conversation(self._base_session(user_id="dev-007"))
+        assert conv["user_id"] == "dev-007"
+
+    def test_user_id_default_none(self):
+        conv = self.importer.parse_conversation(self._base_session())
+        assert conv["user_id"] is None
+
+    def test_tags_include_workspace_and_file_changes(self):
+        """Workspace name and file-change presence appear as tags."""
+        conv = self.importer.parse_conversation(self._base_session())
+        assert "workspace:myproject" in conv["tags"]
+        assert "has-file-changes" in conv["tags"]
+
+    def test_tags_explicit_appended(self):
+        conv = self.importer.parse_conversation(
+            self._base_session(tags=["sprint-7", "urgent"])
+        )
+        assert "sprint-7" in conv["tags"]
+        assert "urgent" in conv["tags"]
+
+    def test_conversation_type_defaults_code(self):
+        """Cursor sessions default to 'code' since the platform is an IDE."""
+        conv = self.importer.parse_conversation(self._base_session())
+        assert conv["conversation_type"] == "code"
+
+    def test_conversation_type_explicit_overrides(self):
+        conv = self.importer.parse_conversation(
+            self._base_session(conversation_type="analysis")
+        )
+        assert conv["conversation_type"] == "analysis"
+
+    def test_custom_fields_capture_workspace_and_files(self):
+        conv = self.importer.parse_conversation(self._base_session())
+        assert conv["custom_fields"]["workspace_path"] == "/home/dev/myproject"
+        assert conv["custom_fields"]["files_involved"] == ["src/main.py"]
+
+    def test_custom_fields_caller_overrides_merged(self):
+        """Caller-supplied custom_fields are merged on top of defaults."""
+        conv = self.importer.parse_conversation(
+            self._base_session(
+                custom_fields={"experiment": "beta", "workspace_path": "override"}
+            )
+        )
+        assert conv["custom_fields"]["experiment"] == "beta"
+        # Caller wins on key collision
+        assert conv["custom_fields"]["workspace_path"] == "override"

--- a/tests/test_importers/test_generic_importer.py
+++ b/tests/test_importers/test_generic_importer.py
@@ -12,7 +12,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+import pytest  # type: ignore[import-not-found]
 
 from src.importers.generic_importer import GenericImporter
 
@@ -55,7 +55,9 @@ class TestGenericImporter:
         test_file = self.storage_path / "test.json"
         test_file.write_text('{"test": "data"}')
 
-        with patch.object(self.importer, '_import_json_format', side_effect=Exception("Test error")):
+        with patch.object(
+            self.importer, "_import_json_format", side_effect=Exception("Test error")
+        ):
             result = self.importer.import_file(test_file)
 
         assert result.success is False
@@ -79,14 +81,14 @@ class TestGenericImporterJSONFormat:
             "title": "Test Conversation",
             "messages": [
                 {"role": "user", "content": "Hello"},
-                {"role": "assistant", "content": "Hi there!"}
-            ]
+                {"role": "assistant", "content": "Hi there!"},
+            ],
         }
 
         test_file = self.storage_path / "simple.json"
         test_file.write_text(json.dumps(json_data))
 
-        with patch.object(self.importer, '_save_conversation') as mock_save:
+        with patch.object(self.importer, "_save_conversation") as mock_save:
             result = self.importer.import_file(test_file)
 
         assert result.success is True
@@ -100,19 +102,19 @@ class TestGenericImporterJSONFormat:
             {
                 "title": "Conv 1",
                 "content": "First conversation",
-                "messages": [{"role": "user", "content": "Hello 1"}]
+                "messages": [{"role": "user", "content": "Hello 1"}],
             },
             {
                 "title": "Conv 2",
                 "content": "Second conversation",
-                "messages": [{"role": "user", "content": "Hello 2"}]
-            }
+                "messages": [{"role": "user", "content": "Hello 2"}],
+            },
         ]
 
         test_file = self.storage_path / "array.json"
         test_file.write_text(json.dumps(json_data))
 
-        with patch.object(self.importer, '_save_conversation') as mock_save:
+        with patch.object(self.importer, "_save_conversation") as mock_save:
             result = self.importer.import_file(test_file)
 
         assert result.success is True
@@ -153,8 +155,8 @@ class TestGenericImporterJSONFormat:
             "content": "A conversation",
             "messages": [
                 {"role": "user", "content": "Hello"},
-                {"role": "assistant", "content": "Hi"}
-            ]
+                {"role": "assistant", "content": "Hi"},
+            ],
         }
 
         conversations = self.importer._parse_json_object(data)
@@ -168,9 +170,9 @@ class TestGenericImporterJSONFormat:
         data = {
             "chats": [
                 {"title": "Chat 1", "content": "First", "messages": []},
-                {"title": "Chat 2", "content": "Second", "messages": []}
+                {"title": "Chat 2", "content": "Second", "messages": []},
             ],
-            "other_data": "ignored"
+            "other_data": "ignored",
         }
 
         conversations = self.importer._parse_json_object(data)
@@ -181,18 +183,17 @@ class TestGenericImporterJSONFormat:
 
     def test_parse_json_object_fallback(self):
         """Test parsing JSON object as fallback conversation."""
-        data = {
-            "random_field": "random_value",
-            "another_field": 123
-        }
+        data = {"random_field": "random_value", "another_field": 123}
 
         conversations = self.importer._parse_json_object(data)
 
         assert len(conversations) == 1
         assert "Generic Conversation" in conversations[0]["title"]
         # Content should contain the random field data in some form
-        assert "random_value" in conversations[0]["content"] or json.dumps(
-            data) in conversations[0]["content"]
+        assert (
+            "random_value" in conversations[0]["content"]
+            or json.dumps(data) in conversations[0]["content"]
+        )
 
 
 class TestGenericImporterTextFormat:
@@ -220,7 +221,7 @@ class TestGenericImporterTextFormat:
         test_file = self.storage_path / "dialogue.md"
         test_file.write_text(markdown_content)
 
-        with patch.object(self.importer, '_save_conversation') as mock_save:
+        with patch.object(self.importer, "_save_conversation") as mock_save:
             result = self.importer.import_file(test_file)
 
         assert result.success is True
@@ -248,7 +249,7 @@ Final response from assistant
         test_file = self.storage_path / "blocks.txt"
         test_file.write_text(text_content)
 
-        with patch.object(self.importer, '_save_conversation') as mock_save:
+        with patch.object(self.importer, "_save_conversation") as mock_save:
             result = self.importer.import_file(test_file)
 
         assert result.success is True
@@ -263,7 +264,7 @@ Final response from assistant
         test_file = self.storage_path / "plain.txt"
         test_file.write_text(plain_text)
 
-        with patch.object(self.importer, '_save_conversation') as mock_save:
+        with patch.object(self.importer, "_save_conversation") as mock_save:
             result = self.importer.import_file(test_file)
 
         assert result.success is True
@@ -276,7 +277,9 @@ Final response from assistant
         test_file = self.storage_path / "test.txt"
         test_file.write_text("Test content")
 
-        with patch.object(self.importer, '_parse_text_content', side_effect=Exception("Parse error")):
+        with patch.object(
+            self.importer, "_parse_text_content", side_effect=Exception("Parse error")
+        ):
             result = self.importer.import_file(test_file)
 
         assert result.success is False
@@ -300,15 +303,15 @@ class TestGenericImporterCSVFormat:
             ["speaker", "message", "timestamp"],
             ["user", "Hello there", "2025-01-15 10:00:00"],
             ["assistant", "Hi! How can I help?", "2025-01-15 10:01:00"],
-            ["user", "I need help with code", "2025-01-15 10:02:00"]
+            ["user", "I need help with code", "2025-01-15 10:02:00"],
         ]
 
         test_file = self.storage_path / "conversation.csv"
-        with open(test_file, 'w', newline='') as f:
+        with open(test_file, "w", newline="") as f:
             writer = csv.writer(f)
             writer.writerows(csv_data)
 
-        with patch.object(self.importer, '_save_conversation') as mock_save:
+        with patch.object(self.importer, "_save_conversation") as mock_save:
             result = self.importer.import_file(test_file)
 
         assert result.success is True
@@ -319,8 +322,8 @@ class TestGenericImporterCSVFormat:
     def test_import_csv_empty_file(self):
         """Test importing empty CSV file."""
         test_file = self.storage_path / "empty.csv"
-        with open(test_file, 'w', newline='') as f:
-            pass  # Create empty file
+        # Touch an empty file (no contents needed for the empty-CSV test).
+        test_file.write_text("")
 
         result = self.importer.import_file(test_file)
 
@@ -331,9 +334,9 @@ class TestGenericImporterCSVFormat:
     def test_import_csv_exception(self):
         """Test CSV import with exception."""
         test_file = self.storage_path / "test.csv"
-        test_file.write_text("invalid,csv,format\nwith,unbalanced,quotes\"")
+        test_file.write_text('invalid,csv,format\nwith,unbalanced,quotes"')
 
-        with patch('csv.DictReader', side_effect=Exception("CSV error")):
+        with patch("csv.DictReader", side_effect=Exception("CSV error")):
             result = self.importer.import_file(test_file)
 
         assert result.success is False
@@ -363,7 +366,7 @@ class TestGenericImporterXMLFormat:
         test_file = self.storage_path / "conversation.xml"
         test_file.write_text(xml_content)
 
-        with patch.object(self.importer, '_save_conversation') as mock_save:
+        with patch.object(self.importer, "_save_conversation") as mock_save:
             result = self.importer.import_file(test_file)
 
         assert result.success is True
@@ -390,7 +393,7 @@ class TestGenericImporterXMLFormat:
         test_file = self.storage_path / "test.xml"
         test_file.write_text("<conversation></conversation>")
 
-        with patch('xml.etree.ElementTree.parse', side_effect=Exception("XML error")):
+        with patch("xml.etree.ElementTree.parse", side_effect=Exception("XML error")):
             result = self.importer.import_file(test_file)
 
         assert result.success is False
@@ -422,7 +425,7 @@ class TestGenericImporterParsingMethods:
         data = {
             "title": "Test Conv",
             "content": "Test content",
-            "messages": [{"role": "user", "content": "Hello"}]
+            "messages": [{"role": "user", "content": "Hello"}],
         }
 
         result = self.importer.parse_conversation(data)
@@ -435,7 +438,7 @@ class TestGenericImporterParsingMethods:
         """Test parsing list as conversation."""
         data = [
             {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi"}
+            {"role": "assistant", "content": "Hi"},
         ]
 
         result = self.importer.parse_conversation(data)
@@ -519,8 +522,7 @@ class TestGenericImporterParsingMethods:
         assert self.importer._extract_field(data, ["name", "title"]) == "Test"
 
         # No match
-        assert self.importer._extract_field(
-            data, ["missing", "absent"]) is None
+        assert self.importer._extract_field(data, ["missing", "absent"]) is None
 
     def test_find_column(self):
         """Test column name matching."""
@@ -555,11 +557,10 @@ class TestGenericImporterHelperMethods:
             "This is continued text",
             "**Assistant**: Hi! How can I help?",
             "More assistant text",
-            "**Human**: Thanks!"
+            "**Human**: Thanks!",
         ]
 
-        messages, content_parts = self.importer._extract_dialogue_messages(
-            lines)
+        messages, content_parts = self.importer._extract_dialogue_messages(lines)
 
         assert len(messages) == 3
         assert messages[0]["role"] == "user"
@@ -584,8 +585,8 @@ class TestGenericImporterHelperMethods:
     def test_start_new_message(self):
         """Test starting new message from regex match."""
         import re
-        match = re.match(r'(\*\*)?(\w+)(\*\*)?\s*:\s*(.*)',
-                         "**Human**: Hello there")
+
+        match = re.match(r"(\*\*)?(\w+)(\*\*)?\s*:\s*(.*)", "**Human**: Hello there")
 
         speaker, message = self.importer._start_new_message(match)
 
@@ -596,7 +597,8 @@ class TestGenericImporterHelperMethods:
         """Test continuing current message."""
         current_message = ["Hello"]
         result = self.importer._continue_current_message(
-            "Human", current_message, "there")
+            "Human", current_message, "there"
+        )
 
         assert result == ["Hello", "there"]
 
@@ -609,10 +611,8 @@ class TestGenericImporterHelperMethods:
 
         random_elem = ET.Element("data")
 
-        assert self.importer._xml_element_looks_like_conversation(
-            conv_elem) is True
-        assert self.importer._xml_element_looks_like_conversation(
-            random_elem) is False
+        assert self.importer._xml_element_looks_like_conversation(conv_elem) is True
+        assert self.importer._xml_element_looks_like_conversation(random_elem) is False
 
 
 class TestGenericImporterSaveConversation:
@@ -631,7 +631,7 @@ class TestGenericImporterSaveConversation:
             "date": "2025-01-15T12:00:00",
             "title": "Test Generic Conversation",
             "content": "Test content",
-            "platform": "generic"
+            "platform": "generic",
         }
 
         file_path = self.importer._save_conversation(conversation)
@@ -643,7 +643,7 @@ class TestGenericImporterSaveConversation:
         assert file_path.name.endswith(".json")
 
         # Verify content
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             saved_data = json.load(f)
 
         assert saved_data["id"] == conversation["id"]
@@ -660,7 +660,7 @@ class TestGenericImporterSaveConversation:
                 "platform": "generic",
                 "messages": [],
                 "topics": [],
-                "created_at": "2025-01-15T12:00:00"
+                "created_at": "2025-01-15T12:00:00",
             },
             {
                 "id": "conv2",
@@ -670,13 +670,14 @@ class TestGenericImporterSaveConversation:
                 "platform": "generic",
                 "messages": [],
                 "topics": [],
-                "created_at": "2025-01-15T12:00:00"
-            }
+                "created_at": "2025-01-15T12:00:00",
+            },
         ]
 
         file_path = self.storage_path / "test.json"
         result = self.importer._save_conversations(
-            conversations, file_path, "test_format")
+            conversations, file_path, "test_format"
+        )
 
         assert result.success is True
         assert result.conversations_imported == 2
@@ -694,17 +695,18 @@ class TestGenericImporterSaveConversation:
                 "platform": "generic",
                 "messages": [],
                 "topics": [],
-                "created_at": "2025-01-15T12:00:00"
+                "created_at": "2025-01-15T12:00:00",
             },
             {
                 "id": "invalid_conv"
                 # Missing required fields
-            }
+            },
         ]
 
         file_path = self.storage_path / "test.json"
         result = self.importer._save_conversations(
-            conversations, file_path, "test_format")
+            conversations, file_path, "test_format"
+        )
 
         assert result.success is True  # At least one succeeded
         assert result.conversations_imported == 1
@@ -732,10 +734,12 @@ class TestGenericImporterIntegration:
                         {"role": "user", "content": "Import this conversation"},
                         {"role": "assistant", "content": "I'll import this for you"},
                         {"role": "user", "content": "Make sure it works properly"},
-                        {"role": "assistant",
-                            "content": "The import is working correctly"}
+                        {
+                            "role": "assistant",
+                            "content": "The import is working correctly",
+                        },
                     ],
-                    "metadata": {"test": "e2e_integration"}
+                    "metadata": {"test": "e2e_integration"},
                 }
             ]
         }
@@ -757,12 +761,13 @@ class TestGenericImporterIntegration:
         assert result.metadata["format_type"] == "generic_json"
 
         # Verify conversation file was created (excludes source file)
-        conversation_files = [f for f in self.storage_path.rglob(
-            "*.json") if f.name != "e2e_test.json"]
+        conversation_files = [
+            f for f in self.storage_path.rglob("*.json") if f.name != "e2e_test.json"
+        ]
         assert len(conversation_files) == 1
 
         # Verify conversation content
-        with open(conversation_files[0], 'r') as f:
+        with open(conversation_files[0], "r") as f:
             saved_conversation = json.load(f)
 
         assert saved_conversation["platform"] == "generic"
@@ -816,12 +821,15 @@ For most applications, I'd recommend starting with SQLite FTS as it provides exc
         assert result.metadata["format_type"] == "generic_text"
 
         # Verify conversation file was created (excludes source file)
-        conversation_files = [f for f in self.storage_path.rglob(
-            "*.json") if f.name != "conversation_log.md"]
+        conversation_files = [
+            f
+            for f in self.storage_path.rglob("*.json")
+            if f.name != "conversation_log.md"
+        ]
         assert len(conversation_files) == 1
 
         # Verify conversation content
-        with open(conversation_files[0], 'r') as f:
+        with open(conversation_files[0], "r") as f:
             saved_conversation = json.load(f)
 
         assert saved_conversation["platform"] == "generic"
@@ -836,9 +844,101 @@ For most applications, I'd recommend starting with SQLite FTS as it provides exc
         test_file.write_text("Some content")
 
         # Should fall back to text parsing
-        with patch.object(self.importer, '_save_conversation') as mock_save:
+        with patch.object(self.importer, "_save_conversation") as mock_save:
             result = self.importer.import_file(test_file)
 
         assert result.success is True
         assert result.conversations_imported == 1
         mock_save.assert_called_once()
+
+
+class TestGenericUniversalMetadata:
+    """Generic importer pass-through for universal metadata (5.1.3-5.2.4)."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage_path = Path(self.temp_dir)
+        self.importer = GenericImporter(self.storage_path)
+
+    def _base_dict(self, **overrides):
+        data = {
+            "title": "Generic Conv",
+            "content": "some content",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+        }
+        data.update(overrides)
+        return data
+
+    def test_session_id_from_session_id_key(self):
+        conv = self.importer._parse_dict_as_conversation(
+            self._base_dict(session_id="gen-sess-1")
+        )
+        assert conv["session_id"] == "gen-sess-1"
+
+    def test_session_id_from_conversation_id_alias(self):
+        conv = self.importer._parse_dict_as_conversation(
+            self._base_dict(conversation_id="gen-conv-2")
+        )
+        assert conv["session_id"] == "gen-conv-2"
+
+    def test_session_id_default_none(self):
+        conv = self.importer._parse_dict_as_conversation(self._base_dict())
+        assert conv["session_id"] is None
+
+    def test_user_id_from_owner_id_alias(self):
+        """user_id pulls from common synonyms (user_id/account_id/owner_id)."""
+        conv = self.importer._parse_dict_as_conversation(
+            self._base_dict(owner_id="owner-9")
+        )
+        assert conv["user_id"] == "owner-9"
+
+    def test_tags_from_labels_alias(self):
+        """tags pulls from 'tags' or 'labels'."""
+        conv = self.importer._parse_dict_as_conversation(
+            self._base_dict(labels=["alpha", "beta"])
+        )
+        assert "alpha" in conv["tags"]
+        assert "beta" in conv["tags"]
+
+    def test_tags_default_empty(self):
+        conv = self.importer._parse_dict_as_conversation(self._base_dict())
+        assert conv["tags"] == []
+
+    def test_conversation_type_from_type_alias(self):
+        """conversation_type pulls from 'conversation_type'/'type'/'category'."""
+        conv = self.importer._parse_dict_as_conversation(
+            self._base_dict(type="support")
+        )
+        assert conv["conversation_type"] == "support"
+
+    def test_conversation_type_default_none(self):
+        conv = self.importer._parse_dict_as_conversation(self._base_dict())
+        assert conv["conversation_type"] is None
+
+    def test_custom_fields_from_extras_alias(self):
+        """custom_fields pulls from 'custom_fields'/'extra'/'extras'."""
+        conv = self.importer._parse_dict_as_conversation(
+            self._base_dict(extras={"k": "v"})
+        )
+        assert conv["custom_fields"] == {"k": "v"}
+
+    def test_custom_fields_default_empty(self):
+        conv = self.importer._parse_dict_as_conversation(self._base_dict())
+        assert conv["custom_fields"] == {}
+
+    def test_non_string_session_id_ignored(self):
+        """Non-string session_id values default to None (type safety)."""
+        conv = self.importer._parse_dict_as_conversation(
+            self._base_dict(session_id=12345)
+        )
+        assert conv["session_id"] is None
+
+    def test_non_list_tags_ignored(self):
+        """Non-list tags values default to empty list."""
+        conv = self.importer._parse_dict_as_conversation(
+            self._base_dict(tags="not-a-list")
+        )
+        assert conv["tags"] == []


### PR DESCRIPTION
## Summary

Implements todos.md items 5.1.3, 5.1.4, 5.2.1, 5.2.3, 5.2.4 by adding five optional metadata fields to BaseImporter.create_universal_conversation and populating them from each concrete importer's source data.

| Field | Default | Purpose |
|---|---|---|
| session_id | None | Group related conversations within a session |
| user_id | None | Reserved for multi-user support |
| tags | [] | Platform-specific categorisation |
| conversation_type | None | Free-form classification (chat / code / analysis) |
| custom_fields | {} | Open extensibility bucket |

All fields are optional with safe defaults — existing callers and previously-stored conversations remain valid; _validate_conversation is unchanged.

## Per-importer extraction

| Importer | session_id | user_id | tags | conversation_type | custom_fields |
|---|---|---|---|---|---|
| ChatGPT | conversation_id (or id) | injected only | starred / archived / gizmo | code-fence heuristic | default_model_slug, gizmo_id, memory_scope |
| Cursor | native session_id | injected only | workspace, has-file-changes | defaults to code | workspace_path, files_involved |
| Claude | session_id / conversation_id / id | user_id / account_id | variant tag | code-fence heuristic | project_id, organization_id, workspace_id |
| Generic | recognises conversation_id synonym | recognises owner_id, account_id | reads tags or labels | reads type / category | reads extra / extras |

## Other changes

* Adds a minimal [tool.mypy] block to pyproject.toml (explicit_package_bases, namespace_packages, ignore_missing_imports) so the pre-commit mypy hook stops failing with 'Source file found twice' when src/ and tests/ files are staged together. This is a long-standing repo-wide hook config bug unrelated to these changes — surfaced only because this PR touches both buckets.
* Adds # type: ignore[import-not-found] to the import pytest lines in the affected test modules (matches the established convention used in PR #112's tests/test_bulk_import_enhanced.py).

## Tests

* +52 new tests across five importer test modules.
* All defaults / explicit values / mutation isolation / source-data extraction paths covered.
* Full suite: 573 passed, 1 skipped (was 521 before).

## Test plan

- [x] pytest tests/test_importers/ — all 210 tests pass
- [x] Full suite pytest tests/ — all 573 tests pass
- [x] Pre-commit hooks (ruff, ruff-format, mypy, bandit, file checks) all pass
- [x] Coverage on changed importer code: 78–90% per file; every newly-added line is exercised — uncovered lines are pre-existing __main__ / error-fallback branches.

## Out of scope (future PRs in section 5.3)

- Search-by-tag / search-by-session_id (todos 5.3.x)
- project_context field (5.2.2 — needs deeper design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)