### PR TITLE
feat: surface popular_tags and conversation_types in get_search_stats

### DIFF
--- a/src/server_fastmcp.py
+++ b/src/server_fastmcp.py
@@ -372,6 +372,16 @@ async def get_search_stats() -> str:
                 f"  - {topic_info['topic']}: {topic_info['count']} conversations\n"
             )
 
+    if stats.get("popular_tags"):
+        response += "\nPopular Tags:\n"
+        for tag_info in stats["popular_tags"][:5]:
+            response += f"  - {tag_info['tag']}: {tag_info['count']} conversations\n"
+
+    if stats.get("conversation_types"):
+        response += "\nConversation Types:\n"
+        for type_info in stats["conversation_types"]:
+            response += f"  - {type_info['type']}: {type_info['count']}\n"
+
     if "sqlite_error" in stats:
         response += f"\nSQLite Error: {stats['sqlite_error']}\n"
 

--- a/tests/test_fastmcp_coverage.py
+++ b/tests/test_fastmcp_coverage.py
@@ -336,6 +336,50 @@ class TestMCPToolFunctions:
         assert "**1. Z**" in result
 
     @pytest.mark.asyncio
+    async def test_mcp_get_search_stats_tool_surfaces_tags_and_types(self, monkeypatch):
+        """get_search_stats MCP tool renders popular_tags/conversation_types."""
+
+        async def fake_stats():
+            return {
+                "sqlite_available": True,
+                "sqlite_enabled": True,
+                "search_engine": "sqlite_fts",
+                "popular_tags": [{"tag": "starred", "count": 3}],
+                "conversation_types": [{"type": "code", "count": 5}],
+            }
+
+        monkeypatch.setattr(
+            server_fastmcp.memory_server, "get_search_stats", fake_stats
+        )
+
+        result = await server_fastmcp.get_search_stats()
+        assert "Popular Tags:" in result
+        assert "- starred: 3 conversations" in result
+        assert "Conversation Types:" in result
+        assert "- code: 5" in result
+
+    @pytest.mark.asyncio
+    async def test_mcp_get_search_stats_tool_omits_empty_sections(self, monkeypatch):
+        """No tags/conversation_types yet -> no empty section headers."""
+
+        async def fake_stats():
+            return {
+                "sqlite_available": True,
+                "sqlite_enabled": True,
+                "search_engine": "sqlite_fts",
+                "popular_tags": [],
+                "conversation_types": [],
+            }
+
+        monkeypatch.setattr(
+            server_fastmcp.memory_server, "get_search_stats", fake_stats
+        )
+
+        result = await server_fastmcp.get_search_stats()
+        assert "Popular Tags:" not in result
+        assert "Conversation Types:" not in result
+
+    @pytest.mark.asyncio
     async def test_mcp_metadata_tool_renders_error_marker(self, monkeypatch):
         """Error marker from underlying server surfaces in the tool output."""
 


### PR DESCRIPTION
## Summary
- `SearchDatabase.get_conversation_stats()` (src/search_database.py) already computes `popular_tags` and a `conversation_types` breakdown, and `ConversationMemoryServer.get_search_stats()` already merges them into the stats dict returned to the MCP layer.
- The `get_search_stats` MCP tool (src/server_fastmcp.py) formatted `popular_topics` but silently dropped `popular_tags` and `conversation_types` — the data was computed and thrown away.
- This PR surfaces both, matching the existing `Popular Topics:` formatting style. Empty case (no tags / no conversation types) skips the section header entirely instead of emitting an empty block.

Closes todos.md item 5.4.4.

## Test plan
- [x] Added `test_mcp_get_search_stats_tool_surfaces_tags_and_types` — verifies both sections render with expected formatting
- [x] Added `test_mcp_get_search_stats_tool_omits_empty_sections` — verifies empty `popular_tags`/`conversation_types` produce no section headers
- [x] Full suite: `PYTHONPATH=. python -m pytest tests/ --ignore=tests/standalone_test.py --ignore=tests/test_performance_benchmarks.py --cov=src --cov-report=term` → 706 passed, 1 skipped (matches baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)