### PR TITLE
fix: pin CI dependency installs to exact locked versions (S8544, S8541)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install linting tools
         run: |
-          pip install flake8 mypy black isort
+          pip install --only-binary :all: -e ".[lint]"
 
       - name: Check code formatting (Black)
         run: |
@@ -71,8 +71,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e .
-          pip install pytest pytest-cov pytest-asyncio
+          pip install --only-binary :all: -e ".[dev]"
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -36,9 +36,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-asyncio psutil
-        pip install -e .
+        python -m pip install --upgrade pip==26.1.2
+        pip install --only-binary :all: -e ".[dev]"
 
     - name: Generate test data
       run: |
@@ -150,9 +149,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-asyncio psutil
-        pip install -e .
+        python -m pip install --upgrade pip==26.1.2
+        pip install --only-binary :all: -e ".[dev]"
 
     - name: Run baseline performance (main branch)
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,18 +5,33 @@ description = "A Model Context Protocol server for searchable local storage of C
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli]>=1.28.1",
-    "jsonschema>=4.26.0",
-    "aiofiles>=25.1.0",
+    "mcp[cli]==1.28.1",
+    "jsonschema==4.26.0",
+    "aiofiles==25.1.0",
 ]
 
+# Pinned to exact resolved versions (not floors) so `pip install -e .` in CI
+# resolves the same dependency graph every run instead of whatever PyPI
+# happens to serve that day (SonarCloud githubactions:S8544 -- "Using
+# dependencies without locking resolved versions is security-sensitive").
+# This is the single source of truth both workflow files install from; bump
+# versions here, not by editing .github/workflows/*.yml.
 [project.optional-dependencies]
 dev = [
-    "pytest>=9.1.1",
-    "pytest-cov>=7.1.0",
-    "pytest-asyncio>=1.4.0",
-    "psutil>=7.2.2",
-    "types-aiofiles>=24.1.0",
+    "pytest==9.1.1",
+    "pytest-cov==7.1.0",
+    "pytest-asyncio==1.4.0",
+    "psutil==7.2.2",
+    "types-aiofiles==25.1.0.20260518",
+]
+# CI-only lint tooling (quick-checks job in build.yml). Not used by
+# pre-commit, which already runs ruff instead -- see chore/strict-lint-config
+# (#167) for migrating CI to match. Pinned for the same S8544 reason as dev.
+lint = [
+    "flake8==7.3.0",
+    "mypy==1.16.0",
+    "black==26.5.1",
+    "isort==8.0.1",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

Closes 16 of the 27 open SonarCloud vulnerabilities on `main` (9× `githubactions:S8544`, 7× `githubactions:S8541`) — see PR #169 for the other 11 (importer path validation, independent of this one).

CI does `pip install pytest pytest-cov pytest-asyncio psutil flake8 mypy black isort` etc. with **no version pins**, so every run resolves whatever PyPI serves that day. The repo already has a `uv.lock` that Dependabot keeps current — CI just never reads it.

## Options weighed

1. **Scatter `pkg==X.Y.Z` inline into both workflow files.** Works, but duplicates every version string across `build.yml` and `performance.yml` with no shared source — exactly what the task said to avoid.
2. **`uv sync` against `uv.lock`.** The textbook-correct mechanism, and the lockfile is already Dependabot-maintained. Checked first: `uv lock --check` → **the lockfile is currently out of sync with `pyproject.toml`** (missing `types-aiofiles` entirely). Wiring CI to `--locked` mode would fail immediately. Regenerating a stale lockfile is a different problem from "CI ignores pinning," so I didn't fold it into this PR — flagging it as a followup instead of quietly fixing two things at once.
3. **Exact `==` pins in `pyproject.toml`'s `[project.optional-dependencies]`** (chosen). The `dev` group already existed (with floors); I tightened it to exact pins and added a new `lint` group for the CI-only tools (flake8/mypy/black/isort) that weren't tracked anywhere before. Both workflows now install via `pip install -e ".[dev]"` / `.[lint]"` — one file to bump, two workflows consume it. Per a [SonarCloud community thread](https://community.sonarsource.com/t/false-positive-on-githubactions-s8544-python-dependencies-should-be-locked-to-verified-versions/182307) with a Sonar-staff reply, exact `pkg==X.Y.Z` specifiers are what the rule accepts as "locked" — confirmed this empirically holds for extras-based installs too (see Verification).

Also pinned the runtime `dependencies` block itself (`mcp[cli]`, `jsonschema`, `aiofiles`) from `>=` floors to `==`, matching what `uv.lock` already resolves them to — `pip install -e .` (no extras) was independently flagged since those floors aren't locked either.

## S8541 — `--only-binary :all:`

Tested it rather than assuming: `pip install --only-binary :all: -e ".[dev]"` and `-e ".[lint]"` in a clean venv, covering the full runtime + dev + lint dependency graph plus the local editable build. **Every dependency resolves to a wheel** — no sdist/setup-script execution needed anywhere in this dependency set. Applied it to every `pip install` line in both workflows. (Documenting this since the alternative — leaving it off with a "would break installs" excuse — would've been false for this repo.)

Also pinned `performance.yml`'s `python -m pip install --upgrade pip` bootstrap line to `pip==26.1.2` (the other 2 of the 9 S8544 sites) — the one pin that can't live in `pyproject.toml`, since pip bootstraps the extras mechanism itself.

## Verification

- **Venv trap**: the shared `.venv` / `claude-memory-mcp-venv` both have editable installs pointing at the **main checkout**, not this worktree (`python -c "import conversation_memory; print(__file__)"` resolved outside this tree). Built a throwaway venv inside the worktree for all testing below.
- `pip install --only-binary :all: -e ".[dev]"` and `-e ".[lint]"` → both succeed clean, `conversation_memory.__file__` resolves into this worktree.
- `PYTHONPATH=. python -m pytest tests/ --ignore=tests/standalone_test.py --ignore=tests/test_performance_benchmarks.py -q` → **803 passed, 1 skipped** (matches main baseline; this PR touches no `src/`/`tests/` files).
- `mypy src --ignore-missing-imports` → clean.
- `cd src && python3 -c "import server_fastmcp"` → clean import, no `--- Logging error ---`.
- `python scripts/bulk_import_enhanced.py --help` → clean.
- `black --check src/`, `isort --check-only src/`, `flake8 src/ --max-line-length=100 --extend-ignore=E203,W503` all pass clean **with the newly pinned exact tool versions** — confirms pinning didn't silently redefine what "clean" means for this codebase.
- `.github/workflows/*.yml` parse as valid YAML; `pyproject.toml` parses as valid TOML.
- Committed **without** `--no-verify` — pre-commit (ruff, mypy, bandit, gitleaks) passed clean.
- **Real CI run, not claimed**: watching the GitHub Actions run on this PR before marking it ready — will confirm the re-pinned installs actually resolve on Python 3.14 (CI's version) here rather than asserting it from local-only testing.

## Known followup (not in this PR)

`uv.lock` is stale relative to `pyproject.toml` (`uv lock --check` fails). Worth a `uv lock` regeneration + wiring CI to `uv sync --locked` as a stronger version of this fix later, but that's a separate, larger change from "stop CI from ignoring pinning entirely."

## Test plan

- [x] Local install + test verification above.
- [ ] Confirm GitHub Actions run on this PR is green on Python 3.14 before flipping to ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
