### PR TITLE
fix(sonar): stop blanket-suppressing the ReDoS rule; encode the S5145 decision

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,27 @@ sonar.exclusions=**/*test*/**,**/__pycache__/**,htmlcov/**,archive/**,scripts/**
 # Quality gate enforcement
 sonar.qualitygate.wait=true
 
-# Exclude python:S5852 (ReDoS vulnerabilities) - personal project with trusted input sources
+# Issue suppressions. Each entry states WHY, and is scoped as narrowly as the
+# decision actually warrants -- a blanket rule-wide ignore is how a real bug
+# stays invisible (see the S5852 note below).
+#
+# Removed: python:S5852 (ReDoS), previously ignored across **/*.py with the
+# justification "personal project with trusted input sources". That premise was
+# false: this project imports ChatGPT/Cursor/Claude conversation exports, and a
+# genuine high-severity ReDoS shipped in _extract_topics (GitHub code-scanning
+# alert #1, fixed in #152 -- 28 chars took 32s, and the trigger was ordinary
+# pasted content like a hex digest or base64 blob, not an attack). SonarCloud
+# was configured never to report that entire class of bug. CodeQL caught it
+# instead. The rule is now active again.
+
+# e1: python:S5145 in base_importer._parse_timestamp -- logs an untrusted
+# timestamp string when every known format fails to parse. Mitigated: the value
+# goes through lazy %r formatting, so control/newline chars are escaped rather
+# than injected into the log. Kept deliberately: knowing WHICH timestamp failed
+# is the whole diagnostic value, and the injection vector is closed. Resolved as
+# Safe/WONTFIX in the SonarCloud UI, but encoded here too because a UI
+# resolution does not survive a line shift -- reformatting the line creates a
+# "new" issue and re-blocks the gate.
 sonar.issue.ignore.multicriteria=e1
-sonar.issue.ignore.multicriteria.e1.ruleKey=python:S5852
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.py
+sonar.issue.ignore.multicriteria.e1.ruleKey=pythonsecurity:S5145
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/importers/base_importer.py


### PR DESCRIPTION
## The ReDoS rule was switched off repo-wide

```properties
# Exclude python:S5852 (ReDoS vulnerabilities) - personal project with trusted input sources
sonar.issue.ignore.multicriteria.e1.ruleKey=python:S5852
sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.py
```

Added in #89. The justification — *"trusted input sources"* — is not true of this project: it exists to import ChatGPT/Cursor/Claude conversation exports.

And it mattered. A real high-severity ReDoS shipped in `_extract_topics` and survived until #152:

| input | time |
|---|---|
| `A`*26 + `1` | 3,986 ms |
| `A`*28 + `1` | 32,668 ms |
| `A`*40 + `1` | ~37 hours (4x per +2 chars) |

The trigger wasn't an attack — it was ordinary pasted content: a hex digest, a base64 blob, `MAX_RETRIES_2` in a stack trace. **SonarCloud never reported it, because it had been told not to look at that rule.** GitHub code-scanning caught it instead (alert #1, now `fixed`).

The rule is active again. If it surfaces real findings, they're findings.

## Replaced with a narrow, documented suppression

`pythonsecurity:S5145` in `importers/base_importer.py` only — the timestamp-parse warning. The value goes through lazy `%r` formatting so control/newline chars are escaped; the injection vector is closed, and knowing *which* timestamp failed is the whole diagnostic. Resolved Safe/WONTFIX in the UI by the maintainer.

It's encoded here **as well as** the UI because a UI resolution doesn't survive a line shift: reformatting the line mints a "new" issue and re-blocks the gate — which is exactly what blocked #167.

## The distinction

- The S5852 ignore **hid an entire class of real bug** behind a false premise, repo-wide.
- The S5145 ignore **records one reviewed decision** about one line whose risk is genuinely mitigated, scoped to that file.

Same mechanism; opposite intent.