### PR TITLE
fix: validate storage_path in ConversationMemoryServer.__init__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,6 @@ benchmark_data/
 /test_*_*/
 /claude_memory_test_*/
 /*_test_*/
-/None/
 /test_*/
 /*test*/
 # Re-include the canonical tests directory (overrides /*test*/ above)

--- a/src/conversation_memory.py
+++ b/src/conversation_memory.py
@@ -28,6 +28,11 @@ try:
 except ImportError:
     SQLITE_AVAILABLE = False
 
+# Plain absolute import, matching the ``search_database`` import above and
+# validators.py's own header comment: ``src/`` is always a direct sys.path
+# entry, so no relative-import fallback is needed here.
+from validators import validate_storage_path
+
 
 class ConversationMemoryServer:
     def __init__(
@@ -36,6 +41,13 @@ class ConversationMemoryServer:
         use_data_dir: Optional[bool] = None,
         enable_sqlite: bool = True,
     ):
+        # Reject malformed storage_path values (empty, null bytes, the
+        # stringified-None sentinel, relative paths) before they're used to
+        # build any Path or create any directory. See validators.py for the
+        # full rationale -- this is the single choke point both this class
+        # and FastMCPConversationMemoryServer (which calls super().__init__)
+        # go through.
+        validate_storage_path(storage_path)
         self.storage_path = Path(storage_path).expanduser()
 
         # Auto-detect directory structure if not specified

--- a/src/validators.py
+++ b/src/validators.py
@@ -3,7 +3,8 @@
 import json
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
 # Plain absolute import, matching server_fastmcp.py/conversation_memory.py:
 # ``src/`` is always a direct sys.path entry, and server_fastmcp.py imports
@@ -232,6 +233,81 @@ def validate_limit(limit: int) -> int:
         return 100
 
     return limit
+
+
+def validate_storage_path(storage_path: Union[str, "Path", None]) -> str:
+    """Validate a ``storage_path`` before it is used to create directories.
+
+    This is the shared choke point for ``ConversationMemoryServer.__init__``
+    (and, by inheritance, ``FastMCPConversationMemoryServer``): it rejects
+    malformed values that would otherwise silently create bogus directories
+    relative to the current working directory -- e.g. ``""`` -> ``./data/``,
+    the stringified-None bug -> ``./None/``, or a bare relative string like
+    ``"evil-relative"`` -> ``./evil-relative/``.
+
+    This intentionally does NOT enforce location policy (``..`` traversal,
+    the home-directory jail). That's a separate, caller-specific concern
+    already handled by
+    ``FastMCPConversationMemoryServer._validate_storage_path`` -- duplicating
+    it here would mean two places to keep in sync.
+
+    Args:
+        storage_path: The raw storage_path value as passed to the
+            constructor (before ``~`` expansion).
+
+    Returns:
+        The original ``storage_path`` string, unchanged, once it passes
+        validation.
+
+    Raises:
+        MetadataValidationError: If storage_path is missing, not a
+            string/Path, empty/whitespace-only, contains a null byte, is a
+            stringified None/null/nil sentinel, or is not absolute once
+            ``~`` is expanded.
+    """
+    if storage_path is None:
+        raise MetadataValidationError("storage_path cannot be None")
+
+    if not isinstance(storage_path, (str, Path)):
+        raise MetadataValidationError(
+            f"storage_path must be a string or Path, got {type(storage_path).__name__}"
+        )
+
+    text = str(storage_path)
+
+    if not text.strip():
+        raise MetadataValidationError("storage_path cannot be empty or whitespace-only")
+
+    if NULL_BYTE_PATTERN.search(text):
+        raise MetadataValidationError("storage_path contains null bytes")
+
+    # Defense-in-depth: reject literal Python-sentinel strings. These almost
+    # always indicate an upstream bug where str(None) (or a similarly
+    # stringified null) was used to build the path -- without this guard the
+    # value passes every other check and happily creates a ./None/ (or
+    # ./null/) directory next to the cwd.
+    if text.strip().lower() in {"none", "null", "nil"}:
+        raise MetadataValidationError(
+            f"storage_path is the literal sentinel string {text!r} -- "
+            "likely an upstream bug where a None/null value was "
+            "stringified into the path."
+        )
+
+    # Relative paths are the actual harm here: they silently create
+    # directory trees relative to whatever the current working directory
+    # happens to be at import time, rather than the location the caller
+    # meant. Every legitimate caller in this codebase (tests via
+    # tempfile.mkdtemp, scripts via os.path.expanduser, the "~/claude-memory"
+    # default) already produces an absolute path, so this is a deliberate,
+    # non-breaking restriction -- not an accident.
+    if not Path(text).expanduser().is_absolute():
+        raise MetadataValidationError(
+            f"storage_path must be an absolute path (after ~ expansion); "
+            f"got {text!r}. Relative paths silently create directories "
+            "relative to the current working directory."
+        )
+
+    return text
 
 
 def _strip_control_chars(value: str) -> str:

--- a/tests/test_100_percent_coverage.py
+++ b/tests/test_100_percent_coverage.py
@@ -1392,20 +1392,30 @@ class TestServerExceptionCoverage:
             ConversationMemoryServer(restricted_path)
 
     def test_malformed_storage_path_handling(self):
-        """Test handling of malformed storage paths"""
+        """Malformed storage_path values must be rejected outright rather
+        than silently creating bogus directories relative to the cwd (e.g.
+        ``./None/`` for the string "None", or ``./data/`` for "").
+
+        See validators.py::validate_storage_path -- the shared choke point
+        both ConversationMemoryServer and FastMCPConversationMemoryServer
+        route through.
+        """
         malformed_paths = [
-            "",  # Empty path
-            "None",  # String "None"
+            "",  # Empty path -> would resolve into cwd
+            "   ",  # whitespace-only
+            "None",  # str(None) upstream bug -> would create ./None/
             "invalid\x00path",  # Path with null character
+            "evil-relative",  # relative -> would scribble into cwd
         ]
 
+        cwd_entries_before = set(Path.cwd().iterdir())
+
         for path in malformed_paths:
-            try:
+            with pytest.raises((ValueError, OSError, TypeError)):
                 ConversationMemoryServer(path)
-                # Some paths might be accepted and handled
-            except (ValueError, OSError, TypeError) as e:
-                # Expected for malformed paths
-                assert isinstance(e, (ValueError, OSError, TypeError))
+
+        # None of the rejected paths left a stray directory behind.
+        assert set(Path.cwd().iterdir()) == cwd_entries_before
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `ConversationMemoryServer.__init__` accepted any string as `storage_path` and used it to create directories unchecked: `""` resolved to cwd (scribbling `./data/` into the repo root), and `str(None)` ("None") created `./None/`. The real validation (`..` traversal + home-directory jail) lived only in the `FastMCPConversationMemoryServer` subclass, so every direct caller of the base class (most of the test suite, `scripts/bulk_import_enhanced.py`) went completely unvalidated.
- Added `validators.validate_storage_path()` as the shared choke point in the base class `__init__`: rejects `None`, non-str/Path types, empty/whitespace-only strings, null bytes, the stringified-None/null/nil sentinel, and non-absolute paths. Relative paths are the actual mechanism of harm (they resolve against whatever cwd happens to be); every legitimate caller in this repo already produces an absolute path (`tempfile.mkdtemp`, `os.path.expanduser`), so rejecting relative paths is safe and deliberate, not accidental.
- Deliberately did **not** duplicate the FastMCP subclass's `..`-traversal/home-jail policy check — that stays where it is; this just closes the validation gap underneath it, at the one choke point both classes go through (`super().__init__()`).
- `test_malformed_storage_path_handling` previously had a `try/except` body with no assertion, so it passed regardless of whether the constructor rejected or silently accepted a malformed path. Its side effect (`./None/`) was masked by adding `/None/` to `.gitignore` instead of fixing the bug. Rewrote it to `pytest.raises` on each malformed path and assert no stray directory was left behind in cwd. Removed `/None/` from `.gitignore` now that nothing creates it.

## Verification
- Reproduced the original bug against the fix — all three malformed paths now rejected:
  ```
  'None' -> REJECTED: MetadataValidationError storage_path is the literal sentinel string 'None' -- ...
  ''     -> REJECTED: MetadataValidationError storage_path cannot be empty or whitespace-only
  'evil-relative' -> REJECTED: MetadataValidationError storage_path must be an absolute path ...
  ```
- Proved the rewritten test actually catches regressions: temporarily disabled the validation call, reran `test_malformed_storage_path_handling` → `FAILED: DID NOT RAISE`, restored the fix → `PASSED`.
- `rm -rf None && <full suite> && ls -d None` → nothing found.
- Full suite: `803 passed, 1 skipped` (matches baseline pass rate; count differs slightly from the 799 baseline due to unrelated tests merged since).
- `cd src && python3 -c "import server_fastmcp"` → boots clean, no error.
- `pre-commit run` (staged diff) → all hooks pass, including mypy.
- Confirmed no other stray directories are created by the suite; `git status` clean after a full run.
- Config.py already has independent, already-correct validation for empty/sentinel storage_path (added in an earlier PR after a 2026-04-19 production incident) — left untouched; this PR only fixes the base class, which was the actual unguarded path.

## Test plan
- [x] `pytest tests/test_100_percent_coverage.py -k test_malformed_storage_path_handling -v`
- [x] Full suite: `PYTHONPATH=. python -m pytest tests/ --ignore=tests/standalone_test.py --ignore=tests/test_performance_benchmarks.py -q`
- [x] `pre-commit run` on the diff
- [x] Manual repro of the three malformed paths from the bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)