### PR TITLE
chore(ci): add workflow concurrency block

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,9 @@
 name: Build and analyze
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary

- Adds `concurrency:` to `build.yml` to cancel in-progress runs on new pushes
- Prevents multiple workflow runs from stacking up when commits are pushed rapidly, saving CI minutes

## Test plan

- [ ] Verify `build.yml` triggers correctly on push/PR to main
- [ ] Push two commits in quick succession and confirm the first run is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)