### PR TITLE
feat: add update_conversation MCP tool

### DIFF
--- a/src/conversation_memory.py
+++ b/src/conversation_memory.py
@@ -396,6 +396,260 @@ class ConversationMemoryServer:
                 "message": f"Failed to save conversation: {str(e)}",
             }
 
+    _CONVERSATION_ID_RE = re.compile(r"^conv_(\d{8})_(\d{6})_\d{4}$")
+
+    def _resolve_conversation_path(self, conversation_id: str) -> Optional[Path]:
+        """Resolve a conversation_id to its on-disk JSON path, or None if the
+        ID is malformed or the file is missing."""
+        match = self._CONVERSATION_ID_RE.match(conversation_id)
+        if not match:
+            return None
+        try:
+            date = datetime.strptime(match.group(1), "%Y%m%d")
+        except ValueError:
+            return None
+        year_folder = self.conversations_path / str(date.year)
+        month_folder = year_folder / (f"{date.month:02d}-{date.strftime('%B').lower()}")
+        file_path = month_folder / f"{conversation_id}.json"
+        return file_path if file_path.exists() else None
+
+    async def update_conversation(
+        self,
+        conversation_id: str,
+        *,
+        content: Optional[str] = None,
+        title: Optional[str] = None,
+        add_tags: Optional[List[str]] = None,
+        remove_tags: Optional[List[str]] = None,
+        set_tags: Optional[List[str]] = None,
+        conversation_type: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        change_note: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update fields on an existing conversation in place.
+
+        Mirrors ``add_conversation`` but operates on an existing record. The
+        first line of ``content`` is always rewritten with a self-documenting
+        change line — ``[update <iso-timestamp> — <change_note>]`` — so the
+        record carries its own audit trail (chained for repeated updates).
+
+        Tag ops: ``set_tags`` replaces the full list; ``add_tags`` /
+        ``remove_tags`` mutate it. ``set_tags`` is mutually exclusive with the
+        other two. Pass ``set_tags=[]`` to clear all tags.
+
+        Returns ``{"status": "success", ...}`` on success or
+        ``{"status": "error", "message": ...}`` on failure (malformed ID,
+        missing file, no-op call, conflicting tag ops, I/O error).
+        """
+        if set_tags is not None and (add_tags or remove_tags):
+            return {
+                "status": "error",
+                "message": ("set_tags is mutually exclusive with add_tags/remove_tags"),
+            }
+
+        file_path = self._resolve_conversation_path(conversation_id)
+        if file_path is None:
+            return {
+                "status": "error",
+                "message": (f"Conversation not found or invalid ID: {conversation_id}"),
+            }
+
+        try:
+            async with aiofiles.open(file_path, "r", encoding="utf-8") as f:
+                conversation_data = json.loads(await f.read())
+        except (OSError, ValueError) as e:
+            return {
+                "status": "error",
+                "message": f"Failed to read conversation: {str(e)}",
+            }
+
+        changes: List[str] = []
+
+        if title is not None and title != conversation_data.get("title"):
+            conversation_data["title"] = title
+            changes.append("title")
+
+        if content is not None:
+            conversation_data["content"] = content
+            changes.append("content")
+
+        if conversation_type is not None:
+            conversation_data["conversation_type"] = conversation_type
+            changes.append("conversation_type")
+
+        if session_id is not None:
+            conversation_data["session_id"] = session_id
+            changes.append("session_id")
+
+        if user_id is not None:
+            conversation_data["user_id"] = user_id
+            changes.append("user_id")
+
+        existing_tags = list(conversation_data.get("tags") or [])
+        new_tags = existing_tags
+        if set_tags is not None:
+            new_tags = list(dict.fromkeys(set_tags))
+        elif add_tags or remove_tags:
+            tags_set = list(dict.fromkeys(existing_tags))
+            for t in add_tags or []:
+                if t and t not in tags_set:
+                    tags_set.append(t)
+            if remove_tags:
+                remove_lookup = set(remove_tags)
+                tags_set = [t for t in tags_set if t not in remove_lookup]
+            new_tags = tags_set
+        if new_tags != existing_tags:
+            conversation_data["tags"] = new_tags
+            changes.append("tags")
+
+        if not changes and change_note is None:
+            return {
+                "status": "error",
+                "message": "No changes provided",
+            }
+
+        # Compose blockchain-style audit line and prepend to content.
+        timestamp = datetime.now().isoformat(timespec="seconds")
+        note = change_note if change_note else "; ".join(changes) or "no-op"
+        audit_line = f"[update {timestamp} — {note}]"
+        body = conversation_data.get("content", "")
+        conversation_data["content"] = f"{audit_line}\n\n{body}"
+
+        # Re-extract topics now that content has changed.
+        old_topics = list(conversation_data.get("topics") or [])
+        new_topics = self._extract_topics(conversation_data["content"])
+        conversation_data["topics"] = new_topics
+        conversation_data["updated_at"] = datetime.now().isoformat()
+
+        try:
+            async with aiofiles.open(file_path, "w", encoding="utf-8") as f:
+                await f.write(
+                    json.dumps(conversation_data, indent=2, ensure_ascii=False)
+                )
+        except OSError as e:
+            return {
+                "status": "error",
+                "message": f"Failed to write conversation: {str(e)}",
+            }
+
+        # Resync derived stores. INSERT OR REPLACE on the SQLite row also
+        # cascades through the FTS triggers, so the FTS index stays current.
+        if self.use_sqlite_search and self.search_db:
+            relative_path = str(file_path.relative_to(self.storage_path))
+            self.search_db.add_conversation(conversation_data, relative_path)
+
+        self._replace_index_entry(conversation_data, file_path)
+        self._resync_topics_index(old_topics, new_topics, conversation_id)
+
+        return {
+            "status": "success",
+            "id": conversation_id,
+            "file_path": str(file_path),
+            "changes": changes,
+            "audit_line": audit_line,
+            "message": (
+                f"Conversation {conversation_id} updated "
+                f"({', '.join(changes) if changes else 'note-only'})"
+            ),
+        }
+
+    def _replace_index_entry(self, conversation_data: Dict, file_path: Path):
+        """Replace (or insert) the index.json entry for a conversation."""
+        try:
+            with open(self.index_file, "r") as f:
+                index_data = json.load(f)
+
+            relative_path = file_path.relative_to(self.storage_path)
+            new_entry = {
+                "id": conversation_data["id"],
+                "title": conversation_data["title"],
+                "date": conversation_data["date"],
+                "topics": conversation_data["topics"],
+                "file_path": str(relative_path),
+                "added_at": datetime.now().isoformat(),
+            }
+
+            conversations = index_data.get("conversations", [])
+            replaced = False
+            for i, entry in enumerate(conversations):
+                if entry.get("id") == conversation_data["id"]:
+                    # Preserve original added_at if present so the entry's
+                    # creation time isn't rewritten on every update.
+                    if "added_at" in entry:
+                        new_entry["added_at"] = entry["added_at"]
+                    conversations[i] = new_entry
+                    replaced = True
+                    break
+            if not replaced:
+                conversations.append(new_entry)
+
+            index_data["conversations"] = conversations
+            index_data["last_updated"] = datetime.now().isoformat()
+
+            with open(self.index_file, "w") as f:
+                json.dump(index_data, f, indent=2)
+
+        except (OSError, ValueError, KeyError, TypeError) as e:
+            self.logger.error(f"Error replacing index entry: {e}")
+
+    def _resync_topics_index(
+        self,
+        old_topics: List[str],
+        new_topics: List[str],
+        conversation_id: str,
+    ):
+        """Update the topics index after a content change: drop entries for
+        topics no longer present, add entries for newly-extracted topics.
+        Topics still present after the update are left untouched so we don't
+        churn ``added_at`` timestamps."""
+        try:
+            with open(self.topics_file, "r") as f:
+                topics_data = json.load(f)
+        except (OSError, ValueError) as e:
+            self.logger.error(f"Error loading topics index: {e}")
+            return
+
+        topics_index = topics_data.get("topics", {})
+        old_set = set(old_topics)
+        new_set = set(new_topics)
+        dropped = old_set - new_set
+        added = new_set - old_set
+
+        for topic in dropped:
+            entries = topics_index.get(topic)
+            if not isinstance(entries, list):
+                continue
+            topics_index[topic] = [
+                e
+                for e in entries
+                if not (
+                    isinstance(e, dict) and e.get("conversation_id") == conversation_id
+                )
+            ]
+            if not topics_index[topic]:
+                del topics_index[topic]
+
+        for topic in added:
+            existing = topics_index.get(topic)
+            if not isinstance(existing, list):
+                topics_index[topic] = []
+            topics_index[topic].append(
+                {
+                    "conversation_id": conversation_id,
+                    "added_at": datetime.now().isoformat(),
+                }
+            )
+
+        topics_data["topics"] = topics_index
+        topics_data["last_updated"] = datetime.now().isoformat()
+
+        try:
+            with open(self.topics_file, "w") as f:
+                json.dump(topics_data, f, indent=2)
+        except OSError as e:
+            self.logger.error(f"Error writing topics index: {e}")
+
     def _calculate_search_score(
         self,
         query_terms: List[str],

--- a/src/server_fastmcp.py
+++ b/src/server_fastmcp.py
@@ -214,6 +214,48 @@ async def add_conversation(
 
 
 @mcp.tool()
+async def update_conversation(
+    conversation_id: str,
+    content: Optional[str] = None,
+    title: Optional[str] = None,
+    add_tags: Optional[List[str]] = None,
+    remove_tags: Optional[List[str]] = None,
+    set_tags: Optional[List[str]] = None,
+    conversation_type: Optional[str] = None,
+    session_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    change_note: Optional[str] = None,
+) -> str:
+    """Update fields on an existing conversation in place.
+
+    Pass ``conversation_id`` plus any subset of fields to change. The first
+    line of the stored content is rewritten with a self-documenting audit
+    line: ``[update <iso-timestamp> — <change_note>]``. If ``change_note`` is
+    omitted, it's auto-derived from which fields changed.
+
+    Tag ops: ``set_tags`` replaces the full list; ``add_tags`` and
+    ``remove_tags`` mutate it. ``set_tags`` is mutually exclusive with the
+    other two; pass ``set_tags=[]`` to clear all tags.
+    """
+    result = await memory_server.update_conversation(
+        conversation_id,
+        content=content,
+        title=title,
+        add_tags=add_tags,
+        remove_tags=remove_tags,
+        set_tags=set_tags,
+        conversation_type=conversation_type,
+        session_id=session_id,
+        user_id=user_id,
+        change_note=change_note,
+    )
+    response = f"Status: {result['status']}\n{result['message']}"
+    if result.get("audit_line"):
+        response += f"\nAudit: {result['audit_line']}"
+    return response
+
+
+@mcp.tool()
 async def generate_weekly_summary(week_offset: int = 0) -> str:
     """Generate a summary of conversations from the past week"""
     return await memory_server.generate_weekly_summary(week_offset)

--- a/tests/test_update_conversation.py
+++ b/tests/test_update_conversation.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Tests for ConversationMemoryServer.update_conversation."""
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "src"))
+
+from conversation_memory import ConversationMemoryServer  # noqa: E402
+
+
+SAMPLE_CONTENT = "# Test\n\nDiscussion of python MCP server setup with docker."
+
+
+@pytest.fixture
+def temp_storage():
+    temp_dir = tempfile.mkdtemp(prefix="claude_memory_update_test_")
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def server(temp_storage):
+    return ConversationMemoryServer(temp_storage)
+
+
+async def _seed(server, **kwargs):
+    """Create a conversation and return its ID + file path."""
+    result = await server.add_conversation(
+        content=kwargs.get("content", SAMPLE_CONTENT),
+        title=kwargs.get("title", "Original Title"),
+        conversation_date=kwargs.get("conversation_date", "2026-05-01T12:00:00"),
+        tags=kwargs.get("tags"),
+        conversation_type=kwargs.get("conversation_type"),
+        session_id=kwargs.get("session_id"),
+        user_id=kwargs.get("user_id"),
+    )
+    assert result["status"] == "success"
+    file_path = Path(result["file_path"])
+    conv_id = file_path.stem
+    return conv_id, file_path
+
+
+def _load(file_path):
+    with open(file_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.mark.asyncio
+async def test_update_content_prepends_audit_line(server):
+    conv_id, file_path = await _seed(server)
+    result = await server.update_conversation(
+        conv_id, content="New content about react and javascript"
+    )
+    assert result["status"] == "success"
+    assert "content" in result["changes"]
+
+    data = _load(file_path)
+    first_line = data["content"].split("\n", 1)[0]
+    assert first_line.startswith("[update ")
+    assert first_line.endswith("— content]")
+    # Body follows the audit line + blank line
+    assert "react" in data["content"]
+    # Topics re-extracted from new content
+    assert "react" in data["topics"]
+    assert "python" not in data["topics"]
+
+
+@pytest.mark.asyncio
+async def test_update_title_only_uses_title_in_audit(server):
+    conv_id, file_path = await _seed(server)
+    result = await server.update_conversation(conv_id, title="Renamed")
+    assert result["status"] == "success"
+    assert result["changes"] == ["title"]
+
+    data = _load(file_path)
+    assert data["title"] == "Renamed"
+    assert data["content"].splitlines()[0].endswith("— title]")
+
+
+@pytest.mark.asyncio
+async def test_set_tags_replaces_existing(server):
+    conv_id, file_path = await _seed(server, tags=["old1", "old2"])
+    result = await server.update_conversation(conv_id, set_tags=["new1", "new2"])
+    assert result["status"] == "success"
+    assert _load(file_path)["tags"] == ["new1", "new2"]
+
+
+@pytest.mark.asyncio
+async def test_add_tags_dedups_and_appends(server):
+    conv_id, file_path = await _seed(server, tags=["existing"])
+    result = await server.update_conversation(conv_id, add_tags=["existing", "neetu"])
+    assert result["status"] == "success"
+    assert _load(file_path)["tags"] == ["existing", "neetu"]
+
+
+@pytest.mark.asyncio
+async def test_remove_tags_drops_named(server):
+    conv_id, file_path = await _seed(server, tags=["a", "b", "c"])
+    result = await server.update_conversation(conv_id, remove_tags=["b"])
+    assert result["status"] == "success"
+    assert _load(file_path)["tags"] == ["a", "c"]
+
+
+@pytest.mark.asyncio
+async def test_set_tags_empty_clears(server):
+    conv_id, file_path = await _seed(server, tags=["a", "b"])
+    result = await server.update_conversation(conv_id, set_tags=[])
+    assert result["status"] == "success"
+    assert _load(file_path)["tags"] == []
+
+
+@pytest.mark.asyncio
+async def test_set_tags_conflicts_with_add_tags(server):
+    conv_id, _ = await _seed(server)
+    result = await server.update_conversation(conv_id, set_tags=["x"], add_tags=["y"])
+    assert result["status"] == "error"
+    assert "mutually exclusive" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_malformed_id_returns_error(server):
+    result = await server.update_conversation("not-a-real-id", title="x")
+    assert result["status"] == "error"
+    assert (
+        "not found" in result["message"].lower()
+        or "invalid" in result["message"].lower()
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_file_returns_error(server):
+    # Well-formed ID but no file on disk
+    result = await server.update_conversation("conv_20260501_120000_9999", title="x")
+    assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_no_changes_returns_error(server):
+    conv_id, _ = await _seed(server)
+    result = await server.update_conversation(conv_id)
+    assert result["status"] == "error"
+    assert "No changes" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_change_note_used(server):
+    conv_id, file_path = await _seed(server)
+    result = await server.update_conversation(
+        conv_id, add_tags=["neetu"], change_note="added Neetu per request"
+    )
+    assert result["status"] == "success"
+    first_line = _load(file_path)["content"].splitlines()[0]
+    assert "added Neetu per request" in first_line
+
+
+@pytest.mark.asyncio
+async def test_audit_line_chains_on_repeat_updates(server):
+    conv_id, file_path = await _seed(server)
+    await server.update_conversation(conv_id, title="First rename")
+    await server.update_conversation(conv_id, title="Second rename")
+
+    content_lines = _load(file_path)["content"].splitlines()
+    audit_lines = [ln for ln in content_lines if ln.startswith("[update ")]
+    # Two updates → two audit lines stacked at the top
+    assert len(audit_lines) == 2
+
+
+@pytest.mark.asyncio
+async def test_index_entry_replaced_not_duplicated(server):
+    conv_id, _ = await _seed(server)
+    await server.update_conversation(conv_id, title="Renamed in index")
+
+    with open(server.index_file, "r", encoding="utf-8") as f:
+        index = json.load(f)
+    matching = [c for c in index["conversations"] if c["id"] == conv_id]
+    assert len(matching) == 1
+    assert matching[0]["title"] == "Renamed in index"
+
+
+@pytest.mark.asyncio
+async def test_topics_index_drops_obsolete_topics(server):
+    conv_id, _ = await _seed(server)
+    # Replace content so old topics (python, mcp, docker) are gone
+    await server.update_conversation(
+        conv_id, content="Notes on react and javascript only"
+    )
+
+    with open(server.topics_file, "r", encoding="utf-8") as f:
+        topics_data = json.load(f)
+    topics = topics_data.get("topics", {})
+    # python should no longer reference this conversation
+    python_entries = topics.get("python", [])
+    assert all(e.get("conversation_id") != conv_id for e in python_entries)
+    # react should now reference it
+    react_entries = topics.get("react", [])
+    assert any(e.get("conversation_id") == conv_id for e in react_entries)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_search_reflects_updated_content(server):
+    if not server.use_sqlite_search:
+        pytest.skip("SQLite search unavailable")
+    conv_id, _ = await _seed(server)
+    await server.update_conversation(
+        conv_id, content="Brand new keyword: zebracorn appears here"
+    )
+    results = await server.search_conversations("zebracorn", limit=5)
+    assert any(r.get("id") == conv_id for r in results)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_search_reflects_updated_tags(server):
+    if not server.use_sqlite_search:
+        pytest.skip("SQLite search unavailable")
+    conv_id, _ = await _seed(server, tags=["original"])
+    await server.update_conversation(conv_id, add_tags=["neetu"])
+
+    tag_results = await server.search_by_tag("neetu", limit=5)
+    assert any(r.get("id") == conv_id for r in tag_results)
+
+
+@pytest.mark.asyncio
+async def test_update_metadata_fields(server):
+    """conversation_type / session_id / user_id all flow through."""
+    conv_id, file_path = await _seed(server)
+    result = await server.update_conversation(
+        conv_id,
+        conversation_type="document-transcription",
+        session_id="sess-123",
+        user_id="user-456",
+    )
+    assert result["status"] == "success"
+    assert set(result["changes"]) == {
+        "conversation_type",
+        "session_id",
+        "user_id",
+    }
+    data = _load(file_path)
+    assert data["conversation_type"] == "document-transcription"
+    assert data["session_id"] == "sess-123"
+    assert data["user_id"] == "user-456"
+
+
+@pytest.mark.asyncio
+async def test_well_formed_id_invalid_date_returns_error(server):
+    """ID matches the regex but encodes a non-existent calendar date."""
+    result = await server.update_conversation("conv_20269999_120000_0001", title="x")
+    assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_updated_at_set(server):
+    conv_id, file_path = await _seed(server)
+    await server.update_conversation(conv_id, title="x")
+    data = _load(file_path)
+    assert "updated_at" in data


### PR DESCRIPTION
## Summary

Adds an `update_conversation` MCP tool (and corresponding core method on `ConversationMemoryServer`) so existing memory entries can be modified in place — title, content, tags (add/remove/set), `conversation_type`, `session_id`, `user_id` — without having to re-save as a new record and leave a stale duplicate behind.

Each update prepends a self-documenting audit line to the content:
```
[update 2026-05-05T12:34:56 — added Neetu per request]
```
Repeat updates stack their audit lines at the top, giving a chained, in-content audit trail (the "blockchain-like" pattern requested by the user). If `change_note` is omitted, it's auto-derived from which fields changed (e.g. `title; tags`).

The update path resyncs all three derived stores in one call:
- The conversation JSON file on disk
- The SQLite FTS index (via `INSERT OR REPLACE` on the main row, which fires the existing FTS triggers)
- `index.json` (replaces the matching entry, preserving original `added_at`)
- `topics.json` (drops obsolete topic refs, adds new ones, leaves unchanged topics untouched)

Tag op semantics:
- `set_tags=[...]` replaces the full list (and `set_tags=[]` clears it)
- `add_tags=[...]` / `remove_tags=[...]` mutate the existing list
- `set_tags` is mutually exclusive with the other two

## Files

- `src/conversation_memory.py` — new `update_conversation()` method + `_resolve_conversation_path()`, `_replace_index_entry()`, `_resync_topics_index()` helpers
- `src/server_fastmcp.py` — `@mcp.tool() update_conversation(...)`
- `tests/test_update_conversation.py` — 19 new tests

## Test plan

- [x] All 19 new unit tests pass
- [x] Full suite passes (705 passing, 1 skipped)
- [x] Coverage on `conversation_memory.py` at 89% (new code well above 80%)
- [ ] CI green (Quick Validation, SonarCloud, build)
- [ ] Manual smoke test against a real memory entry once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)