### PR TITLE
feat: add correlation IDs for request tracing

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -6,11 +6,13 @@ parameter; when omitted, ``Config.load(validate=False)`` is used so existing
 env-var-driven tests continue to work without modification.
 """
 
+import contextvars
 import json
 import logging
 import logging.handlers
 import os
 import sys
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -44,6 +46,54 @@ CONTROL_CHAR_PATTERN = r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]"
 
 # ISO 8601 datetime format for structured logging
 ISO_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+# Correlation ID for tracing a high-level operation (search, add_conversation,
+# weekly summary, ...) across log lines and await boundaries. A ContextVar
+# (not thread-local) is required because this codebase is async/aiofiles
+# throughout: each asyncio Task gets its own copy of the context, so
+# concurrent operations never see each other's correlation ID, while a single
+# operation's own await chain keeps seeing the value it set.
+_correlation_id: "contextvars.ContextVar[Optional[str]]" = contextvars.ContextVar(
+    "correlation_id", default=None
+)
+
+# Placeholder used in log output when no correlation ID is set for the
+# current context (e.g. logging during startup, before any operation began).
+NO_CORRELATION_ID = "-"
+
+
+def get_correlation_id() -> Optional[str]:
+    """Return the correlation ID for the current context, if any."""
+    return _correlation_id.get()
+
+
+def set_correlation_id(correlation_id: Optional[str] = None) -> str:
+    """Start (or attach to) a correlation ID for the current context.
+
+    Call this once at the top of a high-level operation (a search, an
+    ``add_conversation`` call, a weekly summary run). If ``correlation_id``
+    is omitted, a new UUID4 is generated. Every log record emitted for the
+    rest of this context — including across ``await`` boundaries within the
+    same asyncio Task — carries the returned ID.
+
+    Returns:
+        str: The correlation ID now active for this context.
+    """
+    value = correlation_id or str(uuid.uuid4())
+    _correlation_id.set(value)
+    return value
+
+
+class CorrelationIdFilter(logging.Filter):
+    """Attach the current context's correlation ID to every log record.
+
+    Always returns True (it never drops records) — it exists purely to
+    stamp ``record.correlation_id`` so formatters can include it.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.correlation_id = get_correlation_id() or NO_CORRELATION_ID
+        return True
 
 
 class JSONFormatter(logging.Formatter):
@@ -84,6 +134,12 @@ class JSONFormatter(logging.Formatter):
             "line": record.lineno,
             "message": record.getMessage(),
         }
+
+        # Add correlation ID if one is active for this context (set via
+        # CorrelationIdFilter, which runs before formatters see the record).
+        correlation_id = getattr(record, "correlation_id", None)
+        if correlation_id and correlation_id != NO_CORRELATION_ID:
+            log_data["correlation_id"] = correlation_id
 
         # Add context if present in the log record
         if hasattr(record, "context"):
@@ -204,8 +260,11 @@ def setup_logging(
     logger = logging.getLogger("claude_memory_mcp")
     logger.setLevel(getattr(logging, log_level.upper()))
 
-    # Clear existing handlers
+    # Clear existing handlers/filters (setup_logging may be called more than
+    # once, e.g. in tests, and filters would otherwise stack).
     logger.handlers = []
+    logger.filters = []
+    logger.addFilter(CorrelationIdFilter())
 
     # Determine log format via Config (env-aware) or the explicit instance.
     log_format = _get_log_format(config)
@@ -221,11 +280,12 @@ def setup_logging(
     else:
         # Use text formatters (default)
         file_formatter = logging.Formatter(
-            "%(asctime)s | %(levelname)-8s | %(name)s:%(lineno)d | %(funcName)s() | %(message)s",
+            "%(asctime)s | %(levelname)-8s | %(name)s:%(lineno)d | %(funcName)s() "
+            "| [%(correlation_id)s] | %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
         console_formatter = ColoredFormatter(
-            "%(asctime)s | %(levelname)-8s | %(funcName)s() | %(message)s",
+            "%(asctime)s | %(levelname)-8s | %(funcName)s() | [%(correlation_id)s] | %(message)s",
             datefmt="%H:%M:%S",
         )
 

--- a/src/server_fastmcp.py
+++ b/src/server_fastmcp.py
@@ -19,6 +19,7 @@ try:
         init_default_logging,
         log_function_call,
         log_security_event,
+        set_correlation_id,
     )
 except ImportError:
     # For direct imports during testing
@@ -29,6 +30,7 @@ except ImportError:
         init_default_logging,
         log_function_call,
         log_security_event,
+        set_correlation_id,
     )
 
 # Constants
@@ -180,6 +182,7 @@ memory_server = FastMCPConversationMemoryServer()
 @mcp.tool()
 async def search_conversations(query: str, limit: int = DEFAULT_SEARCH_LIMIT) -> str:
     """Search through stored Claude conversations for relevant content"""
+    set_correlation_id()
     results = await memory_server.search_conversations(query, limit)
 
     if not results:
@@ -218,6 +221,7 @@ async def add_conversation(
     (``search_by_tag`` / ``search_by_session_id`` /
     ``search_by_conversation_type``).
     """
+    set_correlation_id()
     result = await memory_server.add_conversation(
         content,
         title,
@@ -275,6 +279,7 @@ async def update_conversation(
 @mcp.tool()
 async def generate_weekly_summary(week_offset: int = 0) -> str:
     """Generate a summary of conversations from the past week"""
+    set_correlation_id()
     return await memory_server.generate_weekly_summary(week_offset)
 
 

--- a/tests/test_correlation_id.py
+++ b/tests/test_correlation_id.py
@@ -1,0 +1,140 @@
+"""
+Test suite for correlation ID support (issue #16).
+
+Covers: ContextVar get/set semantics, propagation across await boundaries,
+isolation between concurrent asyncio tasks, the CorrelationIdFilter, and
+JSONFormatter/text-formatter output.
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+from io import StringIO
+
+import pytest
+
+from src.logging_config import (
+    NO_CORRELATION_ID,
+    CorrelationIdFilter,
+    JSONFormatter,
+    get_correlation_id,
+    set_correlation_id,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_correlation_id():
+    """Every test starts (and ends) with no correlation ID set."""
+    from src.logging_config import _correlation_id
+
+    yield
+    _correlation_id.set(None)
+
+
+class TestCorrelationIdBasics:
+    def test_get_returns_none_when_unset(self):
+        assert get_correlation_id() is None
+
+    def test_set_generates_uuid4_when_omitted(self):
+        value = set_correlation_id()
+        assert get_correlation_id() == value
+        # Must be a valid UUID4 string
+        parsed = uuid.UUID(value, version=4)
+        assert str(parsed) == value
+
+    def test_set_uses_explicit_value(self):
+        value = set_correlation_id("my-explicit-id")
+        assert value == "my-explicit-id"
+        assert get_correlation_id() == "my-explicit-id"
+
+    def test_successive_calls_generate_different_ids(self):
+        first = set_correlation_id()
+        second = set_correlation_id()
+        assert first != second
+
+
+class TestCorrelationIdFilter:
+    def test_filter_stamps_record_and_always_returns_true(self):
+        set_correlation_id("stamped-id")
+        record = logging.LogRecord(
+            "test", logging.INFO, __file__, 1, "message", None, None
+        )
+        result = CorrelationIdFilter().filter(record)
+        assert result is True
+        assert record.correlation_id == "stamped-id"
+
+    def test_filter_uses_placeholder_when_unset(self):
+        record = logging.LogRecord(
+            "test", logging.INFO, __file__, 1, "message", None, None
+        )
+        CorrelationIdFilter().filter(record)
+        assert record.correlation_id == NO_CORRELATION_ID
+
+
+class TestCorrelationIdAsyncPropagation:
+    @pytest.mark.asyncio
+    async def test_propagates_across_await_boundary(self):
+        set_correlation_id("await-test-id")
+
+        async def inner():
+            await asyncio.sleep(0)
+            return get_correlation_id()
+
+        assert await inner() == "await-test-id"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_tasks_do_not_leak_ids(self):
+        async def operation(op_id: str):
+            set_correlation_id(op_id)
+            await asyncio.sleep(0.01)
+            # After the await, this task must still see its own ID, not a
+            # sibling task's ID.
+            return get_correlation_id()
+
+        results = await asyncio.gather(
+            operation("task-a"), operation("task-b"), operation("task-c")
+        )
+        assert results == ["task-a", "task-b", "task-c"]
+
+
+class TestCorrelationIdFormatterOutput:
+    def _make_json_logger(self):
+        logger = logging.getLogger("test_correlation_json_logger")
+        logger.setLevel(logging.DEBUG)
+        logger.handlers = []
+        logger.filters = []
+        logger.addFilter(CorrelationIdFilter())
+        buf = StringIO()
+        handler = logging.StreamHandler(buf)
+        handler.setFormatter(JSONFormatter())
+        logger.addHandler(handler)
+        return logger, buf
+
+    def test_json_output_includes_correlation_id_when_set(self):
+        logger, buf = self._make_json_logger()
+        set_correlation_id("json-corr-id")
+        logger.info("hello")
+        data = json.loads(buf.getvalue().strip())
+        assert data["correlation_id"] == "json-corr-id"
+
+    def test_json_output_omits_correlation_id_when_unset(self):
+        logger, buf = self._make_json_logger()
+        logger.info("hello")
+        data = json.loads(buf.getvalue().strip())
+        assert "correlation_id" not in data
+
+    def test_text_formatter_includes_correlation_id(self):
+        logger = logging.getLogger("test_correlation_text_logger")
+        logger.setLevel(logging.DEBUG)
+        logger.handlers = []
+        logger.filters = []
+        logger.addFilter(CorrelationIdFilter())
+        buf = StringIO()
+        handler = logging.StreamHandler(buf)
+        handler.setFormatter(logging.Formatter("%(message)s | [%(correlation_id)s]"))
+        logger.addHandler(handler)
+
+        set_correlation_id("text-corr-id")
+        logger.info("hello")
+        assert "[text-corr-id]" in buf.getvalue()


### PR DESCRIPTION
## Summary
- Adds correlation IDs so every log line for a single high-level operation (search, add_conversation, weekly summary) can be traced together, even across `await` boundaries.
- Uses `contextvars.ContextVar`, not thread-local storage, since this codebase is async/aiofiles throughout — thread-locals leak across await points in ways a ContextVar doesn't. Verified with a test that runs three concurrent `asyncio.gather()`'d operations and confirms none see each other's ID.
- `CorrelationIdFilter` stamps `record.correlation_id` on every `LogRecord`. `JSONFormatter` (from #14/#52, already on `main`) includes `correlation_id` in its output when one is active. Text formatters (file + console) now render `[%(correlation_id)s]`.
- `set_correlation_id()` / `get_correlation_id()` are the public API. `server_fastmcp.py` calls `set_correlation_id()` at the top of the three MCP tools the issue names: `search_conversations`, `add_conversation`, `generate_weekly_summary`.

## Branch note
Targets `main` directly. Issue #14 (structured JSON logging) — which this issue is nominally chained after — turned out to already be fully implemented on `main` (PR #53/#116, for near-duplicate issue #52). Closed #14 as a duplicate rather than opening a no-op PR; see the issue for the verification.

## Judgment call: correlation IDs in MCP tool responses
The issue also suggests adding correlation IDs to MCP tool responses for client-side tracing. Left this out: tool responses are plain human-readable strings, not structured JSON, so there's no clean additive way to attach an ID without changing the shape every MCP client sees (Claude Desktop, etc.) for a debugging aid that's already fully served by the log stream. Revisit if a concrete client-side tracing need shows up.

## Testing
- New `tests/test_correlation_id.py` (11 tests): get/set semantics, UUID4 generation, explicit IDs, the filter, propagation across an `await` boundary, isolation across concurrent asyncio tasks, and JSON/text formatter output.
- Full suite: `715 passed, 1 skipped` (was `704 passed, 1 skipped` on `main`), run via:
  `PYTHONPATH=. python -m pytest tests/ --ignore=tests/standalone_test.py --ignore=tests/test_performance_benchmarks.py --cov=src --cov-report=term`
- `src/logging_config.py` coverage: 94% (up from 93%); all uncovered lines are pre-existing gaps, none in the new correlation-ID code.
- `black --check` and `flake8` clean on all changed files.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)