### PR TITLE
fix: logging regression from PR #157/#160 — child-logger records silently dropped

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -89,11 +89,49 @@ class CorrelationIdFilter(logging.Filter):
 
     Always returns True (it never drops records) — it exists purely to
     stamp ``record.correlation_id`` so formatters can include it.
+
+    Not used by ``setup_logging()`` itself (see ``_install_correlation_id_
+    record_factory`` below for why) — kept as a standalone, directly
+    testable unit and for anyone building a logger by hand outside this
+    module's wiring.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
         record.correlation_id = get_correlation_id() or NO_CORRELATION_ID
         return True
+
+
+# Root fix for correlation IDs: a LogRecord factory, not a filter.
+#
+# A *logger's* filters only run for records emitted through that exact
+# logger — never for records propagating up from a child logger to the
+# parent's handlers (Handler.handle() calls the handler's own filters, but
+# nothing re-runs the ancestor Logger.filter() chain). This app logs
+# through child loggers (get_logger("claude_memory_mcp.server") etc.), so a
+# logger-level CorrelationIdFilter silently never fires for real traffic —
+# that was the bug. A record factory is called by logging.Logger.makeRecord
+# for *every* record, on *every* logger in the process (including
+# third-party ones), so it can't be bypassed by propagation the way a
+# filter can.
+_stdlib_record_factory = logging.getLogRecordFactory()
+
+
+def _correlation_id_record_factory(*args, **kwargs):
+    record = _stdlib_record_factory(*args, **kwargs)
+    record.correlation_id = get_correlation_id() or NO_CORRELATION_ID
+    return record
+
+
+def _install_correlation_id_record_factory() -> None:
+    """Install the correlation-id-stamping record factory, idempotently.
+
+    ``setup_logging()`` may be called many times in a process (tests do
+    this routinely). Re-checking ``is not`` before installing avoids
+    stacking wrapper-of-a-wrapper layers on repeated calls — each call
+    after the first is a no-op.
+    """
+    if logging.getLogRecordFactory() is not _correlation_id_record_factory:
+        logging.setLogRecordFactory(_correlation_id_record_factory)
 
 
 class SamplingFilter(logging.Filter):
@@ -109,6 +147,17 @@ class SamplingFilter(logging.Filter):
     sample away an error. ponytail: a plain per-type counter, not an
     adaptive-sampling engine; upgrade only if a real need for
     frequency-adaptive rates shows up.
+
+    This filter is stateful (the per-type counters), so ``setup_logging()``
+    attaches ONE shared instance to every handler on the logger rather than
+    a filter-per-handler — handler-level filters are required (see the
+    module-level note on ``CorrelationIdFilter``/record factory for why),
+    but a handler's ``Handler.handle()`` calls ``self.filter()``
+    independently for each handler that sees the record. With N handlers,
+    a plain counter would advance N times per record and silently sample
+    at N times the configured rate. The decision is cached on the record
+    itself the first time this instance sees it, so every subsequent
+    handler in the same emit reuses that decision instead of re-counting.
     """
 
     def __init__(self, sample_rates: Optional[dict] = None):
@@ -117,20 +166,29 @@ class SamplingFilter(logging.Filter):
         self._counters: dict = {}
 
     def filter(self, record: logging.LogRecord) -> bool:
+        cached = getattr(record, "_sampling_decision", None)
+        if cached is not None:
+            return cached
+
         if record.levelno >= logging.WARNING:
-            return True
+            decision = True
+        else:
+            context = getattr(record, "context", None)
+            op_type = (
+                context.get("type", "default")
+                if isinstance(context, dict)
+                else "default"
+            )
+            rate = self.sample_rates.get(op_type, 1)
+            if rate <= 1:
+                decision = True
+            else:
+                count = self._counters.get(op_type, 0) + 1
+                self._counters[op_type] = count
+                decision = count % rate == 0
 
-        context = getattr(record, "context", None)
-        op_type = (
-            context.get("type", "default") if isinstance(context, dict) else "default"
-        )
-        rate = self.sample_rates.get(op_type, 1)
-        if rate <= 1:
-            return True
-
-        count = self._counters.get(op_type, 0) + 1
-        self._counters[op_type] = count
-        return count % rate == 0
+        record._sampling_decision = decision
+        return decision
 
 
 class JSONFormatter(logging.Formatter):
@@ -314,8 +372,17 @@ def setup_logging(
     # once, e.g. in tests, and filters would otherwise stack).
     logger.handlers = []
     logger.filters = []
-    logger.addFilter(CorrelationIdFilter())
-    logger.addFilter(SamplingFilter(_get_log_sample_rates(config)))
+
+    # Correlation IDs are stamped via a record factory (see the module-level
+    # note above), not a logger filter — it works for propagated records too.
+    _install_correlation_id_record_factory()
+
+    # Sampling MUST be attached per-handler, not on the logger: this app
+    # logs through child loggers (get_logger("claude_memory_mcp.<name>")),
+    # and a logger's own filters never run for records that reach its
+    # handlers via propagation from a descendant logger. One shared
+    # instance is reused across handlers to avoid double-counting.
+    sampling_filter = SamplingFilter(_get_log_sample_rates(config))
 
     # Determine log format via Config (env-aware) or the explicit instance.
     log_format = _get_log_format(config)
@@ -345,6 +412,7 @@ def setup_logging(
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(console_formatter)
         console_handler.setLevel(getattr(logging, log_level.upper()))
+        console_handler.addFilter(sampling_filter)
         logger.addHandler(console_handler)
 
     # File handler with rotation
@@ -357,6 +425,7 @@ def setup_logging(
         )
         file_handler.setFormatter(file_formatter)
         file_handler.setLevel(logging.DEBUG)  # Always debug level for files
+        file_handler.addFilter(sampling_filter)
         logger.addHandler(file_handler)
 
     return logger

--- a/tests/test_log_sampling.py
+++ b/tests/test_log_sampling.py
@@ -113,17 +113,36 @@ class TestConfigWiring:
         # Never let a malformed config bring down logging setup.
         assert _get_log_sample_rates(_Broken()) == {}
 
-    def test_setup_logging_attaches_sampling_filter(self):
+    def test_setup_logging_attaches_sampling_filter(self, tmp_path):
+        # NOTE: this used to assert the filter lived on `logger.filters`.
+        # That encoded the bug this suite's sibling (test_logging_wiring.py)
+        # exists to catch: a logger's own filters never run for records that
+        # reach its handlers via propagation from a child logger (the
+        # pattern this app actually uses via get_logger()). The fix moves
+        # sampling to per-handler filters, so the assertion now checks the
+        # handlers instead.
         from config import Config
 
         cfg = Config(log_sample_rates={"performance": 7}, console_output=False)
-        logger = setup_logging(config=cfg)
-        sampling_filters = [f for f in logger.filters if isinstance(f, SamplingFilter)]
-        assert len(sampling_filters) == 1
-        assert sampling_filters[0].sample_rates == {"performance": 7}
+        logger = setup_logging(
+            config=cfg, log_file=str(tmp_path / "test.log"), console_output=False
+        )
+        assert logger.filters == []
+        for handler in logger.handlers:
+            sampling_filters = [
+                f for f in handler.filters if isinstance(f, SamplingFilter)
+            ]
+            assert len(sampling_filters) == 1
+            assert sampling_filters[0].sample_rates == {"performance": 7}
 
-    def test_setup_logging_default_config_disables_sampling(self):
-        logger = setup_logging()
-        sampling_filters = [f for f in logger.filters if isinstance(f, SamplingFilter)]
-        assert len(sampling_filters) == 1
-        assert sampling_filters[0].sample_rates == {}
+    def test_setup_logging_default_config_disables_sampling(self, tmp_path):
+        logger = setup_logging(
+            log_file=str(tmp_path / "test.log"), console_output=False
+        )
+        assert logger.filters == []
+        for handler in logger.handlers:
+            sampling_filters = [
+                f for f in handler.filters if isinstance(f, SamplingFilter)
+            ]
+            assert len(sampling_filters) == 1
+            assert sampling_filters[0].sample_rates == {}

--- a/tests/test_logging_wiring.py
+++ b/tests/test_logging_wiring.py
@@ -1,0 +1,177 @@
+"""
+End-to-end tests for the logging *wiring* set up by setup_logging().
+
+This file exists because PR #157 (correlation IDs) and PR #160 (log
+sampling) each shipped with unit tests for their filter *classes* only
+(instantiate the filter, call .filter(record) directly) and never asserted
+that a record survives the REAL configured logger end-to-end. Both filters
+were attached to the "claude_memory_mcp" logger itself, but the app logs
+through CHILD loggers (get_logger("claude_memory_mcp.server") etc.).
+Python only consults a logger's own filters for records it emits directly —
+never for records propagating up from a descendant logger to the parent's
+handlers. The result: every child-logger record hit the default TEXT
+formatter's "[%(correlation_id)s]" field with no such attribute set,
+raised, and was silently dropped. Application logging was dead in
+production for an hour before this was caught.
+
+These tests exercise the real setup_logging() -> child logger -> handler ->
+formatter path, the same path server_fastmcp.py uses, so a regression here
+fails loudly instead of passing on a technicality.
+"""
+
+import pytest
+
+from logging_config import (
+    SamplingFilter,
+    get_logger,
+    set_correlation_id,
+    setup_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_correlation_id():
+    """Mirrors test_correlation_id.py's fixture: don't leak a correlation ID
+    set by one test into whatever test (in this file or another) runs next
+    in the same process/thread."""
+    from logging_config import _correlation_id
+
+    yield
+    _correlation_id.set(None)
+
+
+class TestCorrelationIdEndToEnd:
+    """Mandatory test #1: default text format, child logger, no dropped
+    records, no formatting error."""
+
+    def test_child_logger_record_lands_in_file_with_default_text_format(
+        self, tmp_path, capsys
+    ):
+        log_file = tmp_path / "app.log"
+
+        # Default format ("text"), the same as init_default_logging() uses
+        # in production. console_output=False keeps stdout clean for the
+        # capsys assertion below.
+        setup_logging(log_file=str(log_file), console_output=False)
+
+        set_correlation_id("e2e-test-id")
+        child_logger = get_logger("claude_memory_mcp.server")
+        child_logger.info("child logger message")
+
+        # No "--- Logging error ---" / traceback should have been printed
+        # to stderr by Handler.handleError() (the KeyError path this bug
+        # hit lives there, since RotatingFileHandler swallows the
+        # exception rather than raising it out of .info()).
+        captured = capsys.readouterr()
+        assert "Logging error" not in captured.err
+        assert "KeyError" not in captured.err
+
+        # The line must actually be written — this is the assertion that
+        # fails outright on unfixed main: the record never reaches the file
+        # at all (the KeyError happens during formatting, inside the
+        # handler, after the record was already accepted).
+        contents = log_file.read_text()
+        assert "child logger message" in contents
+        assert "e2e-test-id" in contents
+
+
+class TestSamplingEndToEnd:
+    """Mandatory test #2: sampling actually samples through a child logger,
+    and WARNING/ERROR are never sampled."""
+
+    def test_sampling_through_child_logger_drops_records_at_configured_rate(
+        self, tmp_path
+    ):
+        from config import Config
+
+        log_file = tmp_path / "sampled.log"
+        rate = 5
+        cfg = Config(log_sample_rates={"noisy": rate})
+        setup_logging(config=cfg, log_file=str(log_file), console_output=False)
+
+        child_logger = get_logger("claude_memory_mcp.server")
+        total = 50
+        for i in range(total):
+            child_logger.info(f"noisy record {i}", extra={"context": {"type": "noisy"}})
+
+        lines = [
+            line for line in log_file.read_text().splitlines() if "noisy record" in line
+        ]
+        assert len(lines) == total // rate
+
+    def test_warning_and_error_are_never_sampled_through_child_logger(self, tmp_path):
+        from config import Config
+
+        log_file = tmp_path / "warnings.log"
+        # Absurdly high rate: if WARNING/ERROR were subject to sampling,
+        # essentially none of them would appear.
+        cfg = Config(log_sample_rates={"noisy": 1000})
+        setup_logging(config=cfg, log_file=str(log_file), console_output=False)
+
+        child_logger = get_logger("claude_memory_mcp.server")
+        for i in range(10):
+            child_logger.warning(f"warning {i}", extra={"context": {"type": "noisy"}})
+            child_logger.error(f"error {i}", extra={"context": {"type": "noisy"}})
+
+        contents = log_file.read_text()
+        for i in range(10):
+            assert f"warning {i}" in contents
+            assert f"error {i}" in contents
+
+
+class TestNoDoubleCountingAcrossHandlers:
+    """Mandatory test #3: a shared SamplingFilter instance on 2 handlers
+    must not double-count (i.e. must not sample at 2x the configured
+    rate)."""
+
+    def test_two_handlers_do_not_double_count(self, tmp_path):
+        from config import Config
+
+        log_file = tmp_path / "multi.log"
+        rate = 4
+        cfg = Config(log_sample_rates={"noisy": rate})
+        # console_output=True + log_file=... attaches TWO handlers
+        # (console StreamHandler and RotatingFileHandler) sharing the one
+        # SamplingFilter instance created inside setup_logging().
+        logger = setup_logging(config=cfg, log_file=str(log_file), console_output=True)
+
+        sampling_filters = {
+            id(f)
+            for handler in logger.handlers
+            for f in handler.filters
+            if isinstance(f, SamplingFilter)
+        }
+        # Exactly one shared instance, not one-per-handler.
+        assert len(sampling_filters) == 1
+
+        child_logger = get_logger("claude_memory_mcp.server")
+        total = 40
+        for i in range(total):
+            child_logger.info(f"noisy record {i}", extra={"context": {"type": "noisy"}})
+
+        # If the counter advanced once per handler (double-counting), the
+        # effective rate would be rate/2 and this would be total // (rate/2).
+        file_lines = [
+            line for line in log_file.read_text().splitlines() if "noisy record" in line
+        ]
+        assert len(file_lines) == total // rate
+
+
+def demo() -> None:
+    """ponytail: smallest runnable self-check, not a pytest replacement."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as d:
+        log_file = Path(d) / "demo.log"
+        setup_logging(log_file=str(log_file), console_output=False)
+        set_correlation_id("demo-id")
+        get_logger("claude_memory_mcp.server").info("demo message")
+        contents = log_file.read_text()
+        assert "demo message" in contents, "child-logger record was dropped"
+        assert "demo-id" in contents, "correlation id missing from output"
+    print("demo() OK")
+
+
+if __name__ == "__main__":
+    demo()


### PR DESCRIPTION
## Summary

**Live production regression.** PR #157 (correlation IDs) and PR #160 (log sampling — the task referenced #159, but that PR was never merged; #160 with the identical title is the one on main) both attached their filters to the `claude_memory_mcp` logger itself:

```python
logger = logging.getLogger("claude_memory_mcp")
logger.addFilter(CorrelationIdFilter())
logger.addFilter(SamplingFilter(...))
```

A logger's own filters only run for records it emits **directly** — never for records propagating up from a **child** logger to the parent's handlers. This app logs exclusively through child loggers (`get_logger("claude_memory_mcp.server")` etc.), so `CorrelationIdFilter` never actually ran for real traffic. The default TEXT formatter references `%(correlation_id)s`, which was never stamped on propagated records, so formatting raised `KeyError: 'correlation_id'` inside the handler and the record was silently dropped.

Verified: `~/.claude-memory/logs/claude-mcp.log` shows 8990 historical `claude_memory_mcp.server` lines, the last one at the moment #157 merged. Every application log line since has been dropped in production.

`SamplingFilter` (#160) has the identical defect — never runs on propagated child-logger records, so sampling is a complete no-op in practice.

`JSONFormatter` survived because it uses `getattr(record, "correlation_id", None)` instead of a format-string field — only the TEXT formatter (the default) died, which is why this shipped unnoticed.

## Why the tests missed it

11 correlation tests + 20 sampling tests all passed on #157/#160. Every one of them instantiates the filter class directly and calls `.filter(record)` — none of them exercised the real `setup_logging()` → child logger → handler → formatter path. The wiring itself was never tested.

## Fix

- **Correlation ID: moved from a filter to `logging.setLogRecordFactory()`.** A record factory runs for *every* record on *every* logger in the process (including third-party ones and anything propagating), so it can't be bypassed by propagation the way a logger-level filter can — root fix, not a patch on the symptom. Installation is idempotent (checked by object identity) so repeated `setup_logging()` calls, which the test suite does routinely, don't stack wrapped factories. Traded off against the global-state cost of a process-wide record factory; accepted because this app owns the whole process and nothing else in the codebase touches the factory.
- **Sampling: moved from the logger to each handler**, since sampling is genuinely stateful and factories aren't a good fit for "drop this record." Handler-level filters run for propagated records (unlike logger-level ones). One **shared** `SamplingFilter` instance is attached to all handlers rather than one instance per handler — a naive one-instance-per-handler (or shared-instance-with-independent-counting) setup would have each handler's `Handler.handle()` call `.filter()` independently on the *same* record, advancing the counter once per handler and silently sampling at N× the configured rate for N handlers. Fixed by caching the sampling decision on the record itself the first time the filter sees it and reusing that decision on later passes through other handlers.
- `logger.filters` is now always empty by design — handler-level filtering covers both direct and propagated records, so logger-level filters are redundant once the wiring is correct.
- Two existing tests in `test_log_sampling.py` (`test_setup_logging_attaches_sampling_filter`, `test_setup_logging_default_config_disables_sampling`) asserted `SamplingFilter` lived on `logger.filters` — that encoded the bug. Updated to assert per-handler placement.

## New tests (`tests/test_logging_wiring.py`)

All exercise the real `setup_logging()` → `get_logger()` (child) → handler → **default text formatter** path — the actual path `server_fastmcp.py` uses:

1. `test_child_logger_record_lands_in_file_with_default_text_format` — logs through a child logger, asserts the line actually lands in the file and no `Logging error`/`KeyError` was printed. **Fails on unfixed code** with the exact production symptom (`ValueError: Formatting field not found in record: 'correlation_id'`).
2. `test_sampling_through_child_logger_drops_records_at_configured_rate` / `test_warning_and_error_are_never_sampled_through_child_logger` — proves sampling actually samples through a child logger (N records at rate K → N/K lines) and WARNING/ERROR are never dropped.
3. `test_two_handlers_do_not_double_count` — two handlers share one `SamplingFilter` instance; asserts the effective rate isn't halved.

## Verification

`cd src && python3 -c "import server_fastmcp"` — clean import, no logging error:
```
INFO     SQLite FTS search enabled
INFO     FastMCP Server initialized with SQLite: True
CLEAN IMPORT
```

Full suite (throwaway venv built fresh for this worktree — the shared repo venv's editable `.pth` points at the main checkout, confirmed `import logging_config` resolved to the worktree path before trusting any result):
```
803 passed
```

New tests confirmed failing on unfixed code first (reproduced by stashing the fix and running `pytest tests/test_logging_wiring.py`), then passing after the fix — pasted in the session log.

`ruff check`, `ruff format --check`, and `mypy` all pass clean on the changed files (rebased onto latest `main`, which includes #156's mypy fix — the pre-existing, unrelated `Optional[str]` issue in `init_default_logging`'s `os.getenv("HOME")` fallback that blocked the pre-commit hook before rebasing is resolved on current `main`).

Closes the logging regression introduced by #157 and #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)