### PR TITLE
feat: wire Config.load() into server, logging, and path_utils

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,4 +1,10 @@
-"""Logging configuration for Claude Memory MCP system"""
+"""Logging configuration for Claude Memory MCP system.
+
+Settings (log level, log format, console output) are sourced from
+:class:`~config.Config`. Functions here accept an optional ``config``
+parameter; when omitted, ``Config.load(validate=False)`` is used so existing
+env-var-driven tests continue to work without modification.
+"""
 
 import json
 import logging
@@ -6,7 +12,7 @@ import logging.handlers
 import os
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 # Import path utilities for dynamic path resolution
 try:
@@ -14,6 +20,24 @@ try:
 except ImportError:
     # Fallback if path_utils is not available
     get_default_log_file = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - type-only import
+    from config import Config
+
+
+def _resolve_config(config: "Optional[Config]") -> "Config":
+    """Return ``config`` when supplied, otherwise build one from env+file.
+
+    Uses ``validate=False`` because logging setup is performed early in the
+    process lifecycle and we don't want to raise on (e.g.) a missing storage
+    directory just because someone wanted to write a log line.
+    """
+    if config is not None:
+        return config
+    from config import Config as _Config
+
+    return _Config.load(validate=False)
+
 
 # Control character removal pattern for log injection prevention
 CONTROL_CHAR_PATTERN = r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]"
@@ -108,20 +132,31 @@ class ColoredFormatter(logging.Formatter):
         return super().format(record)
 
 
-def _get_log_format() -> str:
+def _get_log_format(config: "Optional[Config]" = None) -> str:
     """
-    Get the log format from environment variable.
+    Get the log format, preferring an explicit :class:`~config.Config`.
 
-    Reads CLAUDE_MCP_LOG_FORMAT environment variable and validates the value.
-    Valid values are 'json' or 'text'. Defaults to 'text' for backward compatibility.
+    When ``config`` is omitted the value is sourced from
+    ``Config.load(validate=False)``, which still consults
+    ``CLAUDE_MCP_LOG_FORMAT`` (and the optional config file). Invalid values
+    fall back to ``"text"`` with a warning, preserving the historical behaviour
+    of this function.
+
+    Args:
+        config: Optional pre-loaded :class:`~config.Config` instance.
 
     Returns:
-        str: Log format ('json' or 'text')
+        str: Log format (``'json'`` or ``'text'``).
 
     Environment Variables:
         CLAUDE_MCP_LOG_FORMAT: Log output format (json|text). Default: text
     """
-    log_format = os.getenv("CLAUDE_MCP_LOG_FORMAT", "text").lower()
+    try:
+        cfg = _resolve_config(config)
+        log_format = (cfg.log_format or "text").lower()
+    except Exception:
+        # Defensive: never let a malformed config bring down logging setup.
+        log_format = os.getenv("CLAUDE_MCP_LOG_FORMAT", "text").lower()
 
     # Validate format value
     valid_formats = ["json", "text"]
@@ -143,6 +178,7 @@ def setup_logging(
     console_output: bool = True,
     max_bytes: int = 10_485_760,  # 10MB
     backup_count: int = 5,
+    config: "Optional[Config]" = None,
 ) -> logging.Logger:
     """
     Set up comprehensive logging for the application
@@ -153,6 +189,10 @@ def setup_logging(
         console_output: Whether to output to console
         max_bytes: Maximum size of log file before rotation
         backup_count: Number of backup files to keep
+        config: Optional pre-loaded :class:`~config.Config` instance.
+            When supplied, the log format is sourced from it; otherwise
+            ``Config.load(validate=False)`` is used (which still respects
+            ``CLAUDE_MCP_LOG_FORMAT``).
 
     Returns:
         Configured logger instance
@@ -167,8 +207,8 @@ def setup_logging(
     # Clear existing handlers
     logger.handlers = []
 
-    # Determine log format from environment variable
-    log_format = _get_log_format()
+    # Determine log format via Config (env-aware) or the explicit instance.
+    log_format = _get_log_format(config)
 
     # Create formatters based on log format
     file_formatter: logging.Formatter
@@ -376,27 +416,46 @@ def log_file_operation(operation: str, file_path: str, success: bool, **details)
 
 
 # Default logging setup for the application
-def init_default_logging():
-    """Initialize default logging configuration"""
-    # Get log level from environment or default to INFO
-    log_level = os.getenv("CLAUDE_MCP_LOG_LEVEL", "INFO")
+def init_default_logging(config: "Optional[Config]" = None):
+    """Initialize default logging configuration.
 
-    # Get log file path from environment or use default
+    Args:
+        config: Optional pre-loaded :class:`~config.Config`. When omitted,
+            ``Config.load(validate=False)`` is used so existing env-var-driven
+            behaviour is preserved (``CLAUDE_MCP_LOG_LEVEL``,
+            ``CLAUDE_MCP_CONSOLE_OUTPUT``).
+    """
+    cfg = _resolve_config(config)
+
+    # Log level from Config (already upper-cased on validate, but safe).
+    log_level = (cfg.log_level or "INFO").upper()
+
+    # Get log file path from environment or use default. ``CLAUDE_MCP_LOG_FILE``
+    # is not yet a Config field (deferred follow-up), so we still read it here.
     log_file = os.getenv("CLAUDE_MCP_LOG_FILE")
     if not log_file:
         if get_default_log_file is not None:
-            # Use path_utils for dynamic path resolution
-            log_file = str(get_default_log_file())
+            # Use path_utils for dynamic path resolution. The helper accepts an
+            # optional ``config`` kwarg in newer versions; older builds did not,
+            # so we try with ``cfg`` first and gracefully fall back.
+            try:
+                log_file = str(get_default_log_file(cfg))
+            except TypeError:
+                log_file = str(get_default_log_file())
         elif os.getenv("HOME"):
             # Fallback to manual construction
             log_file = os.path.join(
                 os.getenv("HOME"), ".claude-memory", "logs", "claude-mcp.log"
             )
 
-    # Disable console output for MCP server mode to prevent JSON-RPC interference
-    console_output = os.getenv("CLAUDE_MCP_CONSOLE_OUTPUT", "false").lower() == "true"
+    # Console output for MCP server mode (must remain False by default to
+    # avoid corrupting the JSON-RPC stream over stdout).
+    console_output = bool(cfg.console_output)
 
     # Set up logging
     return setup_logging(
-        log_level=log_level, log_file=log_file, console_output=console_output
+        log_level=log_level,
+        log_file=log_file,
+        console_output=console_output,
+        config=cfg,
     )

--- a/src/path_utils.py
+++ b/src/path_utils.py
@@ -2,11 +2,36 @@
 
 This module provides utilities for resolving paths dynamically to ensure
 the project works correctly regardless of installation location.
+
+The path-resolution helpers below accept an optional :class:`~config.Config`
+instance. When supplied, the helpers read paths from the config rather than
+re-reading environment variables. When omitted, they call
+``Config.load(validate=False)`` so existing call sites that rely on env-var
+behaviour continue to work unchanged.
 """
 
 import os
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - type-only import
+    from config import Config
+
+
+def _resolve_config(config: "Optional[Config]") -> "Config":
+    """Return ``config`` when supplied, otherwise build one from env+file.
+
+    ``validate=False`` is used because the path helpers are called from many
+    lightweight contexts (logging setup, importers, scripts) where attempting
+    to create the storage directory is unwanted side-effect.
+    """
+    if config is not None:
+        return config
+    # Local import keeps the module side-effect free at import time and
+    # avoids a circular import between ``path_utils`` and ``config``.
+    from config import Config as _Config
+
+    return _Config.load(validate=False)
 
 
 def get_project_root() -> Path:
@@ -41,35 +66,48 @@ def get_project_root() -> Path:
     raise RuntimeError("Could not determine project root directory")
 
 
-def get_data_directory() -> Path:
+def get_data_directory(config: "Optional[Config]" = None) -> Path:
     """Get the data directory for storing conversations.
 
     The directory is determined by the following priority:
-    1. CLAUDE_MEMORY_PATH environment variable
-    2. Default: ~/claude-memory/
+    1. ``config.storage_path`` (if ``config`` is provided)
+    2. ``CLAUDE_MEMORY_PATH`` environment variable (resolved via
+       :class:`~config.Config`)
+    3. Default: ``~/claude-memory/``
+
+    Args:
+        config: Optional pre-loaded :class:`~config.Config` instance. When
+            omitted, a fresh ``Config.load(validate=False)`` is used.
 
     Returns:
         Path: The data directory path
     """
-    # Check for environment variable override
-    env_path = os.environ.get("CLAUDE_MEMORY_PATH")
-    if env_path:
-        return Path(env_path).expanduser().resolve()
-
-    # Default to home directory location
-    return Path.home() / "claude-memory"
+    cfg = _resolve_config(config)
+    return cfg.resolved_storage_path()
 
 
-def get_log_directory() -> Path:
+def get_log_directory(config: "Optional[Config]" = None) -> Path:
     """Get the log directory for storing application logs.
 
     The directory is determined by:
-    1. CLAUDE_MCP_LOG_FILE environment variable (if set, extract directory)
-    2. Default: ~/.claude-memory/logs/
+    1. ``CLAUDE_MCP_LOG_FILE`` environment variable (if set, extract directory)
+    2. Default: ``~/.claude-memory/logs/``
+
+    ``CLAUDE_MCP_LOG_FILE`` is intentionally not part of :class:`~config.Config`
+    yet, so this function still reads it directly. The ``config`` parameter is
+    accepted for API symmetry and forward-compatibility.
+
+    Args:
+        config: Optional pre-loaded :class:`~config.Config` instance. Reserved
+            for forward compatibility; currently unused.
 
     Returns:
         Path: The log directory path
     """
+    # ``config`` is accepted for API symmetry; CLAUDE_MCP_LOG_FILE is not (yet)
+    # part of Config so we still read it directly here.
+    del config  # explicitly unused
+
     # Check if log file is specified
     log_file = os.environ.get("CLAUDE_MCP_LOG_FILE")
     if log_file:
@@ -79,13 +117,17 @@ def get_log_directory() -> Path:
     return Path.home() / ".claude-memory" / "logs"
 
 
-def get_default_log_file() -> Path:
+def get_default_log_file(config: "Optional[Config]" = None) -> Path:
     """Get the default log file path.
+
+    Args:
+        config: Optional pre-loaded :class:`~config.Config` instance, forwarded
+            to :func:`get_log_directory`.
 
     Returns:
         Path: The default log file path
     """
-    return get_log_directory() / "claude-mcp.log"
+    return get_log_directory(config) / "claude-mcp.log"
 
 
 def resolve_user_path(path: str) -> Path:

--- a/src/server_fastmcp.py
+++ b/src/server_fastmcp.py
@@ -12,6 +12,7 @@ from typing import Optional
 from mcp.server.fastmcp import FastMCP
 
 try:
+    from .config import Config
     from .conversation_memory import ConversationMemoryServer as CoreMemoryServer
     from .logging_config import (
         get_logger,
@@ -21,6 +22,7 @@ try:
     )
 except ImportError:
     # For direct imports during testing
+    from config import Config
     from conversation_memory import ConversationMemoryServer as CoreMemoryServer
     from logging_config import (
         get_logger,
@@ -72,11 +74,30 @@ COMMON_TECH_TERMS = [
 class FastMCPConversationMemoryServer(CoreMemoryServer):
     """FastMCP-specific wrapper around the core ConversationMemoryServer."""
 
+    # Sentinel used to detect "caller did not pass storage_path" so we can
+    # fall back to the Config-derived value while preserving the public API.
+    _DEFAULT_STORAGE_SENTINEL = "~/claude-memory"
+
     def __init__(
-        self, storage_path: str = "~/claude-memory", use_data_dir: Optional[bool] = None
+        self,
+        storage_path: str = _DEFAULT_STORAGE_SENTINEL,
+        use_data_dir: Optional[bool] = None,
+        config: Optional[Config] = None,
     ):
-        # Initialize logging for FastMCP
-        init_default_logging()
+        # Load (or accept) centralized configuration. Validation runs here so
+        # misconfiguration fails loudly at server startup rather than later.
+        # ConfigError is a ValueError subclass and is allowed to propagate.
+        self.config = config if config is not None else Config.load()
+
+        # If the caller didn't explicitly override storage_path, defer to
+        # the Config value (which honours CLAUDE_MEMORY_PATH and the config
+        # file). This keeps backwards compatibility: explicit args win.
+        if storage_path == self._DEFAULT_STORAGE_SENTINEL:
+            storage_path = self.config.storage_path
+
+        # Initialize logging using the (validated) Config so log_format /
+        # log_level / console_output flow from the same source.
+        init_default_logging(self.config)
         self.fastmcp_logger = get_logger("claude_memory_mcp.server")
 
         log_function_call(
@@ -89,9 +110,11 @@ class FastMCPConversationMemoryServer(CoreMemoryServer):
         storage_path_obj = Path(storage_path).expanduser().resolve()
         self._validate_storage_path(storage_path_obj)
 
-        # Initialize the core memory server with SQLite enabled
+        # Initialize the core memory server with SQLite per Config.
         super().__init__(
-            storage_path=storage_path, use_data_dir=use_data_dir, enable_sqlite=True
+            storage_path=storage_path,
+            use_data_dir=use_data_dir,
+            enable_sqlite=self.config.enable_sqlite,
         )
 
         self.fastmcp_logger.info(

--- a/tests/test_fastmcp_coverage.py
+++ b/tests/test_fastmcp_coverage.py
@@ -14,11 +14,12 @@ from pathlib import Path
 import pytest
 
 # Add src directory to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 try:
     import server_fastmcp
     from conversation_memory import ConversationMemoryServer
+
     FASTMCP_AVAILABLE = True
 except ImportError:
     FASTMCP_AVAILABLE = False
@@ -55,24 +56,25 @@ class TestWeeklySummaryGeneration:
         """Test weekly summary generation with conversations"""
         # Add conversations for current week (use UTC to match _calculate_week_range)
         from datetime import timezone
+
         current_time = datetime.now(timezone.utc).isoformat()
 
         await server.add_conversation(
             "Python coding discussion about functions and classes",
             "Coding Discussion",
-            current_time
+            current_time,
         )
 
         await server.add_conversation(
             "We decided to use FastMCP for our approach",
             "Decision Making",
-            current_time
+            current_time,
         )
 
         await server.add_conversation(
             "Learning how to implement MCP servers tutorial",
             "Learning Session",
-            current_time
+            current_time,
         )
 
         summary = await server.generate_weekly_summary(0)
@@ -89,13 +91,14 @@ class TestWeeklySummaryGeneration:
         """Test that weekly summary analyzes topics correctly"""
         # Use UTC time to match _calculate_week_range
         from datetime import timezone
+
         current_time = datetime.now(timezone.utc).isoformat()
 
         # Add conversation with multiple python mentions
         await server.add_conversation(
             "Python development with python libraries and python frameworks",
             "Python Discussion",
-            current_time
+            current_time,
         )
 
         summary = await server.generate_weekly_summary(0)
@@ -108,34 +111,38 @@ class TestWeeklySummaryGeneration:
         """Test that conversations are categorized correctly"""
         # Use UTC time to match _calculate_week_range
         from datetime import timezone
+
         current_time = datetime.now(timezone.utc).isoformat()
 
         # Add coding conversation
         await server.add_conversation(
             "Writing code for a new function with git repository management",
             "Coding Task",
-            current_time
+            current_time,
         )
 
         # Add decision conversation
         await server.add_conversation(
             "We decided to use the recommended approach for this feature",
             "Architecture Decision",
-            current_time
+            current_time,
         )
 
         # Add learning conversation
         await server.add_conversation(
             "Learning how to explain complex concepts in tutorials",
             "Learning Topic",
-            current_time
+            current_time,
         )
 
         summary = await server.generate_weekly_summary(0)
 
         # Check for category sections or conversation titles
         assert "💻 Coding & Development" in summary or "Coding Task" in summary
-        assert "🎯 Decisions & Recommendations" in summary or "Architecture Decision" in summary
+        assert (
+            "🎯 Decisions & Recommendations" in summary
+            or "Architecture Decision" in summary
+        )
         assert "📚 Learning & Exploration" in summary or "Learning Topic" in summary
 
     @pytest.mark.asyncio
@@ -151,12 +158,11 @@ class TestWeeklySummaryGeneration:
         """Test that weekly summary is saved to file"""
         # Use UTC time to match _calculate_week_range
         from datetime import timezone
+
         current_time = datetime.now(timezone.utc).isoformat()
 
         await server.add_conversation(
-            "Test conversation for file saving",
-            "File Save Test",
-            current_time
+            "Test conversation for file saving", "File Save Test", current_time
         )
 
         summary = await server.generate_weekly_summary(0)
@@ -189,7 +195,9 @@ class TestMCPToolFunctions:
     @pytest.mark.asyncio
     async def test_mcp_search_tool_no_results(self):
         """Test MCP search tool when no results found"""
-        result = await server_fastmcp.search_conversations("nonexistentquery12345", limit=5)
+        result = await server_fastmcp.search_conversations(
+            "nonexistentquery12345", limit=5
+        )
         assert "No conversations found" in result
 
     @pytest.mark.asyncio
@@ -199,7 +207,7 @@ class TestMCPToolFunctions:
         await server.add_conversation(
             "Testing MCP search tool functionality",
             "MCP Search Test",
-            "2025-06-01T11:00:00Z"
+            "2025-06-01T11:00:00Z",
         )
 
         # Test the MCP tool function
@@ -215,9 +223,7 @@ class TestMCPToolFunctions:
     async def test_mcp_add_conversation_tool(self):
         """Test the MCP add_conversation tool"""
         result = await server_fastmcp.add_conversation(
-            "Test content for MCP add tool",
-            "MCP Add Test",
-            "2025-06-01T12:00:00Z"
+            "Test content for MCP add tool", "MCP Add Test", "2025-06-01T12:00:00Z"
         )
 
         assert "Status: success" in result
@@ -228,9 +234,7 @@ class TestMCPToolFunctions:
         """Test MCP add_conversation tool error handling"""
         # Test with invalid date format
         result = await server_fastmcp.add_conversation(
-            "Test content",
-            "Error Test",
-            "invalid-date-format"
+            "Test content", "Error Test", "invalid-date-format"
         )
 
         # Should handle error gracefully
@@ -242,11 +246,10 @@ class TestMCPToolFunctions:
         # Add some test data
         # Use UTC time to match _calculate_week_range
         from datetime import timezone
+
         current_time = datetime.now(timezone.utc).isoformat()
         await server.add_conversation(
-            "Weekly summary test conversation",
-            "Weekly Test",
-            current_time
+            "Weekly summary test conversation", "Weekly Test", current_time
         )
 
         # Test weekly summary tool
@@ -264,13 +267,11 @@ class TestErrorHandlingAndEdgeCases:
         """Test search when conversation files are missing"""
         # Add a conversation normally
         result = await server.add_conversation(
-            "Test content",
-            "Test Title",
-            "2025-01-15T10:30:00"
+            "Test content", "Test Title", "2025-01-15T10:30:00"
         )
 
         # Remove the conversation file but keep index entry
-        file_path = Path(result['file_path'])
+        file_path = Path(result["file_path"])
         if file_path.exists():
             file_path.unlink()
 
@@ -288,13 +289,11 @@ class TestErrorHandlingAndEdgeCases:
             conversations_dir.chmod(0o444)  # Read-only
 
             result = await server.add_conversation(
-                "Test content",
-                "Error Test",
-                "2025-01-15T10:30:00"
+                "Test content", "Error Test", "2025-01-15T10:30:00"
             )
 
             # Should handle error gracefully
-            assert result['status'] in ['success', 'error']
+            assert result["status"] in ["success", "error"]
 
         finally:
             # Restore permissions for cleanup
@@ -305,18 +304,16 @@ class TestErrorHandlingAndEdgeCases:
         """Test index updates with corrupted JSON files"""
         # Corrupt the index file
         index_file = Path(temp_storage) / "data" / "conversations" / "index.json"
-        with open(index_file, 'w') as f:
+        with open(index_file, "w") as f:
             f.write("invalid json content")
 
         # This should either succeed by recreating the file or handle error gracefully
         result = await server.add_conversation(
-            "Test content after corruption",
-            "Corruption Test",
-            "2025-01-15T10:30:00"
+            "Test content after corruption", "Corruption Test", "2025-01-15T10:30:00"
         )
 
         # Check that operation either succeeded or failed gracefully
-        assert 'status' in result
+        assert "status" in result
 
     def test_topic_extraction_with_unicode(self, server):
         """Test topic extraction with unicode characters"""
@@ -341,16 +338,18 @@ class TestErrorHandlingAndEdgeCases:
     async def test_conversation_content_encoding_issues(self, server):
         """Test handling of various text encodings"""
         # Content with various special characters
-        special_content = "Content with special chars: àáâãäåæçèéêë ñ 中文 русский العربية"
+        special_content = (
+            "Content with special chars: àáâãäåæçèéêë ñ 中文 русский العربية"
+        )
 
         result = await server.add_conversation(
             content=special_content,
             title="Encoding Test",
-            conversation_date="2025-01-15T10:30:00"
+            conversation_date="2025-01-15T10:30:00",
         )
 
         # Should handle encoding gracefully
-        assert result['status'] == 'success'
+        assert result["status"] == "success"
 
         # Search should also handle special characters
         search_results = await server.search_conversations("special", limit=1)
@@ -371,10 +370,10 @@ Line 5: Final line
         result = await server.add_conversation(
             content=content,
             title="Preview Test",
-            conversation_date="2025-01-15T10:30:00"
+            conversation_date="2025-01-15T10:30:00",
         )
 
-        file_path = Path(result['file_path'])
+        file_path = Path(result["file_path"])
 
         # Test preview generation
         preview = server._get_preview(file_path, ["search", "term"])
@@ -397,6 +396,56 @@ Line 5: Final line
             assert str(test_date.year) in str(folder)
 
 
+@pytest.fixture
+def home_temp_storage():
+    """Temp storage directory created under HOME so FastMCP path validation passes."""
+    home = Path.home()
+    temp_dir = tempfile.mkdtemp(prefix="claude_memory_test_", dir=str(home))
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.mark.skipif(not FASTMCP_AVAILABLE, reason="FastMCP server not available")
+class TestFastMCPConfigWiring:
+    """Test the new ``config`` parameter on ``FastMCPConversationMemoryServer``."""
+
+    def test_init_uses_supplied_config(self, home_temp_storage):
+        """Passing an explicit Config bypasses Config.load() and sets storage."""
+        from config import Config
+
+        cfg = Config(storage_path=home_temp_storage, enable_sqlite=False)
+        srv = server_fastmcp.FastMCPConversationMemoryServer(config=cfg)
+
+        assert srv.config is cfg
+        # Storage path should be derived from Config when caller didn't override.
+        assert str(srv.storage_path) == str(Path(home_temp_storage).expanduser())
+        # enable_sqlite from Config is honoured.
+        assert srv.use_sqlite_search is False
+
+    def test_explicit_storage_path_overrides_config(self, home_temp_storage):
+        """Explicit ``storage_path`` argument wins over ``config.storage_path``."""
+        from config import Config
+
+        # Config points to a different directory (also under HOME so it validates).
+        other = tempfile.mkdtemp(prefix="other_storage_", dir=str(Path.home()))
+        try:
+            cfg = Config(storage_path=other, enable_sqlite=False)
+            srv = server_fastmcp.FastMCPConversationMemoryServer(
+                storage_path=home_temp_storage, config=cfg
+            )
+            assert str(srv.storage_path) == str(Path(home_temp_storage).expanduser())
+        finally:
+            shutil.rmtree(other, ignore_errors=True)
+
+
 if __name__ == "__main__":
     # Run tests with coverage
-    pytest.main([__file__, "-v", "--cov=server_fastmcp", "--cov-report=html", "--cov-report=term"])
+    pytest.main(
+        [
+            __file__,
+            "-v",
+            "--cov=server_fastmcp",
+            "--cov-report=html",
+            "--cov-report=term",
+        ]
+    )

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -26,9 +26,7 @@ class TestLoggingSetup:
 
     def test_setup_logging_console_only(self):
         """Test setting up console-only logging"""
-        logger = setup_logging(
-            log_level="DEBUG", console_output=True, log_file=None
-        )
+        logger = setup_logging(log_level="DEBUG", console_output=True, log_file=None)
 
         assert logger.level == logging.DEBUG
         assert len(logger.handlers) == 1
@@ -135,9 +133,7 @@ class TestLoggerHelpers:
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
 
-        log_function_call(
-            "test_function", param1="value1", param2=42, param3=None
-        )
+        log_function_call("test_function", param1="value1", param2=42, param3=None)
 
         mock_logger.debug.assert_called_once()
         call_args = mock_logger.debug.call_args[0][0]
@@ -187,10 +183,7 @@ class TestLoggerHelpers:
         mock_logger.log.assert_called_once()
         call_args = mock_logger.log.call_args
         assert call_args[0][0] == logging.CRITICAL
-        assert (
-            "Security Event: CRITICAL_BREACH | System compromised"
-            in call_args[0][1]
-        )
+        assert "Security Event: CRITICAL_BREACH | System compromised" in call_args[0][1]
 
     @patch("src.logging_config.get_logger")
     def test_log_validation_failure(self, mock_get_logger):
@@ -202,15 +195,10 @@ class TestLoggerHelpers:
         log_validation_failure("title", "normal title", "too long")
         # Verify the message is correct (ignore extra parameter)
         call_args = mock_logger.warning.call_args[0][0]
-        assert (
-            "Validation failed: title='normal title' | Reason: too long"
-            in call_args
-        )
+        assert "Validation failed: title='normal title' | Reason: too long" in call_args
 
         # Test with value containing newlines (should be escaped)
-        log_validation_failure(
-            "content", "line1\nline2\rline3", "invalid format"
-        )
+        log_validation_failure("content", "line1\nline2\rline3", "invalid format")
         call_args = mock_logger.warning.call_args[0][0]
         assert "line1\\nline2\\rline3" in call_args
 
@@ -226,9 +214,7 @@ class TestLoggerHelpers:
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
 
-        log_file_operation(
-            "create", "/path/to/file.txt", True, size=1024, topics=5
-        )
+        log_file_operation("create", "/path/to/file.txt", True, size=1024, topics=5)
 
         mock_logger.info.assert_called_once()
         call_args = mock_logger.info.call_args[0][0]
@@ -243,15 +229,12 @@ class TestLoggerHelpers:
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
 
-        log_file_operation(
-            "read", "/missing/file.txt", False, error="File not found"
-        )
+        log_file_operation("read", "/missing/file.txt", False, error="File not found")
 
         mock_logger.info.assert_called_once()
         call_args = mock_logger.info.call_args[0][0]
         assert (
-            "File read: /missing/file.txt | FAILED | error=File not found"
-            in call_args
+            "File read: /missing/file.txt | FAILED | error=File not found" in call_args
         )
 
 
@@ -288,9 +271,12 @@ class TestInitDefaultLogging:
         """Test default logging with environment variables"""
         init_default_logging()
 
-        mock_setup.assert_called_once_with(
-            log_level="DEBUG", log_file="/tmp/test.log", console_output=False
-        )
+        # Config is now also forwarded; assert on the relevant kwargs.
+        mock_setup.assert_called_once()
+        kwargs = mock_setup.call_args.kwargs
+        assert kwargs["log_level"] == "DEBUG"
+        assert kwargs["log_file"] == "/tmp/test.log"
+        assert kwargs["console_output"] is False
 
     @patch.dict(os.environ, {"HOME": "/home/user"}, clear=True)
     @patch("src.logging_config.setup_logging")
@@ -299,23 +285,23 @@ class TestInitDefaultLogging:
         init_default_logging()
 
         expected_log_file = "/home/user/.claude-memory/logs/claude-mcp.log"
-        mock_setup.assert_called_once_with(
-            log_level="INFO", log_file=expected_log_file, console_output=False
-        )
+        mock_setup.assert_called_once()
+        kwargs = mock_setup.call_args.kwargs
+        assert kwargs["log_level"] == "INFO"
+        assert kwargs["log_file"] == expected_log_file
+        assert kwargs["console_output"] is False
 
-    @patch.dict(
-        os.environ, {"CLAUDE_MCP_CONSOLE_OUTPUT": "true", "HOME": "/home/test"}
-    )
+    @patch.dict(os.environ, {"CLAUDE_MCP_CONSOLE_OUTPUT": "true", "HOME": "/home/test"})
     @patch("src.logging_config.setup_logging")
     def test_init_default_logging_console_enabled(self, mock_setup):
         """Test default logging with console output explicitly enabled"""
         init_default_logging()
 
-        mock_setup.assert_called_once_with(
-            log_level="INFO",
-            log_file="/home/test/.claude-memory/logs/claude-mcp.log",
-            console_output=True,
-        )
+        mock_setup.assert_called_once()
+        kwargs = mock_setup.call_args.kwargs
+        assert kwargs["log_level"] == "INFO"
+        assert kwargs["log_file"] == "/home/test/.claude-memory/logs/claude-mcp.log"
+        assert kwargs["console_output"] is True
 
 
 class TestLoggingIntegration:
@@ -326,9 +312,7 @@ class TestLoggingIntegration:
         with tempfile.TemporaryDirectory() as temp_dir:
             log_file = Path(temp_dir) / "nested" / "dirs" / "test.log"
 
-            logger = setup_logging(
-                log_file=str(log_file), console_output=False
-            )
+            logger = setup_logging(log_file=str(log_file), console_output=False)
             logger.info("Test message")
 
             assert log_file.exists()
@@ -346,9 +330,7 @@ class TestLoggingIntegration:
 
                 # Write enough data to trigger rotation
                 for i in range(50):
-                    logger.info(
-                        f"This is a test message number {i} with some padding"
-                    )
+                    logger.info(f"This is a test message number {i} with some padding")
 
                 # Check that backup files are created
                 base_name = temp_file.name
@@ -383,14 +365,10 @@ class TestLoggingExceptionHandling:
             # This should trigger the exception handling in log_function_call
             # The function should fail silently and not crash
             try:
-                log_function_call(
-                    "test_function", param1="value1", param2="value2"
-                )
+                log_function_call("test_function", param1="value1", param2="value2")
                 # Should not raise an exception due to silent failure
             except Exception as e:
-                pytest.fail(
-                    f"log_function_call should fail silently, but raised: {e}"
-                )
+                pytest.fail(f"log_function_call should fail silently, but raised: {e}")
 
     def test_log_performance_exception_handling(self):
         """Test log_performance exception handling (silent failure)"""
@@ -404,9 +382,7 @@ class TestLoggingExceptionHandling:
                 log_performance("test_function", 1.234, results=10)
                 # Should not raise an exception due to silent failure
             except Exception as e:
-                pytest.fail(
-                    f"log_performance should fail silently, but raised: {e}"
-                )
+                pytest.fail(f"log_performance should fail silently, but raised: {e}")
 
     def test_log_security_event_exception_handling(self):
         """Test log_security_event exception handling (silent failure)"""
@@ -420,9 +396,7 @@ class TestLoggingExceptionHandling:
                 log_security_event("TEST_EVENT", "Test message", "ERROR")
                 # Should not raise an exception due to silent failure
             except Exception as e:
-                pytest.fail(
-                    f"log_security_event should fail silently, but raised: {e}"
-                )
+                pytest.fail(f"log_security_event should fail silently, but raised: {e}")
 
     def test_security_event_path_redaction_failure(self):
         """Test log_security_event path redaction failure handling"""
@@ -537,9 +511,7 @@ class TestLoggingSecurity:
         call_args = mock_logger.warning.call_args[0][0]
         assert "\\n" in call_args
         assert "\\r" in call_args
-        assert (
-            "\n" not in call_args.split("'")[1]
-        )  # Not in the actual value part
+        assert "\n" not in call_args.split("'")[1]  # Not in the actual value part
 
     @patch("src.logging_config.get_logger")
     def test_value_truncation(self, mock_get_logger):
@@ -565,7 +537,9 @@ class TestLoggingSecurity:
         mock_get_logger.return_value = mock_logger
 
         # Test with details containing the word "path" to trigger path processing
-        details_with_paths = "Error accessing path /home/user/secret/file.txt and /var/log/sensitive.log"
+        details_with_paths = (
+            "Error accessing path /home/user/secret/file.txt and /var/log/sensitive.log"
+        )
         log_security_event("file_access", details_with_paths)
 
         # Verify that logging completed without error
@@ -603,3 +577,94 @@ class TestLoggingSecurity:
         log_security_event("event", "details")
         log_file_operation("op", "file", True)
         log_function_call("func", param="value")
+
+
+class TestConfigWiring:
+    """Tests for the new ``config`` parameter on logging helpers."""
+
+    def test_setup_logging_accepts_explicit_config(self, tmp_path):
+        """``setup_logging`` should derive log_format from an explicit Config."""
+        # Local import so the new field is exercised in the changed code.
+        import sys
+
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+        from config import Config  # type: ignore[import-not-found]
+
+        cfg = Config(storage_path=str(tmp_path), log_format="json")
+        log_file = tmp_path / "out.log"
+
+        logger = setup_logging(
+            log_level="INFO",
+            log_file=str(log_file),
+            console_output=False,
+            config=cfg,
+        )
+
+        # File handler exists.
+        assert any(hasattr(h, "baseFilename") for h in logger.handlers)
+        # The logger gets the JSON formatter when log_format='json'.
+        from src.logging_config import JSONFormatter
+
+        file_handler = next(h for h in logger.handlers if hasattr(h, "baseFilename"))
+        assert isinstance(file_handler.formatter, JSONFormatter)
+
+    def test_init_default_logging_accepts_explicit_config(self, tmp_path, monkeypatch):
+        """``init_default_logging`` should pull log level/console from Config."""
+        import sys
+
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+        from config import Config  # type: ignore[import-not-found]
+
+        # Make sure no log file env var leaks in.
+        monkeypatch.delenv("CLAUDE_MCP_LOG_FILE", raising=False)
+        cfg = Config(
+            storage_path=str(tmp_path),
+            log_level="WARNING",
+            console_output=True,
+        )
+        with patch("src.logging_config.setup_logging") as mock_setup:
+            init_default_logging(cfg)
+
+        mock_setup.assert_called_once()
+        kwargs = mock_setup.call_args.kwargs
+        assert kwargs["log_level"] == "WARNING"
+        assert kwargs["console_output"] is True
+        assert kwargs["config"] is cfg
+
+    def test_get_log_format_uses_explicit_config(self):
+        """``_get_log_format`` reads from the supplied Config when provided."""
+        import sys
+
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+        from config import Config  # type: ignore[import-not-found]
+        from src.logging_config import _get_log_format
+
+        cfg = Config(log_format="json")
+        assert _get_log_format(cfg) == "json"
+
+    def test_get_log_format_falls_back_when_config_load_fails(self, monkeypatch):
+        """If Config.load explodes, ``_get_log_format`` falls back to env."""
+        import sys
+
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+        import src.logging_config as lc
+
+        # Make Config.load raise so the defensive ``except Exception`` runs.
+        def _boom(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+            raise RuntimeError("simulated config failure")
+
+        monkeypatch.setattr("src.config.Config.load", classmethod(_boom))
+        # Also need to clear any cached module-level config import path.
+        monkeypatch.setenv("CLAUDE_MCP_LOG_FORMAT", "json")
+        assert lc._get_log_format() == "json"
+
+    def test_resolve_config_returns_supplied_instance(self, tmp_path):
+        """Sanity-check the helper used by both setup_logging and init."""
+        import sys
+
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+        from config import Config  # type: ignore[import-not-found]
+        from src.logging_config import _resolve_config
+
+        cfg = Config(storage_path=str(tmp_path))
+        assert _resolve_config(cfg) is cfg

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -5,7 +5,12 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from path_utils import (
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from config import Config  # noqa: E402
+from path_utils import (  # noqa: E402
+    _resolve_config,
     ensure_directory_exists,
     get_data_directory,
     get_default_log_file,
@@ -14,9 +19,6 @@ from path_utils import (
     get_uv_command,
     resolve_user_path,
 )
-
-# Add src to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
 class TestGetProjectRoot:
@@ -225,3 +227,41 @@ class TestGetUvCommand:
 
         result = get_uv_command()
         assert result is None
+
+
+class TestConfigWiring:
+    """Tests for the new ``config`` parameter on path-resolution helpers."""
+
+    def test_resolve_config_returns_supplied_instance(self, tmp_path):
+        """An explicit Config is returned unchanged (no env/file lookup)."""
+        cfg = Config(storage_path=str(tmp_path))
+        assert _resolve_config(cfg) is cfg
+
+    def test_resolve_config_loads_when_none(self, monkeypatch, tmp_path):
+        """Without an explicit config, env-driven Config.load is used."""
+        monkeypatch.setenv("CLAUDE_MEMORY_PATH", str(tmp_path))
+        # validate=False is used internally so this should never raise even
+        # when the storage path isn't writable.
+        cfg = _resolve_config(None)
+        assert isinstance(cfg, Config)
+        assert cfg.resolved_storage_path() == tmp_path.resolve()
+
+    def test_get_data_directory_uses_supplied_config(self, tmp_path):
+        """``get_data_directory`` should respect an explicit Config."""
+        cfg = Config(storage_path=str(tmp_path))
+        assert get_data_directory(cfg) == tmp_path.resolve()
+
+    def test_get_default_log_file_accepts_config(self, tmp_path):
+        """``get_default_log_file`` should accept a Config without raising."""
+        cfg = Config(storage_path=str(tmp_path))
+        # Even though Config doesn't (yet) drive the log-file location, the
+        # helper must not break when one is supplied.
+        log_file = get_default_log_file(cfg)
+        assert log_file.name == "claude-mcp.log"
+
+    def test_get_log_directory_accepts_config(self, tmp_path):
+        """``get_log_directory`` should accept a Config without raising."""
+        cfg = Config(storage_path=str(tmp_path))
+        # Same as above: parameter is reserved for forward-compat.
+        log_dir = get_log_directory(cfg)
+        assert log_dir.name == "logs"


### PR DESCRIPTION
## Summary

PR #111 introduced `src/config.py` (a `Config` dataclass with env > file > profile > default precedence) but no module consumed it. This PR wires `Config.load()` into the three modules that previously read the same env vars (`CLAUDE_MEMORY_PATH`, `CLAUDE_MCP_LOG_*`) directly.

This is **Stream D1** of the Config rollout. Other streams (importer metadata D2, exporters D3, scripts D4) are tracked separately.

## What changed

- **`src/path_utils`**: `get_data_directory` / `get_log_directory` / `get_default_log_file` now accept an optional `Config` and source `storage_path` from it. When omitted, they call `Config.load(validate=False)` so existing env-var-driven callers and tests keep working unchanged.
- **`src/logging_config`**: `_get_log_format` / `setup_logging` / `init_default_logging` now accept an optional `Config`. Log level / format / console output flow from the same source. `_get_log_format` keeps a defensive env-var fallback so a malformed config can never break logging.
- **`src/server_fastmcp.FastMCPConversationMemoryServer.__init__`**: builds (or accepts) a `Config` once at startup, runs `Config.validate()` so misconfiguration fails loud, and forwards `storage_path` / `enable_sqlite` to the core memory server. An explicit `storage_path` argument still wins over the Config value (backwards-compatible).

## Backwards compatibility

`Config.load()` reads the exact same env vars these modules previously consumed (`CLAUDE_MEMORY_PATH`, `CLAUDE_MCP_LOG_FORMAT`, `CLAUDE_MCP_LOG_LEVEL`, `CLAUDE_MCP_CONSOLE_OUTPUT`, `CLAUDE_MCP_PLATFORM_PROFILE`, `CLAUDE_MCP_ENABLE_SQLITE`), so no existing test had to change behaviour. The three `init_default_logging` tests had to update their assertions because `setup_logging` now also receives a `config=` kwarg.

## Tests

- 12 new tests covering: explicit-`Config` short-circuit on the resolver, env-only fallback, Config-driven storage path / log format, the defensive `Exception` fallback in `_get_log_format`, and explicit-storage-path override on the FastMCP server.
- **Result: 529 passing tests (+12 new), 0 regressions.**

## Test plan

- [x] Full suite passes locally (529 passed, 1 skipped)
- [x] `ruff check` + `ruff-format --check` pass on all changed files
- [x] `isort --check-only`, `black --check`, and `flake8` (CI's actual linters) pass
- [x] New tests added for the new `config=` parameter on every modified entry point
- [ ] CI green
- [ ] SonarCloud quality gate green

## Notes / follow-ups

- `CLAUDE_MCP_LOG_FILE` is still read directly in `init_default_logging`; promoting it to a `Config` field is a deferred follow-up.
- `mypy` pre-commit hook was skipped (`SKIP=mypy`) per the project's documented escape hatch in `.pre-commit-config.yaml`. The hook fails project-wide on `main` due to pre-existing dual-naming and missing-type-stub issues unrelated to this PR; CI's mypy job is gated off via `if: false` for the same reason.
- A future PR could promote `CLAUDE_MCP_LOG_FILE` into `Config` and (separately) clean up the project mypy setup so the hook runs cleanly across multi-file commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)