### PR TITLE
fix: validate import file paths, sanitize a log line (S8707, S5145)

### DIFF
--- a/src/format_detector.py
+++ b/src/format_detector.py
@@ -13,6 +13,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List
 
+from validators import validate_import_file_path
+
 logger = logging.getLogger(__name__)
 
 
@@ -48,6 +50,8 @@ class FormatDetector:
         try:
             if not file_path.exists():
                 return self._create_result(PlatformType.UNKNOWN, 0.0, "File not found")
+
+            file_path = validate_import_file_path(file_path)
 
             # Check file extension
             extension = file_path.suffix.lower()

--- a/src/importers/base_importer.py
+++ b/src/importers/base_importer.py
@@ -278,9 +278,13 @@ class BaseImporter(ABC):
             except ValueError:
                 continue
 
-        # If all formats fail, use current time and log warning
+        # If all formats fail, use current time and log warning.
+        # ``timestamp_str`` is untrusted (platform export data); log it via
+        # %r (through lazy %-formatting) rather than f-string concatenation
+        # so control/newline characters are escaped instead of injected
+        # verbatim into the log (SonarCloud pythonsecurity:S5145).
         self.logger.warning(
-            f"Could not parse timestamp: {timestamp_str}, using current time"
+            "Could not parse timestamp: %r, using current time", timestamp_str
         )
         return datetime.now()
 

--- a/src/importers/chatgpt_importer.py
+++ b/src/importers/chatgpt_importer.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
+from validators import validate_import_file_path
+
 from .base_importer import BaseImporter, ImportResult
 
 logger = logging.getLogger(__name__)
@@ -43,6 +45,8 @@ class ChatGPTImporter(BaseImporter):
                     imported_ids=[],
                     metadata={},
                 )
+
+            file_path = validate_import_file_path(file_path)
 
             # Load and validate ChatGPT export file
             with open(file_path, "r", encoding="utf-8") as f:

--- a/src/importers/claude_importer.py
+++ b/src/importers/claude_importer.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from validators import validate_import_file_path
+
 from .base_importer import BaseImporter, ImportResult
 
 logger = logging.getLogger(__name__)
@@ -48,6 +50,8 @@ class ClaudeImporter(BaseImporter):
                     imported_ids=[],
                     metadata={},
                 )
+
+            file_path = validate_import_file_path(file_path)
 
             # Determine format based on file extension
             extension = file_path.suffix.lower()

--- a/src/importers/cursor_importer.py
+++ b/src/importers/cursor_importer.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from validators import validate_import_file_path
+
 from .base_importer import BaseImporter, ImportResult
 
 logger = logging.getLogger(__name__)
@@ -43,6 +45,8 @@ class CursorImporter(BaseImporter):
                     imported_ids=[],
                     metadata={},
                 )
+
+            file_path = validate_import_file_path(file_path)
 
             # Load and validate Cursor export file
             with open(file_path, "r", encoding="utf-8") as f:

--- a/src/importers/generic_importer.py
+++ b/src/importers/generic_importer.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from validators import validate_import_file_path
+
 from .base_importer import BaseImporter, ImportResult
 
 logger = logging.getLogger(__name__)
@@ -47,6 +49,8 @@ class GenericImporter(BaseImporter):
                     imported_ids=[],
                     metadata={},
                 )
+
+            file_path = validate_import_file_path(file_path)
 
             # Determine format based on file extension
             extension = file_path.suffix.lower()

--- a/src/schemas/chatgpt_schema.py
+++ b/src/schemas/chatgpt_schema.py
@@ -380,9 +380,11 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) > 1:
-        file_path = sys.argv[1]
+        from validators import validate_import_file_path
 
         try:
+            file_path = validate_import_file_path(sys.argv[1])
+
             with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
 

--- a/src/validators.py
+++ b/src/validators.py
@@ -310,6 +310,65 @@ def validate_storage_path(storage_path: Union[str, "Path", None]) -> str:
     return text
 
 
+def validate_import_file_path(file_path: Union[str, "Path", None]) -> Path:
+    """Validate a file path immediately before it is opened for import
+    parsing or format detection.
+
+    Shared choke point for the ``BaseImporter`` subclasses' ``import_file``
+    entry points and ``FormatDetector.detect_format`` (SonarCloud
+    pythonsecurity:S8707 -- "LLMs running this code with faulty CLI
+    arguments can escape file system restrictions"). Every caller of these
+    entry points is a human running a local script
+    (``scripts/bulk_import_enhanced.py``, or an importer's own ``__main__``
+    demo block) against a file of their own choosing; the importers are not
+    wired into any MCP tool, so there is no remote/privilege boundary being
+    crossed here -- this is hardening a CLI against its own operator, not
+    closing a live hole.
+
+    This intentionally does NOT reject ``..`` traversal or relative paths:
+    doing so would only break legitimate relative-path CLI usage without
+    stopping anything a local user couldn't already do directly with
+    ``cat``. That mirrors the "no location policy" carve-out documented on
+    ``validate_storage_path`` above, for the same reason.
+
+    Args:
+        file_path: The raw path as passed to import_file/detect_format.
+
+    Returns:
+        The path, resolved to an absolute ``Path``.
+
+    Raises:
+        MetadataValidationError: If file_path is missing, not a string or
+            Path, empty/whitespace-only, contains a null byte, does not
+            exist, or is not a regular file (e.g. a directory).
+    """
+    if file_path is None:
+        raise MetadataValidationError("file_path cannot be None")
+
+    if not isinstance(file_path, (str, Path)):
+        raise MetadataValidationError(
+            f"file_path must be a string or Path, got {type(file_path).__name__}"
+        )
+
+    text = str(file_path)
+
+    if not text.strip():
+        raise MetadataValidationError("file_path cannot be empty or whitespace-only")
+
+    if NULL_BYTE_PATTERN.search(text):
+        raise MetadataValidationError("file_path contains null bytes")
+
+    resolved = Path(file_path).resolve()
+
+    if not resolved.exists():
+        raise MetadataValidationError(f"file_path does not exist: {resolved}")
+
+    if not resolved.is_file():
+        raise MetadataValidationError(f"file_path is not a regular file: {resolved}")
+
+    return resolved
+
+
 def _strip_control_chars(value: str) -> str:
     """Remove control chars (keeping safe whitespace), matching validate_title."""
     return "".join(

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,11 +1,13 @@
 """Test input validation for security and data integrity"""
 
+from pathlib import Path
 
 import pytest
 
 from exceptions import (
     ContentValidationError,
     DateValidationError,
+    MetadataValidationError,
     QueryValidationError,
     TitleValidationError,
     ValidationError,
@@ -13,6 +15,7 @@ from exceptions import (
 from validators import (
     validate_content,
     validate_date,
+    validate_import_file_path,
     validate_limit,
     validate_search_query,
     validate_title,
@@ -59,9 +62,12 @@ class TestTitleValidation:
 
     def test_dangerous_characters_removed(self):
         """Test dangerous file characters are sanitized"""
-        assert validate_title('test<script>alert("xss")</script>') == "testscriptalert(xss)/script"
-        assert validate_title('file:name|test') == "filenametest"
-        assert validate_title('test*file?name') == "testfilename"
+        assert (
+            validate_title('test<script>alert("xss")</script>')
+            == "testscriptalert(xss)/script"
+        )
+        assert validate_title("file:name|test") == "filenametest"
+        assert validate_title("test*file?name") == "testfilename"
 
     def test_control_characters_removed(self):
         """Test control characters are removed except safe ones"""
@@ -71,7 +77,7 @@ class TestTitleValidation:
 
         # Other control chars should be removed
         assert validate_title("test\x01\x02\x03") == "test"
-        assert validate_title("test\x7F") == "test"
+        assert validate_title("test\x7f") == "test"
 
 
 class TestContentValidation:
@@ -258,3 +264,69 @@ class TestValidatorEdgeCases:
         # Should be valid since it's not empty (length > 0) and passes all checks
         result = validate_content(whitespace_content)
         assert result == whitespace_content  # Should return as-is
+
+
+class TestImportFilePathValidation:
+    """Test validate_import_file_path -- the choke point importers and
+    FormatDetector route through before opening a file (SonarCloud
+    pythonsecurity:S8707)."""
+
+    def test_valid_existing_file(self, tmp_path):
+        target = tmp_path / "export.json"
+        target.write_text("{}")
+
+        result = validate_import_file_path(target)
+
+        assert result == target.resolve()
+        assert isinstance(result, Path)
+
+    def test_valid_existing_file_as_string(self, tmp_path):
+        target = tmp_path / "export.json"
+        target.write_text("{}")
+
+        result = validate_import_file_path(str(target))
+
+        assert result == target.resolve()
+
+    def test_none_rejected(self):
+        with pytest.raises(MetadataValidationError, match="cannot be None"):
+            validate_import_file_path(None)
+
+    def test_wrong_type_rejected(self):
+        with pytest.raises(MetadataValidationError, match="must be a string or Path"):
+            validate_import_file_path(12345)
+
+    def test_empty_string_rejected(self):
+        with pytest.raises(MetadataValidationError, match="empty or whitespace-only"):
+            validate_import_file_path("")
+
+    def test_whitespace_only_rejected(self):
+        with pytest.raises(MetadataValidationError, match="empty or whitespace-only"):
+            validate_import_file_path("   ")
+
+    def test_null_byte_rejected(self):
+        with pytest.raises(MetadataValidationError, match="null bytes"):
+            validate_import_file_path("evil\x00path.json")
+
+    def test_nonexistent_path_rejected(self, tmp_path):
+        missing = tmp_path / "does-not-exist.json"
+        with pytest.raises(MetadataValidationError, match="does not exist"):
+            validate_import_file_path(missing)
+
+    def test_directory_rejected(self, tmp_path):
+        with pytest.raises(MetadataValidationError, match="not a regular file"):
+            validate_import_file_path(tmp_path)
+
+    def test_relative_and_traversal_paths_not_blocked(self, tmp_path, monkeypatch):
+        # Deliberate design choice (see validate_import_file_path docstring):
+        # these importers are only reachable from a local CLI script run by
+        # a human against their own files, so relative/`..` paths are not a
+        # privilege-escalation vector here and are intentionally allowed.
+        target = tmp_path / "sub" / "export.json"
+        target.parent.mkdir()
+        target.write_text("{}")
+        monkeypatch.chdir(tmp_path)
+
+        result = validate_import_file_path("sub/../sub/export.json")
+
+        assert result == target.resolve()


### PR DESCRIPTION
## Summary

Closes 10× `pythonsecurity:S8707` + 1× `pythonsecurity:S5145` of the 27 open SonarCloud vulnerabilities on `main` (see PR #(CI pinning) for the other 16).

**Severity, for the record:** the importers this touches (`src/importers/*`, `src/format_detector.py`, `src/schemas/chatgpt_schema.py`) are **not reachable from any MCP tool** — `server_fastmcp.py` never imports them. The only caller is `scripts/bulk_import_enhanced.py`, a script a human runs locally, passing a path they chose themselves. S8707's "LLM with faulty CLI args" threat model is real as a hardening concern, not a live exploitable hole — there's no privilege boundary an attacker crosses by pointing their own CLI at their own filesystem. Treat this PR as defense-in-depth, not an incident fix.

## What changed

- **`src/validators.py`**: added `validate_import_file_path()`, following the `validate_storage_path()` pattern from #165 (same file, same error type `MetadataValidationError`, same "resolve + reject the pathological inputs" shape). Rejects `None`, wrong type, empty/whitespace, null bytes, non-existent paths, and non-regular-files (e.g. a directory — which the *existing* `.exists()` checks didn't catch, since `.exists()` is true for directories too). **Deliberately allows `..` traversal and relative paths** — every caller is a local human against their own file, so blocking that would only break legitimate CLI usage without stopping anything real. Documented in the docstring.

- **Choke points, not 11 individual checks**: the raw `open()` call count was 10 S8707 sites; fixed via **6 call-site insertions**, not 10:
  - 4× one-line inserts, one per importer's `import_file()` entry point (`chatgpt_importer.py`, `claude_importer.py`, `cursor_importer.py`, `generic_importer.py`) — each `import_file()` is the single place every downstream `_import_json_format`/`_import_text_format`/`_import_csv_format`/`_import_xml_format` helper receives its `file_path` from, so validating once there covers all 7 raw `open()` sites across those four files transparently (`claude_importer.py` had 2 sites, `generic_importer.py` had 3, both now covered by 1 call each).
  - 1× insert in `FormatDetector.detect_format()`, which is the shared dispatch point for `_detect_json_format`/`_detect_text_format` — covers both of `format_detector.py`'s sites.
  - 1× insert in `chatgpt_schema.py`'s `__main__` demo block — fixed individually since it's a standalone script entry, not part of either importer or detector flow, so there's no shared choke point to route it through.

  So: **10 raw sites → 6 call sites → 1 shared validator function.**

- **`S5145` (log injection) in `base_importer.py`**: `_parse_timestamp`'s fallback warning logged untrusted platform-export data raw via f-string. Didn't delete the log line (it's a real diagnostic — tells you *which* timestamp format broke). Switched to lazy `%`-formatting with `%r`: `self.logger.warning("Could not parse timestamp: %r, using current time", timestamp_str)`. `%r` runs the value through `repr()`, which escapes control/newline characters instead of injecting them verbatim into the log stream.

## Unblocks #167

`chore/strict-lint-config` (#167) is currently blocked on SonarCloud's `new_security_rating: 3 (C) > 1 (A)` gate. Verified this is **not** because #167 introduces anything new — it's pure reformatting (ruff dropped the redundant `"r"` mode arg from `open()` calls, shifting line numbers), which caused these same pre-existing issues to get re-attributed as "new code" on that branch:

- `format_detector.py:73` → `:71` (confirmed against `origin/chore/strict-lint-config`)
- `format_detector.py:122` → `:112` (confirmed)
- `base_importer.py:282` → `:278` (confirmed)

Once this PR merges to `main`, the underlying vulnerabilities won't exist anymore, so a rebase of #167 onto post-merge `main` has nothing left to re-attribute — its SonarCloud gate should clear without any change to #167 itself.

## Verification

- Venv trap: shared `.venv`/`claude-memory-mcp-venv` both have editable installs pointing at the **main checkout**, not this worktree (`python -c "import conversation_memory; print(...)"` resolved to `/home/adam/Code/claude-memory-mcp/src/...`, not this worktree). Built a throwaway venv inside the worktree and re-verified it resolves here before testing.
- `PYTHONPATH=. python -m pytest tests/ --ignore=tests/standalone_test.py --ignore=tests/test_performance_benchmarks.py -q` → **813 passed, 1 skipped** (baseline 803 + 10 new tests in `TestImportFilePathValidation`, zero regressions).
- `mypy src --ignore-missing-imports` → clean.
- `cd src && python3 -c "import server_fastmcp"` → clean import, no `--- Logging error ---`.
- `python scripts/bulk_import_enhanced.py --help` → clean.
- Real dry-run: `python scripts/bulk_import_enhanced.py <sample.json> --dry-run --verbose` → full detect → import → summary flow works end to end.
- Negative-path smoke: missing file → graceful "File does not exist" summary line (exit 0, no traceback); directory passed as `file_path` → importer now correctly rejects it (`file_path is not a regular file`) instead of the previous unchecked behavior.
- Committed **without** `--no-verify` — pre-commit (ruff lint+format, mypy, bandit, gitleaks) all passed clean on the first try.

## Test plan

- [x] New `TestImportFilePathValidation` class in `tests/test_input_validation.py`: valid path (Path and str), `None`, wrong type, empty, whitespace, null byte, missing file, directory, and the deliberate traversal-allowed case.
- [x] Full suite green, no regressions.
- [x] Manual dry-run + negative-path smoke tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
