### PR TITLE
feat(exporters): add export module for ChatGPT and universal JSON

### DIFF
--- a/src/exporters/__init__.py
+++ b/src/exporters/__init__.py
@@ -1,0 +1,19 @@
+"""
+Universal Memory MCP Exporters Package.
+
+Provides format-specific exporters that read conversations stored in
+universal/legacy internal format and write them out in platform-specific
+or universal JSON formats.
+"""
+
+from .base_exporter import BaseExporter, ExportResult, Filters
+from .chatgpt_exporter import ChatgptExporter
+from .json_exporter import JsonExporter
+
+__all__ = [
+    "BaseExporter",
+    "ExportResult",
+    "Filters",
+    "JsonExporter",
+    "ChatgptExporter",
+]

--- a/src/exporters/base_exporter.py
+++ b/src/exporters/base_exporter.py
@@ -18,7 +18,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/exporters/base_exporter.py
+++ b/src/exporters/base_exporter.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""
+Base exporter class for Universal Memory MCP.
+
+Defines the interface and common functionality for all platform exporters.
+Exporters are the inverse of importers: they read conversations from local
+storage (in universal or legacy internal format) and write them out to a
+platform-specific or universal JSON format.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+# Required fields on the universal conversation format.
+# Mirrors create_universal_conversation in src/importers/base_importer.py.
+UNIVERSAL_REQUIRED_FIELDS: tuple[str, ...] = (
+    "id",
+    "platform",
+    "title",
+    "content",
+    "messages",
+    "date",
+)
+
+
+@dataclass
+class ExportResult:
+    """Result of an export operation."""
+
+    success: bool
+    conversations_exported: int
+    conversations_failed: int
+    errors: List[str]
+    output_path: Optional[str]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def total_processed(self) -> int:
+        return self.conversations_exported + self.conversations_failed
+
+    @property
+    def success_rate(self) -> float:
+        if self.total_processed == 0:
+            return 0.0
+        return self.conversations_exported / self.total_processed
+
+
+@dataclass
+class Filters:
+    """Filtering options for exports.
+
+    Attributes:
+        date_from: Only include conversations on or after this datetime.
+        date_to: Only include conversations on or before this datetime.
+        platforms: Only include conversations matching one of these platform
+            names (case-insensitive). ``None`` means no platform filter. Use
+            ``"unknown"`` to match conversations with no platform field
+            (legacy format).
+        limit: Maximum number of conversations to export. ``None`` for
+            unlimited.
+    """
+
+    date_from: Optional[datetime] = None
+    date_to: Optional[datetime] = None
+    platforms: Optional[List[str]] = None
+    limit: Optional[int] = None
+
+    def is_empty(self) -> bool:
+        """Return True if no filters are configured."""
+        return (
+            self.date_from is None
+            and self.date_to is None
+            and not self.platforms
+            and self.limit is None
+        )
+
+
+class BaseExporter(ABC):
+    """Base class for all conversation exporters.
+
+    Subclasses implement :meth:`export` (writes the output file) and
+    :meth:`validate` (verifies the output file).
+    """
+
+    def __init__(self, source_storage_path: Path):
+        """Initialize the exporter.
+
+        Args:
+            source_storage_path: Root storage path that contains the
+                ``data/conversations`` (or legacy ``conversations``)
+                directory tree with ``index.json`` and per-conversation JSON
+                files. Equivalent to ``ConversationMemoryServer``'s
+                ``storage_path``.
+        """
+        self.source_storage_path = Path(source_storage_path).expanduser()
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+    # ------------------------------------------------------------------
+    # Abstract interface
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def export(
+        self,
+        output_path: Path,
+        filters: Optional[Filters] = None,
+    ) -> ExportResult:
+        """Export conversations to ``output_path``.
+
+        Args:
+            output_path: Destination file path. Parent directory must be
+                writable; it will be created if it does not exist.
+            filters: Optional filtering options. ``None`` means export all
+                conversations.
+
+        Returns:
+            ExportResult with statistics and any errors encountered.
+        """
+
+    @abstractmethod
+    def validate(self, output_path: Path) -> Dict[str, Any]:
+        """Validate a previously exported file.
+
+        Returns:
+            ``{"valid": bool, "errors": list[str], "warnings": list[str],
+            "conversation_count": int}``.
+        """
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+
+    def load_conversations(self) -> List[Dict[str, Any]]:
+        """Load all on-disk conversations and normalize to universal format.
+
+        Returns:
+            List of conversations in universal internal format. Conversations
+            stored in the legacy simple format (id/title/content/date/topics/
+            created_at) are upgraded with sensible defaults so downstream
+            exporters always see a uniform shape.
+        """
+        conversations_dir = self._resolve_conversations_dir()
+        index_file = conversations_dir / "index.json"
+
+        if not index_file.exists():
+            self.logger.warning("No index.json found at %s", index_file)
+            return []
+
+        try:
+            with open(index_file, "r", encoding="utf-8") as f:
+                index_data = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            self.logger.error("Failed to read index.json: %s", exc)
+            return []
+
+        loaded: List[Dict[str, Any]] = []
+        for conv_info in index_data.get("conversations", []):
+            rel_path = conv_info.get("file_path")
+            if not rel_path:
+                continue
+            file_path = self.source_storage_path / rel_path
+            if not file_path.exists():
+                self.logger.debug("Skipping missing file: %s", file_path)
+                continue
+            try:
+                with open(file_path, "r", encoding="utf-8") as f:
+                    conv = json.load(f)
+            except (OSError, json.JSONDecodeError) as exc:
+                self.logger.warning("Failed to load %s: %s", file_path, exc)
+                continue
+            loaded.append(self._normalize_to_universal(conv))
+
+        return loaded
+
+    def apply_filters(
+        self,
+        conversations: Iterable[Dict[str, Any]],
+        filters: Optional[Filters],
+    ) -> List[Dict[str, Any]]:
+        """Apply filtering options to a list of conversations.
+
+        Args:
+            conversations: Conversations in universal internal format.
+            filters: Filtering options. May be ``None`` (no-op).
+
+        Returns:
+            Filtered list. Order is preserved.
+        """
+        items = list(conversations)
+        if filters is None or filters.is_empty():
+            return items
+
+        normalized_platforms: Optional[List[str]] = None
+        if filters.platforms:
+            normalized_platforms = [p.lower() for p in filters.platforms]
+
+        result: List[Dict[str, Any]] = []
+        for conv in items:
+            if not self._matches_date_range(conv, filters.date_from, filters.date_to):
+                continue
+            if normalized_platforms is not None and not self._matches_platform(
+                conv, normalized_platforms
+            ):
+                continue
+            result.append(conv)
+            if filters.limit is not None and len(result) >= filters.limit:
+                break
+
+        return result
+
+    def write_json(
+        self,
+        output_path: Path,
+        payload: Any,
+    ) -> None:
+        """Write a JSON payload to ``output_path`` atomically-ish.
+
+        Creates parent directories as needed. Raises ``OSError`` on failure.
+        """
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_conversations_dir(self) -> Path:
+        """Locate the conversations directory (data/ or legacy layout)."""
+        data_layout = self.source_storage_path / "data" / "conversations"
+        if data_layout.exists():
+            return data_layout
+        legacy_layout = self.source_storage_path / "conversations"
+        if legacy_layout.exists():
+            return legacy_layout
+        # Default to new layout for empty installations.
+        return data_layout
+
+    @staticmethod
+    def _normalize_to_universal(
+        conversation: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Upgrade a legacy conversation into universal format if needed.
+
+        Universal-format conversations are returned untouched (other than
+        ensuring required fields exist). Legacy conversations gain default
+        values for ``platform``, ``messages``, ``model``, ``last_updated``,
+        ``session_context``, and ``import_metadata``.
+        """
+        conv = dict(conversation)  # shallow copy; do not mutate caller
+
+        conv.setdefault("platform", "unknown")
+        conv.setdefault("model", "unknown")
+        conv.setdefault("messages", [])
+        conv.setdefault("topics", [])
+        conv.setdefault("session_context", {})
+        conv.setdefault("import_metadata", {})
+        conv.setdefault("last_updated", conv.get("date", ""))
+        conv.setdefault("created_at", conv.get("date", ""))
+
+        # If the conversation has content but no messages, synthesize a
+        # single combined message so downstream consumers always see at
+        # least one entry.
+        if not conv["messages"] and conv.get("content"):
+            conv["messages"] = [
+                {
+                    "id": f"msg_{conv.get('id', 'legacy')}",
+                    "role": "assistant",
+                    "content": conv["content"],
+                    "timestamp": conv.get("date", ""),
+                    "metadata": {"synthetic": True, "source": "legacy_upgrade"},
+                }
+            ]
+
+        return conv
+
+    @staticmethod
+    def _parse_iso(date_str: str) -> Optional[datetime]:
+        """Parse an ISO date string, returning None on failure."""
+        if not date_str:
+            return None
+        try:
+            return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return None
+
+    @classmethod
+    def _matches_date_range(
+        cls,
+        conversation: Dict[str, Any],
+        date_from: Optional[datetime],
+        date_to: Optional[datetime],
+    ) -> bool:
+        """Return True if conversation's date is inside [from, to]."""
+        if date_from is None and date_to is None:
+            return True
+
+        conv_date = cls._parse_iso(conversation.get("date", ""))
+        if conv_date is None:
+            # Conversations with unparseable dates are excluded when
+            # any date filter is active.
+            return False
+
+        # Strip timezone for comparison if needed (compare naive-vs-naive)
+        if date_from is not None:
+            df = cls._strip_tz_for_compare(date_from, conv_date)
+            cd = cls._strip_tz_for_compare(conv_date, date_from)
+            if cd < df:
+                return False
+        if date_to is not None:
+            dt = cls._strip_tz_for_compare(date_to, conv_date)
+            cd = cls._strip_tz_for_compare(conv_date, date_to)
+            if cd > dt:
+                return False
+        return True
+
+    @staticmethod
+    def _strip_tz_for_compare(target: datetime, reference: datetime) -> datetime:
+        """Drop tzinfo from ``target`` if ``reference`` is naive."""
+        if reference.tzinfo is None and target.tzinfo is not None:
+            return target.replace(tzinfo=None)
+        return target
+
+    @staticmethod
+    def _matches_platform(conversation: Dict[str, Any], platforms: List[str]) -> bool:
+        """Return True if conversation's platform matches one of ``platforms``."""
+        platform = str(conversation.get("platform", "unknown")).lower()
+        return platform in platforms

--- a/src/exporters/chatgpt_exporter.py
+++ b/src/exporters/chatgpt_exporter.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+ChatGPT-format exporter for Universal Memory MCP.
+
+Converts conversations stored in universal internal format back into the
+ChatGPT (OpenAI) export shape used by ``src/schemas/chatgpt_schema.py``.
+
+Notes
+-----
+The ChatGPT export format is a JSON array of conversation objects whose
+messages are stored under a ``mapping`` dict keyed by node id. We
+reconstruct a linear parent->child chain from the universal ``messages``
+list. Round-tripping through the universal format is lossy:
+
+* Tree branching present in real ChatGPT exports is collapsed into a
+  single linear chain.
+* Per-message metadata such as model slug, request id, and tool call
+  details is not stored in our universal format and therefore cannot be
+  reconstructed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .base_exporter import BaseExporter, ExportResult, Filters
+
+
+def _validate_chatgpt_export(data):
+    """Lazy proxy to ``schemas.chatgpt_schema.validate_chatgpt_export``.
+
+    Resolving the import inside the call (rather than at module load) keeps
+    static analysis from getting confused about whether the schemas module
+    is reached via ``src.schemas`` or just ``schemas`` (depending on how
+    the surrounding package was imported).
+    """
+    import importlib
+
+    for mod_name in ("schemas.chatgpt_schema", "src.schemas.chatgpt_schema"):
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError:  # pragma: no cover - import wiring fallback
+            continue
+        return mod.validate_chatgpt_export(data)
+    raise ImportError(  # pragma: no cover - both import paths failed
+        "Could not locate schemas.chatgpt_schema"
+    )
+
+
+logger = logging.getLogger(__name__)
+
+
+# ChatGPT supports these author roles in its export schema.
+_VALID_CHATGPT_ROLES = ("user", "assistant", "system")
+
+
+class ChatgptExporter(BaseExporter):
+    """Exports conversations to ChatGPT export-compatible JSON."""
+
+    def export(
+        self,
+        output_path: Path,
+        filters: Optional[Filters] = None,
+    ) -> ExportResult:
+        """Write conversations as a ChatGPT-format JSON array."""
+        output_path = Path(output_path)
+        try:
+            conversations = self.load_conversations()
+        except Exception as exc:  # noqa: BLE001 - defensive boundary
+            return ExportResult(
+                success=False,
+                conversations_exported=0,
+                conversations_failed=0,
+                errors=[f"Failed to load source conversations: {exc}"],
+                output_path=None,
+                metadata={"format": "chatgpt"},
+            )
+
+        filtered = self.apply_filters(conversations, filters)
+
+        chatgpt_array: List[Dict[str, Any]] = []
+        errors: List[str] = []
+        failed = 0
+        for conv in filtered:
+            try:
+                chatgpt_array.append(self._to_chatgpt(conv))
+            except Exception as exc:  # noqa: BLE001 - per-conv resilience
+                failed += 1
+                errors.append(f"Failed to convert {conv.get('id', '<unknown>')}: {exc}")
+
+        try:
+            self.write_json(output_path, chatgpt_array)
+        except OSError as exc:
+            return ExportResult(
+                success=False,
+                conversations_exported=0,
+                conversations_failed=len(filtered),
+                errors=[f"Failed to write {output_path}: {exc}"],
+                output_path=None,
+                metadata={"format": "chatgpt"},
+            )
+
+        self.logger.info(
+            "Exported %d conversations to %s in ChatGPT format",
+            len(chatgpt_array),
+            output_path,
+        )
+        return ExportResult(
+            success=len(chatgpt_array) > 0 or len(filtered) == 0,
+            conversations_exported=len(chatgpt_array),
+            conversations_failed=failed,
+            errors=errors,
+            output_path=str(output_path),
+            metadata={
+                "format": "chatgpt",
+                "source_total": len(conversations),
+                "filtered_total": len(filtered),
+            },
+        )
+
+    def validate(self, output_path: Path) -> Dict[str, Any]:
+        """Validate the exported file against the ChatGPT JSON schema."""
+        output_path = Path(output_path)
+        if not output_path.exists():
+            return {
+                "valid": False,
+                "errors": [f"Output file not found: {output_path}"],
+                "warnings": [],
+                "conversation_count": 0,
+            }
+        try:
+            with open(output_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            return {
+                "valid": False,
+                "errors": [f"Failed to read/parse {output_path}: {exc}"],
+                "warnings": [],
+                "conversation_count": 0,
+            }
+
+        return _validate_chatgpt_export(data)
+
+    # ------------------------------------------------------------------
+    # Conversion helpers
+    # ------------------------------------------------------------------
+
+    def _to_chatgpt(self, conv: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert one universal conversation into ChatGPT export shape."""
+        conv_id = conv.get("platform_id") or conv.get("id") or str(uuid.uuid4())
+        title = conv.get("title") or "Untitled Conversation"
+        create_time = self._iso_to_epoch(conv.get("date"))
+        update_time = self._iso_to_epoch(conv.get("last_updated") or conv.get("date"))
+
+        mapping, current_node = self._build_mapping(conv)
+
+        return {
+            "title": title,
+            "create_time": create_time,
+            "update_time": update_time,
+            "conversation_id": conv_id,
+            "id": conv_id,
+            "mapping": mapping,
+            "moderation_results": [],
+            "current_node": current_node,
+            "default_model_slug": conv.get("model") or "unknown",
+        }
+
+    def _build_mapping(
+        self, conv: Dict[str, Any]
+    ) -> Tuple[Dict[str, Any], Optional[str]]:
+        """Build a ChatGPT-style ``mapping`` dict from universal messages.
+
+        Returns:
+            (mapping, current_node_id).
+        """
+        messages = conv.get("messages") or []
+
+        # The schema requires a non-empty mapping with at least one node.
+        # Insert a synthetic root node so we always have something to anchor.
+        root_id = f"root_{conv.get('id', uuid.uuid4().hex[:8])}"
+        mapping: Dict[str, Any] = {
+            root_id: {
+                "id": root_id,
+                "message": None,
+                "parent": None,
+                "children": [],
+            }
+        }
+
+        previous_id: str = root_id
+        last_real_id: Optional[str] = None
+        for idx, msg in enumerate(messages):
+            node_id = msg.get("id") or f"node_{idx}_{uuid.uuid4().hex[:8]}"
+            # Avoid collisions with the root node id.
+            if node_id == root_id:
+                node_id = f"{node_id}_msg"
+            role = (msg.get("role") or "assistant").lower()
+            if role not in _VALID_CHATGPT_ROLES:
+                # ChatGPT schema only accepts user/assistant/system. Map
+                # everything else to "assistant" to stay valid.
+                role = "assistant"
+            content_text = msg.get("content") or ""
+            timestamp = msg.get("timestamp") or conv.get("date") or ""
+            create_time = self._iso_to_epoch(timestamp)
+
+            chatgpt_message: Dict[str, Any] = {
+                "id": node_id,
+                "author": {
+                    "role": role,
+                    "name": None,
+                    "metadata": {},
+                },
+                "content": {
+                    "content_type": "text",
+                    "parts": [content_text if content_text else ""],
+                },
+                "create_time": create_time,
+                "update_time": create_time,
+                "status": "finished_successfully",
+                "end_turn": role == "assistant",
+                "weight": 1.0,
+                "metadata": dict(msg.get("metadata") or {}),
+                "recipient": "all",
+                "channel": None,
+            }
+
+            mapping[node_id] = {
+                "id": node_id,
+                "message": chatgpt_message,
+                "parent": previous_id,
+                "children": [],
+            }
+            mapping[previous_id]["children"].append(node_id)
+            previous_id = node_id
+            last_real_id = node_id
+
+        return mapping, last_real_id or root_id
+
+    @staticmethod
+    def _iso_to_epoch(date_value: Any) -> float:
+        """Convert an ISO datetime string (or epoch number) to epoch seconds.
+
+        Returns 0.0 for empty / unparseable input.
+        """
+        if date_value is None or date_value == "":
+            return 0.0
+        if isinstance(date_value, (int, float)):
+            return float(date_value)
+        try:
+            text = str(date_value).replace("Z", "+00:00")
+            return datetime.fromisoformat(text).timestamp()
+        except (ValueError, TypeError, OSError):
+            return 0.0

--- a/src/exporters/json_exporter.py
+++ b/src/exporters/json_exporter.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+JSON exporter for Universal Memory MCP.
+
+Exports stored conversations to a single JSON file in the universal
+internal format. This is essentially an "identity" export -- it preserves
+the structure used by the importer pipeline -- with optional filtering.
+
+Output shape:
+
+.. code-block:: json
+
+    {
+        "format": "universal",
+        "format_version": "1.0",
+        "exported_at": "2026-04-18T12:34:56",
+        "source_storage_path": "/home/user/claude-memory",
+        "conversation_count": 42,
+        "filters_applied": {...},
+        "conversations": [ {...universal conversation...}, ... ]
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .base_exporter import (
+    UNIVERSAL_REQUIRED_FIELDS,
+    BaseExporter,
+    ExportResult,
+    Filters,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# Bumped whenever the export envelope structure changes.
+JSON_EXPORT_FORMAT_VERSION = "1.0"
+
+
+class JsonExporter(BaseExporter):
+    """Exports conversations to universal-format JSON."""
+
+    def export(
+        self,
+        output_path: Path,
+        filters: Optional[Filters] = None,
+    ) -> ExportResult:
+        """Write all (filtered) conversations to ``output_path`` as JSON."""
+        output_path = Path(output_path)
+        try:
+            conversations = self.load_conversations()
+        except Exception as exc:  # noqa: BLE001 - defensive boundary
+            return ExportResult(
+                success=False,
+                conversations_exported=0,
+                conversations_failed=0,
+                errors=[f"Failed to load source conversations: {exc}"],
+                output_path=None,
+                metadata={"format": "universal"},
+            )
+
+        filtered = self.apply_filters(conversations, filters)
+
+        envelope = self._build_envelope(filtered, filters)
+
+        try:
+            self.write_json(output_path, envelope)
+        except OSError as exc:
+            return ExportResult(
+                success=False,
+                conversations_exported=0,
+                conversations_failed=len(filtered),
+                errors=[f"Failed to write {output_path}: {exc}"],
+                output_path=None,
+                metadata={"format": "universal"},
+            )
+
+        self.logger.info("Exported %d conversations to %s", len(filtered), output_path)
+        return ExportResult(
+            success=True,
+            conversations_exported=len(filtered),
+            conversations_failed=0,
+            errors=[],
+            output_path=str(output_path),
+            metadata={
+                "format": "universal",
+                "format_version": JSON_EXPORT_FORMAT_VERSION,
+                "source_total": len(conversations),
+            },
+        )
+
+    def validate(self, output_path: Path) -> Dict[str, Any]:
+        """Re-parse exported file and verify universal-format compliance."""
+        output_path = Path(output_path)
+        if not output_path.exists():
+            return {
+                "valid": False,
+                "errors": [f"Output file not found: {output_path}"],
+                "warnings": [],
+                "conversation_count": 0,
+            }
+
+        try:
+            with open(output_path, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            return {
+                "valid": False,
+                "errors": [f"Failed to read/parse {output_path}: {exc}"],
+                "warnings": [],
+                "conversation_count": 0,
+            }
+
+        errors: List[str] = []
+        warnings: List[str] = []
+
+        if not isinstance(payload, dict):
+            return {
+                "valid": False,
+                "errors": ["Top-level payload must be a JSON object"],
+                "warnings": [],
+                "conversation_count": 0,
+            }
+
+        if payload.get("format") != "universal":
+            warnings.append(
+                f"Unexpected format field: {payload.get('format')!r} "
+                "(expected 'universal')"
+            )
+
+        conversations = payload.get("conversations")
+        if not isinstance(conversations, list):
+            errors.append("'conversations' must be a list")
+            return {
+                "valid": False,
+                "errors": errors,
+                "warnings": warnings,
+                "conversation_count": 0,
+            }
+
+        for idx, conv in enumerate(conversations):
+            if not isinstance(conv, dict):
+                errors.append(f"Conversation {idx} is not an object")
+                continue
+            for field_name in UNIVERSAL_REQUIRED_FIELDS:
+                if field_name not in conv:
+                    errors.append(
+                        f"Conversation {idx} missing required field '{field_name}'"
+                    )
+            if "messages" in conv and not isinstance(conv["messages"], list):
+                errors.append(f"Conversation {idx} 'messages' must be a list")
+
+        return {
+            "valid": not errors,
+            "errors": errors,
+            "warnings": warnings,
+            "conversation_count": len(conversations),
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_envelope(
+        self,
+        conversations: List[Dict[str, Any]],
+        filters: Optional[Filters],
+    ) -> Dict[str, Any]:
+        return {
+            "format": "universal",
+            "format_version": JSON_EXPORT_FORMAT_VERSION,
+            "exported_at": datetime.now().isoformat(),
+            "source_storage_path": str(self.source_storage_path),
+            "conversation_count": len(conversations),
+            "filters_applied": _serialize_filters(filters),
+            "conversations": conversations,
+        }
+
+
+def _serialize_filters(filters: Optional[Filters]) -> Dict[str, Any]:
+    """Serialize a Filters dataclass into JSON-safe dict."""
+    if filters is None or filters.is_empty():
+        return {}
+    return {
+        "date_from": (filters.date_from.isoformat() if filters.date_from else None),
+        "date_to": (filters.date_to.isoformat() if filters.date_to else None),
+        "platforms": list(filters.platforms) if filters.platforms else None,
+        "limit": filters.limit,
+    }

--- a/src/exporters/json_exporter.py
+++ b/src/exporters/json_exporter.py
@@ -36,7 +36,6 @@ from .base_exporter import (
     Filters,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_exporters/__init__.py
+++ b/tests/test_exporters/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the exporters package."""

--- a/tests/test_exporters/test_base_exporter.py
+++ b/tests/test_exporters/test_base_exporter.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Tests for ``src/exporters/base_exporter.py``."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest  # type: ignore[import-not-found]
+
+# Make ``src/`` importable when tests are run via pytest from repo root.
+SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from exporters.base_exporter import (  # type: ignore[import-not-found]  # noqa: E402
+    UNIVERSAL_REQUIRED_FIELDS,
+    BaseExporter,
+    ExportResult,
+    Filters,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+class _ConcreteExporter(BaseExporter):
+    """Minimal concrete BaseExporter subclass used to test shared helpers."""
+
+    def export(
+        self,
+        output_path: Path,
+        filters: Optional[Filters] = None,
+    ) -> ExportResult:
+        items = self.apply_filters(self.load_conversations(), filters)
+        self.write_json(output_path, {"conversations": items})
+        return ExportResult(
+            success=True,
+            conversations_exported=len(items),
+            conversations_failed=0,
+            errors=[],
+            output_path=str(output_path),
+        )
+
+    def validate(self, output_path: Path) -> Dict[str, Any]:
+        return {
+            "valid": output_path.exists(),
+            "errors": [],
+            "warnings": [],
+            "conversation_count": 0,
+        }
+
+
+def _build_storage(
+    tmp_path: Path,
+    conversations: List[Dict[str, Any]],
+    *,
+    use_data_layout: bool = True,
+) -> Path:
+    """Create a fake storage tree with index.json + per-conversation files."""
+    convs_root = tmp_path / (
+        "data/conversations" if use_data_layout else "conversations"
+    )
+    convs_root.mkdir(parents=True, exist_ok=True)
+
+    index_entries = []
+    for conv in conversations:
+        date = conv.get("date") or datetime.now().isoformat()
+        try:
+            parsed = datetime.fromisoformat(date.replace("Z", "+00:00"))
+        except ValueError:
+            parsed = datetime.now()
+        month_dir = (
+            convs_root
+            / str(parsed.year)
+            / f"{parsed.month:02d}-{parsed.strftime('%B').lower()}"
+        )
+        month_dir.mkdir(parents=True, exist_ok=True)
+        file_path = month_dir / f"{conv['id']}.json"
+        file_path.write_text(json.dumps(conv, indent=2), encoding="utf-8")
+        index_entries.append(
+            {
+                "id": conv["id"],
+                "title": conv.get("title", ""),
+                "date": date,
+                "topics": conv.get("topics", []),
+                "file_path": str(file_path.relative_to(tmp_path)),
+                "added_at": datetime.now().isoformat(),
+            }
+        )
+
+    (convs_root / "index.json").write_text(
+        json.dumps({"conversations": index_entries}, indent=2),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _legacy_conversation(
+    conv_id: str = "conv_20251010_120000_0001",
+    *,
+    date: str = "2025-10-10T12:00:00",
+    title: str = "Legacy Conversation",
+    content: str = "Hello world content",
+    topics: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Simulate the legacy on-disk shape used by ConversationMemoryServer."""
+    return {
+        "id": conv_id,
+        "title": title,
+        "content": content,
+        "date": date,
+        "topics": topics or ["test"],
+        "created_at": date,
+    }
+
+
+def _universal_conversation(
+    conv_id: str = "conv_20251010_120000_uni0",
+    *,
+    date: str = "2025-10-10T12:00:00",
+    platform: str = "chatgpt",
+    title: str = "Universal Convo",
+) -> Dict[str, Any]:
+    """Simulate a universal-format conversation produced by importers."""
+    msgs = [
+        {
+            "id": "m1",
+            "role": "user",
+            "content": "Hi there",
+            "timestamp": date,
+            "metadata": {},
+        },
+        {
+            "id": "m2",
+            "role": "assistant",
+            "content": "Hello back",
+            "timestamp": date,
+            "metadata": {},
+        },
+    ]
+    return {
+        "id": conv_id,
+        "platform": platform,
+        "platform_id": f"native-{conv_id}",
+        "model": "gpt-4",
+        "title": title,
+        "content": "Hi there\n\nHello back",
+        "messages": msgs,
+        "date": date,
+        "last_updated": date,
+        "topics": ["test", platform],
+        "session_context": {},
+        "import_metadata": {"imported_at": date},
+        "created_at": date,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+class TestExportResult:
+    def test_success_rate_with_zero_total(self):
+        result = ExportResult(
+            success=False,
+            conversations_exported=0,
+            conversations_failed=0,
+            errors=[],
+            output_path=None,
+        )
+        assert result.success_rate == 0.0
+        assert result.total_processed == 0
+
+    def test_success_rate_with_failures(self):
+        result = ExportResult(
+            success=True,
+            conversations_exported=8,
+            conversations_failed=2,
+            errors=[],
+            output_path="/tmp/out.json",
+        )
+        assert result.total_processed == 10
+        assert result.success_rate == 0.8
+
+    def test_success_rate_perfect(self):
+        result = ExportResult(
+            success=True,
+            conversations_exported=5,
+            conversations_failed=0,
+            errors=[],
+            output_path="/tmp/out.json",
+        )
+        assert result.success_rate == 1.0
+
+
+class TestFilters:
+    def test_is_empty_default(self):
+        assert Filters().is_empty() is True
+
+    def test_is_empty_with_date_from(self):
+        assert Filters(date_from=datetime(2025, 1, 1)).is_empty() is False
+
+    def test_is_empty_with_platforms(self):
+        assert Filters(platforms=["chatgpt"]).is_empty() is False
+
+    def test_is_empty_with_limit(self):
+        assert Filters(limit=10).is_empty() is False
+
+    def test_is_empty_with_empty_platforms_list(self):
+        # An explicitly empty list is treated as "no platform filter".
+        assert Filters(platforms=[]).is_empty() is True
+
+
+class TestLoadConversations:
+    def test_loads_data_layout(self, tmp_path):
+        _build_storage(
+            tmp_path,
+            [_legacy_conversation()],
+            use_data_layout=True,
+        )
+        exp = _ConcreteExporter(tmp_path)
+        loaded = exp.load_conversations()
+        assert len(loaded) == 1
+        # Legacy conv should be upgraded to universal shape.
+        assert loaded[0]["platform"] == "unknown"
+        assert isinstance(loaded[0]["messages"], list)
+        assert loaded[0]["messages"], "synthetic message expected"
+
+    def test_loads_legacy_layout(self, tmp_path):
+        _build_storage(
+            tmp_path,
+            [_legacy_conversation()],
+            use_data_layout=False,
+        )
+        exp = _ConcreteExporter(tmp_path)
+        loaded = exp.load_conversations()
+        assert len(loaded) == 1
+
+    def test_returns_empty_when_no_index(self, tmp_path, caplog):
+        exp = _ConcreteExporter(tmp_path)
+        loaded = exp.load_conversations()
+        assert loaded == []
+
+    def test_handles_corrupt_index(self, tmp_path):
+        convs_root = tmp_path / "data" / "conversations"
+        convs_root.mkdir(parents=True)
+        (convs_root / "index.json").write_text("not json{")
+        exp = _ConcreteExporter(tmp_path)
+        assert exp.load_conversations() == []
+
+    def test_skips_missing_files(self, tmp_path):
+        # Build storage then delete the conversation file but keep index.
+        _build_storage(tmp_path, [_legacy_conversation()])
+        for f in (tmp_path / "data" / "conversations").rglob("conv_*.json"):
+            f.unlink()
+        exp = _ConcreteExporter(tmp_path)
+        assert exp.load_conversations() == []
+
+    def test_skips_index_entry_without_file_path(self, tmp_path):
+        convs_root = tmp_path / "data" / "conversations"
+        convs_root.mkdir(parents=True)
+        (convs_root / "index.json").write_text(
+            json.dumps({"conversations": [{"id": "x", "title": "no path"}]})
+        )
+        exp = _ConcreteExporter(tmp_path)
+        assert exp.load_conversations() == []
+
+    def test_skips_corrupt_conversation_file(self, tmp_path):
+        _build_storage(tmp_path, [_legacy_conversation()])
+        # Corrupt the conversation file
+        for f in (tmp_path / "data" / "conversations").rglob("conv_*.json"):
+            f.write_text("totally not json")
+        exp = _ConcreteExporter(tmp_path)
+        assert exp.load_conversations() == []
+
+    def test_universal_conversation_passes_through(self, tmp_path):
+        original = _universal_conversation()
+        _build_storage(tmp_path, [original])
+        exp = _ConcreteExporter(tmp_path)
+        loaded = exp.load_conversations()
+        assert loaded[0]["platform"] == "chatgpt"
+        # Existing messages should be preserved (no synthetic injection).
+        assert len(loaded[0]["messages"]) == 2
+        assert loaded[0]["messages"][0]["role"] == "user"
+
+
+class TestNormalizeToUniversal:
+    def test_legacy_gains_required_defaults(self):
+        legacy = _legacy_conversation()
+        upgraded = BaseExporter._normalize_to_universal(legacy)
+        for field_name in UNIVERSAL_REQUIRED_FIELDS:
+            assert field_name in upgraded
+        assert upgraded["platform"] == "unknown"
+        assert upgraded["model"] == "unknown"
+        assert upgraded["messages"][0]["metadata"]["synthetic"] is True
+
+    def test_does_not_mutate_input(self):
+        legacy = _legacy_conversation()
+        before = dict(legacy)
+        BaseExporter._normalize_to_universal(legacy)
+        assert legacy == before  # outer dict unchanged
+
+    def test_no_synthetic_message_when_content_empty(self):
+        conv = _legacy_conversation(content="")
+        upgraded = BaseExporter._normalize_to_universal(conv)
+        assert upgraded["messages"] == []
+
+
+class TestApplyFilters:
+    def test_no_filters_returns_all(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [_universal_conversation(conv_id=f"c{i}") for i in range(3)]
+        assert exp.apply_filters(items, None) == items
+        assert exp.apply_filters(items, Filters()) == items
+
+    def test_date_from_filter(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [
+            _universal_conversation(conv_id="old", date="2025-01-01T00:00:00"),
+            _universal_conversation(conv_id="new", date="2025-12-01T00:00:00"),
+        ]
+        result = exp.apply_filters(items, Filters(date_from=datetime(2025, 6, 1)))
+        assert [c["id"] for c in result] == ["new"]
+
+    def test_date_to_filter(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [
+            _universal_conversation(conv_id="old", date="2025-01-01T00:00:00"),
+            _universal_conversation(conv_id="new", date="2025-12-01T00:00:00"),
+        ]
+        result = exp.apply_filters(items, Filters(date_to=datetime(2025, 6, 1)))
+        assert [c["id"] for c in result] == ["old"]
+
+    def test_date_range_filter(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [
+            _universal_conversation(conv_id="a", date="2025-01-01T00:00:00"),
+            _universal_conversation(conv_id="b", date="2025-06-15T00:00:00"),
+            _universal_conversation(conv_id="c", date="2025-12-31T00:00:00"),
+        ]
+        result = exp.apply_filters(
+            items,
+            Filters(
+                date_from=datetime(2025, 6, 1),
+                date_to=datetime(2025, 7, 1),
+            ),
+        )
+        assert [c["id"] for c in result] == ["b"]
+
+    def test_date_filter_excludes_unparseable_dates(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [
+            _universal_conversation(conv_id="bad", date="not-a-date"),
+            _universal_conversation(conv_id="good", date="2025-06-01T00:00:00"),
+        ]
+        result = exp.apply_filters(items, Filters(date_from=datetime(2025, 1, 1)))
+        assert [c["id"] for c in result] == ["good"]
+
+    def test_date_filter_handles_tz_aware_conversation(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [
+            _universal_conversation(conv_id="tz", date="2025-06-01T00:00:00+00:00")
+        ]
+        # Naive filter compared against tz-aware conversation should still
+        # work without raising.
+        result = exp.apply_filters(
+            items,
+            Filters(date_from=datetime(2025, 1, 1)),
+        )
+        assert [c["id"] for c in result] == ["tz"]
+
+    def test_date_filter_tz_aware_filter_against_naive_conv(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [_universal_conversation(date="2025-06-01T00:00:00")]
+        tz_filter = Filters(date_from=datetime(2025, 1, 1, tzinfo=timezone.utc))
+        result = exp.apply_filters(items, tz_filter)
+        assert len(result) == 1
+
+    def test_platform_filter(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [
+            _universal_conversation(conv_id="g", platform="chatgpt"),
+            _universal_conversation(conv_id="c", platform="claude"),
+            _universal_conversation(conv_id="u", platform="cursor"),
+        ]
+        result = exp.apply_filters(items, Filters(platforms=["chatgpt", "cursor"]))
+        assert sorted(c["id"] for c in result) == ["g", "u"]
+
+    def test_platform_filter_case_insensitive(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [_universal_conversation(platform="ChatGPT")]
+        result = exp.apply_filters(items, Filters(platforms=["chatgpt"]))
+        assert len(result) == 1
+
+    def test_platform_filter_unknown_matches_legacy(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        legacy = _legacy_conversation()
+        upgraded = BaseExporter._normalize_to_universal(legacy)
+        result = exp.apply_filters([upgraded], Filters(platforms=["unknown"]))
+        assert len(result) == 1
+
+    def test_limit_filter(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [_universal_conversation(conv_id=f"c{i}") for i in range(5)]
+        result = exp.apply_filters(items, Filters(limit=3))
+        assert len(result) == 3
+        assert [c["id"] for c in result] == ["c0", "c1", "c2"]
+
+    def test_combined_filters(self):
+        exp = _ConcreteExporter(Path("/tmp"))
+        items = [
+            _universal_conversation(
+                conv_id="a", platform="chatgpt", date="2025-01-01T00:00:00"
+            ),
+            _universal_conversation(
+                conv_id="b", platform="chatgpt", date="2025-06-01T00:00:00"
+            ),
+            _universal_conversation(
+                conv_id="c", platform="claude", date="2025-06-01T00:00:00"
+            ),
+        ]
+        result = exp.apply_filters(
+            items,
+            Filters(
+                date_from=datetime(2025, 5, 1),
+                platforms=["chatgpt"],
+                limit=10,
+            ),
+        )
+        assert [c["id"] for c in result] == ["b"]
+
+
+class TestWriteJson:
+    def test_writes_payload_creating_parent_dirs(self, tmp_path):
+        exp = _ConcreteExporter(tmp_path)
+        out = tmp_path / "subdir" / "deeper" / "out.json"
+        exp.write_json(out, {"hello": "world"})
+        assert out.exists()
+        assert json.loads(out.read_text()) == {"hello": "world"}
+
+    def test_unwritable_directory_raises(self, tmp_path):
+        exp = _ConcreteExporter(tmp_path)
+        # /proc is non-writable on Linux; using a known pseudo-fs path keeps
+        # the test platform-portable since we only need the OSError raise.
+        bad_path = Path("/proc/cannot-write-here/out.json")
+        with pytest.raises(OSError):
+            exp.write_json(bad_path, {"x": 1})
+
+
+class TestParseIso:
+    def test_parses_basic_iso(self):
+        result = BaseExporter._parse_iso("2025-06-15T12:00:00")
+        assert result is not None
+        assert result.year == 2025
+
+    def test_parses_iso_with_z(self):
+        result = BaseExporter._parse_iso("2025-06-15T12:00:00Z")
+        assert result is not None
+        assert result.tzinfo is not None
+
+    def test_returns_none_for_empty(self):
+        assert BaseExporter._parse_iso("") is None
+        assert BaseExporter._parse_iso(None) is None  # type: ignore[arg-type]
+
+    def test_returns_none_for_invalid(self):
+        assert BaseExporter._parse_iso("not-a-date") is None

--- a/tests/test_exporters/test_chatgpt_exporter.py
+++ b/tests/test_exporters/test_chatgpt_exporter.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Tests for ``src/exporters/chatgpt_exporter.py``."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Ensure ``src/`` is importable so we can use bare ``exporters.X`` imports
+# (matching the pattern used by tests/test_config.py).
+SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from exporters.base_exporter import Filters  # type: ignore[import-not-found]  # noqa: E402
+from exporters.chatgpt_exporter import ChatgptExporter  # type: ignore[import-not-found]  # noqa: E402
+
+from .test_base_exporter import (  # noqa: E402
+    _build_storage,
+    _legacy_conversation,
+    _universal_conversation,
+)
+
+
+class TestChatgptExporterBasics:
+    def test_export_writes_array(self, tmp_path):
+        _build_storage(tmp_path, [_universal_conversation()])
+        out = tmp_path / "out.json"
+        result = ChatgptExporter(tmp_path).export(out)
+        assert result.success
+        assert result.conversations_exported == 1
+        data = json.loads(out.read_text())
+        assert isinstance(data, list)
+        assert len(data) == 1
+        first = data[0]
+        # Required ChatGPT fields are present.
+        assert "title" in first
+        assert "create_time" in first
+        assert "mapping" in first
+        assert "conversation_id" in first
+
+    def test_mapping_has_root_plus_messages(self, tmp_path):
+        _build_storage(tmp_path, [_universal_conversation()])
+        out = tmp_path / "out.json"
+        ChatgptExporter(tmp_path).export(out)
+        data = json.loads(out.read_text())
+        mapping = data[0]["mapping"]
+        # Root + 2 messages = 3 nodes.
+        assert len(mapping) == 3
+        # Exactly one root node (parent is None).
+        roots = [n for n in mapping.values() if n["parent"] is None]
+        assert len(roots) == 1
+        assert roots[0]["message"] is None
+
+    def test_export_empty_storage(self, tmp_path):
+        out = tmp_path / "out.json"
+        result = ChatgptExporter(tmp_path).export(out)
+        assert result.success is True
+        assert result.conversations_exported == 0
+        assert json.loads(out.read_text()) == []
+
+    def test_export_with_legacy_conversation(self, tmp_path):
+        _build_storage(tmp_path, [_legacy_conversation()])
+        out = tmp_path / "out.json"
+        result = ChatgptExporter(tmp_path).export(out)
+        assert result.success
+        assert result.conversations_exported == 1
+        data = json.loads(out.read_text())
+        # The synthetic universal upgrade should produce one assistant
+        # message in the mapping, plus the synthetic root.
+        mapping = data[0]["mapping"]
+        msg_nodes = [n for n in mapping.values() if n["message"] is not None]
+        assert len(msg_nodes) == 1
+        assert msg_nodes[0]["message"]["author"]["role"] == "assistant"
+
+    def test_unwritable_path_returns_error(self, tmp_path):
+        _build_storage(tmp_path, [_universal_conversation()])
+        bad = Path("/proc/no-such-dir/out.json")
+        result = ChatgptExporter(tmp_path).export(bad)
+        assert result.success is False
+        assert result.errors
+
+    def test_load_failure_propagates(self, tmp_path, monkeypatch):
+        exporter = ChatgptExporter(tmp_path)
+
+        def boom():
+            raise RuntimeError("explode")
+
+        monkeypatch.setattr(exporter, "load_conversations", boom)
+        result = exporter.export(tmp_path / "out.json")
+        assert result.success is False
+        assert any("Failed to load" in e for e in result.errors)
+
+    def test_per_conversion_failure_recorded(self, tmp_path, monkeypatch):
+        _build_storage(
+            tmp_path,
+            [
+                _universal_conversation(conv_id="ok"),
+                _universal_conversation(conv_id="fail"),
+            ],
+        )
+        exporter = ChatgptExporter(tmp_path)
+        original_to_chatgpt = exporter._to_chatgpt
+
+        def maybe_explode(conv):
+            if conv["id"] == "fail":
+                raise ValueError("boom")
+            return original_to_chatgpt(conv)
+
+        monkeypatch.setattr(exporter, "_to_chatgpt", maybe_explode)
+        result = exporter.export(tmp_path / "out.json")
+        assert result.conversations_exported == 1
+        assert result.conversations_failed == 1
+        assert any("fail" in e for e in result.errors)
+
+
+class TestChatgptExporterMessageNormalization:
+    def test_unknown_role_mapped_to_assistant(self, tmp_path):
+        conv = _universal_conversation()
+        conv["messages"][0]["role"] = "tool"
+        _build_storage(tmp_path, [conv])
+        out = tmp_path / "out.json"
+        ChatgptExporter(tmp_path).export(out)
+        data = json.loads(out.read_text())
+        roles = {
+            n["message"]["author"]["role"]
+            for n in data[0]["mapping"].values()
+            if n["message"] is not None
+        }
+        assert roles == {"assistant"}
+
+    def test_missing_message_id_generated(self, tmp_path):
+        conv = _universal_conversation()
+        for m in conv["messages"]:
+            m.pop("id", None)
+        _build_storage(tmp_path, [conv])
+        out = tmp_path / "out.json"
+        ChatgptExporter(tmp_path).export(out)
+        data = json.loads(out.read_text())
+        msg_nodes = [n for n in data[0]["mapping"].values() if n["message"] is not None]
+        assert all(n["id"] for n in msg_nodes)
+        # All ids should be unique.
+        ids = [n["id"] for n in msg_nodes]
+        assert len(set(ids)) == len(ids)
+
+    def test_message_id_collision_with_root_is_rewritten(self, tmp_path):
+        """If a message id happens to equal the synthetic root id, the
+        exporter must rewrite it so the mapping still has a single root."""
+        conv = _universal_conversation(conv_id="collide")
+        # Root id is built from conv['id'] -> "root_collide".
+        conv["messages"][0]["id"] = "root_collide"
+        _build_storage(tmp_path, [conv])
+        out = tmp_path / "out.json"
+        ChatgptExporter(tmp_path).export(out)
+        data = json.loads(out.read_text())
+        mapping = data[0]["mapping"]
+        # Exactly one root.
+        roots = [n for n in mapping.values() if n["parent"] is None]
+        assert len(roots) == 1
+        # Renamed message id should appear.
+        assert "root_collide_msg" in mapping
+
+    def test_iso_to_epoch_basic(self):
+        epoch = ChatgptExporter._iso_to_epoch("2025-06-15T12:00:00")
+        assert epoch > 0
+
+    def test_iso_to_epoch_z_suffix(self):
+        epoch = ChatgptExporter._iso_to_epoch("2025-06-15T12:00:00Z")
+        assert epoch > 0
+
+    def test_iso_to_epoch_passthrough_numeric(self):
+        assert ChatgptExporter._iso_to_epoch(1234567890) == 1234567890.0
+
+    def test_iso_to_epoch_invalid(self):
+        assert ChatgptExporter._iso_to_epoch("not-a-date") == 0.0
+        assert ChatgptExporter._iso_to_epoch("") == 0.0
+        assert ChatgptExporter._iso_to_epoch(None) == 0.0
+
+
+class TestChatgptExporterValidate:
+    def test_validate_round_trip_passes_schema(self, tmp_path):
+        _build_storage(
+            tmp_path,
+            [_universal_conversation(conv_id="r1")],
+        )
+        out = tmp_path / "out.json"
+        exporter = ChatgptExporter(tmp_path)
+        exporter.export(out)
+
+        result = exporter.validate(out)
+        assert result["valid"], result
+        assert result["conversation_count"] == 1
+
+    def test_validate_missing_file(self, tmp_path):
+        result = ChatgptExporter(tmp_path).validate(tmp_path / "nope.json")
+        assert result["valid"] is False
+        assert any("not found" in e for e in result["errors"])
+
+    def test_validate_invalid_json(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json{", encoding="utf-8")
+        result = ChatgptExporter(tmp_path).validate(bad)
+        assert result["valid"] is False
+
+    # Note: a separate "validate output directly against the chatgpt schema"
+    # test is intentionally omitted to avoid pulling jsonschema into the
+    # mypy graph. ``test_validate_round_trip_passes_schema`` above already
+    # exercises the schema indirectly via ``ChatgptExporter.validate()``.
+
+
+class TestChatgptExporterFilters:
+    def test_filters_applied(self, tmp_path):
+        _build_storage(
+            tmp_path,
+            [
+                _universal_conversation(
+                    conv_id="a",
+                    platform="chatgpt",
+                    date="2025-01-01T00:00:00",
+                ),
+                _universal_conversation(
+                    conv_id="b",
+                    platform="claude",
+                    date="2025-06-01T00:00:00",
+                ),
+            ],
+        )
+        out = tmp_path / "out.json"
+        result = ChatgptExporter(tmp_path).export(out, Filters(platforms=["chatgpt"]))
+        assert result.conversations_exported == 1
+        data = json.loads(out.read_text())
+        assert len(data) == 1
+
+
+class TestChatgptExporterRoundTrip:
+    """Import ChatGPT export → store → export back to ChatGPT → validate."""
+
+    def _write_chatgpt_export(self, tmp_path: Path) -> Path:
+        export_data = {
+            "conversations": [
+                {
+                    "id": "conv-rt-1",
+                    "title": "Round Trip ChatGPT",
+                    "create_time": "2025-04-01T10:00:00Z",
+                    "update_time": "2025-04-01T10:30:00Z",
+                    "messages": [
+                        {
+                            "id": "u-1",
+                            "role": "user",
+                            "content": "What is 2+2?",
+                            "create_time": "2025-04-01T10:00:00Z",
+                        },
+                        {
+                            "id": "a-1",
+                            "role": "assistant",
+                            "content": "4",
+                            "create_time": "2025-04-01T10:00:30Z",
+                        },
+                    ],
+                }
+            ]
+        }
+        path = tmp_path / "chatgpt_in.json"
+        path.write_text(json.dumps(export_data), encoding="utf-8")
+        return path
+
+    def test_round_trip_chatgpt_to_chatgpt(self, tmp_path):
+        # Lazy import: avoid mypy following src/importers into the schema
+        # module which has a pre-existing missing-stubs warning.
+        from importers.chatgpt_importer import (  # type: ignore[import-not-found]
+            ChatGPTImporter,
+        )
+
+        storage_root = tmp_path / "storage"
+        storage_dir = storage_root / "data" / "conversations"
+        importer = ChatGPTImporter(storage_dir)
+        result = importer.import_file(self._write_chatgpt_export(tmp_path))
+        assert result.success
+        original_id = result.imported_ids[0]
+
+        # Build minimal index.
+        conv_file = next(storage_dir.rglob("conv_*.json"))
+        (storage_dir / "index.json").write_text(
+            json.dumps(
+                {
+                    "conversations": [
+                        {
+                            "id": original_id,
+                            "title": "Round Trip ChatGPT",
+                            "date": "2025-04-01T10:00:00",
+                            "topics": [],
+                            "file_path": str(conv_file.relative_to(storage_root)),
+                            "added_at": "2025-04-01T10:00:00",
+                        }
+                    ]
+                }
+            )
+        )
+
+        out = tmp_path / "out.json"
+        exporter = ChatgptExporter(storage_root)
+        export_result = exporter.export(out)
+        assert export_result.success
+        assert export_result.conversations_exported == 1
+
+        # Validate against ChatGPT schema.
+        validation = exporter.validate(out)
+        assert validation["valid"], validation
+
+        # Re-import into a fresh storage to ensure the output is parseable.
+        reimport_dir = tmp_path / "reimport"
+        reimporter = ChatGPTImporter(reimport_dir)
+        # The exporter writes a list, but the importer expects a dict with
+        # "conversations" key. Wrap accordingly for the round-trip check.
+        wrapped = tmp_path / "wrapped.json"
+        wrapped.write_text(
+            json.dumps({"conversations": json.loads(out.read_text())}),
+            encoding="utf-8",
+        )
+        # The wrapped form won't match the importer's expected message
+        # shape (mapping vs simple messages list), but it should at least
+        # not crash. The first form of round-trip we care about is schema
+        # compliance, which is what `validation` above asserts.
+        reimport_result = reimporter.import_file(wrapped)
+        # Importer rejects mapping format wrapped this way, that's ok.
+        # We've already verified schema compliance for the actual ChatGPT
+        # export shape.
+        assert reimport_result is not None

--- a/tests/test_exporters/test_json_exporter.py
+++ b/tests/test_exporters/test_json_exporter.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Tests for ``src/exporters/json_exporter.py``."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest  # type: ignore[import-not-found]
+
+# Ensure ``src/`` is importable so we can use bare ``exporters.X`` imports
+# (matching the pattern used by tests/test_config.py).
+SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from exporters.base_exporter import Filters  # type: ignore[import-not-found]  # noqa: E402
+from exporters.json_exporter import (  # type: ignore[import-not-found]  # noqa: E402
+    JSON_EXPORT_FORMAT_VERSION,
+    JsonExporter,
+)
+
+from .test_base_exporter import (  # noqa: E402
+    _build_storage,
+    _legacy_conversation,
+    _universal_conversation,
+)
+
+
+class TestJsonExporterBasics:
+    def test_export_writes_envelope(self, tmp_path):
+        _build_storage(
+            tmp_path,
+            [_universal_conversation(conv_id="c1", platform="chatgpt")],
+        )
+        out = tmp_path / "out.json"
+        exporter = JsonExporter(tmp_path)
+        result = exporter.export(out)
+
+        assert result.success is True
+        assert result.conversations_exported == 1
+        assert result.conversations_failed == 0
+        assert result.output_path == str(out)
+        assert result.metadata["format"] == "universal"
+        assert result.metadata["format_version"] == JSON_EXPORT_FORMAT_VERSION
+        assert result.success_rate == 1.0
+
+        payload = json.loads(out.read_text())
+        assert payload["format"] == "universal"
+        assert payload["conversation_count"] == 1
+        assert len(payload["conversations"]) == 1
+        assert payload["conversations"][0]["id"] == "c1"
+        # Filters block should be present and empty.
+        assert payload["filters_applied"] == {}
+
+    def test_export_empty_storage(self, tmp_path):
+        out = tmp_path / "out.json"
+        exporter = JsonExporter(tmp_path)
+        result = exporter.export(out)
+
+        assert result.success is True
+        assert result.conversations_exported == 0
+        assert out.exists()
+        payload = json.loads(out.read_text())
+        assert payload["conversation_count"] == 0
+        assert payload["conversations"] == []
+
+    def test_export_to_unwritable_path_returns_error(self, tmp_path):
+        _build_storage(tmp_path, [_universal_conversation()])
+        bad = Path("/proc/no-such-dir/out.json")
+        exporter = JsonExporter(tmp_path)
+        result = exporter.export(bad)
+        assert result.success is False
+        assert result.output_path is None
+        assert result.errors
+
+    def test_load_failure_propagates(self, tmp_path, monkeypatch):
+        exporter = JsonExporter(tmp_path)
+
+        def boom():
+            raise RuntimeError("explode")
+
+        monkeypatch.setattr(exporter, "load_conversations", boom)
+        result = exporter.export(tmp_path / "out.json")
+        assert result.success is False
+        assert any("Failed to load" in e for e in result.errors)
+
+
+class TestJsonExporterFilters:
+    def test_export_with_filters_records_them_in_envelope(self, tmp_path):
+        _build_storage(
+            tmp_path,
+            [
+                _universal_conversation(
+                    conv_id="a", platform="chatgpt", date="2025-01-01T00:00:00"
+                ),
+                _universal_conversation(
+                    conv_id="b", platform="chatgpt", date="2025-08-01T00:00:00"
+                ),
+                _universal_conversation(
+                    conv_id="c", platform="claude", date="2025-08-01T00:00:00"
+                ),
+            ],
+        )
+        out = tmp_path / "out.json"
+        exporter = JsonExporter(tmp_path)
+        filters = Filters(
+            date_from=datetime(2025, 6, 1),
+            platforms=["chatgpt"],
+            limit=10,
+        )
+        result = exporter.export(out, filters)
+        assert result.conversations_exported == 1
+
+        payload = json.loads(out.read_text())
+        applied = payload["filters_applied"]
+        assert applied["platforms"] == ["chatgpt"]
+        assert applied["date_from"] == "2025-06-01T00:00:00"
+        assert applied["date_to"] is None
+        assert applied["limit"] == 10
+        assert payload["conversations"][0]["id"] == "b"
+
+    def test_limit_truncates_output(self, tmp_path):
+        convs = [_universal_conversation(conv_id=f"c{i}") for i in range(5)]
+        _build_storage(tmp_path, convs)
+        out = tmp_path / "out.json"
+        exporter = JsonExporter(tmp_path)
+        result = exporter.export(out, Filters(limit=2))
+        assert result.conversations_exported == 2
+        payload = json.loads(out.read_text())
+        assert len(payload["conversations"]) == 2
+
+
+class TestJsonExporterValidate:
+    def _write_payload(self, path: Path, payload):
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_validate_round_trip_success(self, tmp_path):
+        _build_storage(tmp_path, [_universal_conversation()])
+        out = tmp_path / "out.json"
+        exporter = JsonExporter(tmp_path)
+        exporter.export(out)
+        result = exporter.validate(out)
+        assert result["valid"] is True
+        assert result["errors"] == []
+        assert result["conversation_count"] == 1
+
+    def test_validate_missing_file(self, tmp_path):
+        exporter = JsonExporter(tmp_path)
+        result = exporter.validate(tmp_path / "nope.json")
+        assert result["valid"] is False
+        assert any("not found" in e for e in result["errors"])
+
+    def test_validate_invalid_json(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json{", encoding="utf-8")
+        result = JsonExporter(tmp_path).validate(bad)
+        assert result["valid"] is False
+
+    def test_validate_top_level_not_object(self, tmp_path):
+        bad = tmp_path / "list.json"
+        self._write_payload(bad, [1, 2, 3])
+        result = JsonExporter(tmp_path).validate(bad)
+        assert result["valid"] is False
+        assert "object" in result["errors"][0].lower()
+
+    def test_validate_conversations_not_list(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        self._write_payload(bad, {"format": "universal", "conversations": {}})
+        result = JsonExporter(tmp_path).validate(bad)
+        assert result["valid"] is False
+        assert any("must be a list" in e for e in result["errors"])
+
+    def test_validate_warns_on_wrong_format(self, tmp_path):
+        out = tmp_path / "out.json"
+        self._write_payload(
+            out,
+            {
+                "format": "chatgpt",
+                "conversations": [
+                    {
+                        "id": "x",
+                        "platform": "chatgpt",
+                        "title": "t",
+                        "content": "c",
+                        "messages": [],
+                        "date": "2025-01-01",
+                    }
+                ],
+            },
+        )
+        result = JsonExporter(tmp_path).validate(out)
+        assert result["valid"] is True
+        assert result["warnings"]
+
+    def test_validate_missing_required_fields(self, tmp_path):
+        out = tmp_path / "missing.json"
+        self._write_payload(
+            out,
+            {
+                "format": "universal",
+                "conversations": [{"id": "x", "title": "incomplete"}],
+            },
+        )
+        result = JsonExporter(tmp_path).validate(out)
+        assert result["valid"] is False
+        assert len(result["errors"]) >= 4  # missing platform/content/etc.
+
+    def test_validate_non_dict_conversation(self, tmp_path):
+        out = tmp_path / "weird.json"
+        self._write_payload(
+            out,
+            {"format": "universal", "conversations": ["not an object"]},
+        )
+        result = JsonExporter(tmp_path).validate(out)
+        assert result["valid"] is False
+        assert any("not an object" in e for e in result["errors"])
+
+    def test_validate_messages_not_list(self, tmp_path):
+        out = tmp_path / "bad_msgs.json"
+        self._write_payload(
+            out,
+            {
+                "format": "universal",
+                "conversations": [
+                    {
+                        "id": "x",
+                        "platform": "chatgpt",
+                        "title": "t",
+                        "content": "c",
+                        "messages": "should-be-list",
+                        "date": "2025-01-01",
+                    }
+                ],
+            },
+        )
+        result = JsonExporter(tmp_path).validate(out)
+        assert result["valid"] is False
+        assert any("must be a list" in e for e in result["errors"])
+
+
+class TestJsonExporterLegacyUpgrade:
+    def test_legacy_records_upgraded_in_export(self, tmp_path):
+        _build_storage(
+            tmp_path,
+            [_legacy_conversation(conv_id="legacy_1")],
+        )
+        out = tmp_path / "out.json"
+        result = JsonExporter(tmp_path).export(out)
+        assert result.conversations_exported == 1
+        payload = json.loads(out.read_text())
+        conv = payload["conversations"][0]
+        # Synthetic universal fields populated
+        assert conv["platform"] == "unknown"
+        assert isinstance(conv["messages"], list)
+        assert conv["messages"], "should have synthetic message"
+        assert conv["messages"][0]["metadata"]["synthetic"] is True
+
+
+class TestJsonExporterRoundTrip:
+    """Full round-trip: import ChatGPT → universal storage → export → re-validate."""
+
+    def _write_chatgpt_export(self, tmp_path: Path) -> Path:
+        export_data = {
+            "conversations": [
+                {
+                    "id": "conv-r-1",
+                    "title": "Round Trip 1",
+                    "create_time": "2025-03-01T10:00:00Z",
+                    "update_time": "2025-03-01T10:30:00Z",
+                    "messages": [
+                        {
+                            "id": "m1",
+                            "role": "user",
+                            "content": "Hello",
+                            "create_time": "2025-03-01T10:00:00Z",
+                        },
+                        {
+                            "id": "m2",
+                            "role": "assistant",
+                            "content": "Hi there!",
+                            "create_time": "2025-03-01T10:01:00Z",
+                        },
+                    ],
+                }
+            ]
+        }
+        export_path = tmp_path / "chatgpt_export.json"
+        export_path.write_text(json.dumps(export_data), encoding="utf-8")
+        return export_path
+
+    def test_round_trip_preserves_key_universal_fields(self, tmp_path):
+        # Lazy import: avoid mypy following src/importers into the schema
+        # module which has a pre-existing missing-stubs warning.
+        from importers.chatgpt_importer import (  # type: ignore[import-not-found]
+            ChatGPTImporter,
+        )
+
+        # Step 1: import a ChatGPT export into universal storage layout.
+        storage_root = tmp_path / "storage"
+        importer_storage = storage_root / "data" / "conversations"
+        importer = ChatGPTImporter(importer_storage)
+        result = importer.import_file(self._write_chatgpt_export(tmp_path))
+        assert result.success
+        assert result.conversations_imported == 1
+        original_id = result.imported_ids[0]
+
+        # Step 2: build minimal index.json so the exporter can find it.
+        # ChatGPT importer doesn't update index.json, so do it manually
+        # (mirrors what ConversationMemoryServer._sync_index_from_files does).
+        conv_file = next(importer_storage.rglob("conv_*.json"))
+        index_entry = {
+            "id": original_id,
+            "title": "Round Trip 1",
+            "date": "2025-03-01T10:00:00",
+            "topics": [],
+            "file_path": str(conv_file.relative_to(storage_root)),
+            "added_at": "2025-03-01T10:00:00",
+        }
+        (importer_storage / "index.json").write_text(
+            json.dumps({"conversations": [index_entry]}, indent=2),
+            encoding="utf-8",
+        )
+
+        # Step 3: export and validate.
+        out = tmp_path / "exported.json"
+        exporter = JsonExporter(storage_root)
+        export_result = exporter.export(out)
+        assert export_result.success
+        assert export_result.conversations_exported == 1
+
+        validation = exporter.validate(out)
+        assert validation["valid"], validation
+
+        payload = json.loads(out.read_text())
+        exported_conv = payload["conversations"][0]
+
+        # Key fields preserved verbatim from the universal-format file.
+        assert exported_conv["id"] == original_id
+        assert exported_conv["platform"] == "chatgpt"
+        assert exported_conv["title"] == "Round Trip 1"
+        assert exported_conv["model"] == "gpt-4"
+        assert len(exported_conv["messages"]) == 2
+        assert exported_conv["messages"][0]["role"] == "user"
+        assert exported_conv["messages"][1]["role"] == "assistant"
+        assert "Hello" in exported_conv["messages"][0]["content"]
+
+
+@pytest.mark.parametrize(
+    "filter_kwargs,expected_count",
+    [
+        ({}, 3),
+        ({"limit": 1}, 1),
+        ({"platforms": ["chatgpt"]}, 2),
+        ({"date_from": datetime(2025, 6, 1)}, 1),
+    ],
+)
+def test_filter_combinations(tmp_path, filter_kwargs, expected_count):
+    convs = [
+        _universal_conversation(
+            conv_id="a", platform="chatgpt", date="2025-01-01T00:00:00"
+        ),
+        _universal_conversation(
+            conv_id="b", platform="chatgpt", date="2025-12-01T00:00:00"
+        ),
+        _universal_conversation(
+            conv_id="c", platform="claude", date="2025-02-01T00:00:00"
+        ),
+    ]
+    _build_storage(tmp_path, convs)
+    out = tmp_path / "out.json"
+    exporter = JsonExporter(tmp_path)
+    result = exporter.export(out, Filters(**filter_kwargs))
+    assert result.conversations_exported == expected_count


### PR DESCRIPTION
## Summary

Adds a new `src/exporters/` package mirroring the existing `src/importers/` architecture so the project can write conversations out (universal JSON or ChatGPT format) the same way it can read them in. Closes todos 2.3.1, 2.3.2, 2.3.3, 2.3.4 (Stream D3).

### What's new

- **BaseExporter** (`src/exporters/base_exporter.py`) — abstract class with shared `load_conversations`, `apply_filters`, and `write_json` helpers. Loads from both the new `data/conversations/` layout and the legacy `conversations/` layout. Upgrades legacy on-disk records to universal shape on load so downstream exporters see a uniform input.
- **Filters** dataclass — `date_from`, `date_to`, `platforms` (case-insensitive list, `unknown` matches legacy entries), `limit`.
- **ExportResult** dataclass — success flag, exported/failed counts, errors, output path, metadata, plus `success_rate` / `total_processed` properties.
- **JsonExporter** — writes a versioned envelope `{format, format_version, exported_at, source_storage_path, conversation_count, filters_applied, conversations: [...]}`. `validate()` re-parses and checks each conversation has the universal required fields.
- **ChatgptExporter** — converts universal `messages` lists back into ChatGPT's `mapping` parent->child node structure (with a synthetic root) and emits epoch timestamps. `validate()` runs the output through the existing `schemas/chatgpt_schema.validate_chatgpt_export`.

### Tests

77 new tests in `tests/test_exporters/`, with **100% line coverage on `src/exporters/`**.

### Round-trip preservation

ChatGPTImporter -> JsonExporter preserves: id, platform, platform_id, model, title, messages, topics, date, created_at, import_metadata.

ChatGPTImporter -> ChatgptExporter passes the ChatGPT schema validator but is lossy on tree branching (collapsed to linear), per-message model_slug/request_id/tool-call metadata, and exact current_node selection.

## Out of scope (deferred)

- CLI command for invoking exporters.
- MCP tool wiring.
- Cursor and Claude exporters.
- Markdown / PDF output formats.
- Restoring exporter output as a re-importable ChatGPT export.

## Test plan

- [x] All 77 new tests pass.
- [x] Full local suite passes: 594 passed, 1 skipped.
- [x] 100% coverage on src/exporters/ (302/302 statements).
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, bandit, file checks).
- [ ] CI green.
- [ ] SonarCloud quality gate green.

Generated with Claude Code (https://claude.com/claude-code)