### PR TITLE
fix: replace hash-based conversation IDs with UUID to prevent collisions

### DIFF
--- a/src/conversation_memory.py
+++ b/src/conversation_memory.py
@@ -9,6 +9,7 @@ shared between the FastMCP server and standalone implementations.
 import json
 import logging
 import re
+import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -335,7 +336,7 @@ class ConversationMemoryServer:
 
             # Create conversation record
             conversation_id = (
-                f"conv_{date.strftime('%Y%m%d_%H%M%S')}_{hash(content) % 10000:04d}"
+                f"conv_{date.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
             )
 
             date_folder = self._get_date_folder(date)
@@ -396,7 +397,7 @@ class ConversationMemoryServer:
                 "message": f"Failed to save conversation: {str(e)}",
             }
 
-    _CONVERSATION_ID_RE = re.compile(r"^conv_(\d{8})_(\d{6})_\d{4}$")
+    _CONVERSATION_ID_RE = re.compile(r"^conv_(\d{8})_(\d{6})_[\w]+$")
 
     def _resolve_conversation_path(self, conversation_id: str) -> Optional[Path]:
         """Resolve a conversation_id to its on-disk JSON path, or None if the


### PR DESCRIPTION
## Summary

- Replaces `hash(content) % 10000` with `uuid.uuid4().hex[:8]` in `conversation_id` generation
- Updates `_CONVERSATION_ID_RE` regex from `\d{4}$` to `[\w]+$` to accept both old and new ID formats
- Fixes a latent hash-collision bug that caused silent data loss in the weekly summary

## Problem

Conversations added in the same second could share the same `conv_YYYYMMDD_HHMMSS_NNNN` ID when `hash(content) % 10000` collided for different content strings. The second write would overwrite the first file, making the first conversation's title disappear from weekly summaries.

This was exposed as `test_weekly_summary_detailed_analysis` failing in CI (PR #130), where three conversations are added in rapid succession. With second-precision timestamps and a 10,000-bucket hash, collision probability per pair is ~0.01% — low but non-zero, and deterministic for a given `PYTHONHASHSEED`.

## Fix

UUID hex fragments guarantee uniqueness regardless of timing or hash seed. The timestamp component is preserved so date-based folder routing (`YYYYMMDD`) still works. The regex is loosened to `[\w]+` so `_resolve_conversation_path` handles both old-format IDs (`_1234`) and new-format IDs (`_a1b2c3d4`) correctly.

## Test plan

- [x] Full test suite: 700 passed, 1 skipped (no regressions)
- [x] `test_weekly_summary_detailed_analysis` passes (the specific test that was failing in #130)
- [x] Old-format IDs (`conv_YYYYMMDD_HHMMSS_NNNN`) still match the updated regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)