### PR TITLE
fix: resolve the 124 judgment-call lint violations deferred from #167

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,23 +80,6 @@ lint.ignore = [
     "E501",  # line too long (handled by ruff format)
     "B008",  # function calls in argument defaults
     "B905",  # zip without explicit strict parameter
-
-    # --- TEMPORARY: deferred to chore/strict-lint-manual (PR 2) ---
-    # These ~124 remaining violations are real behavior/judgment calls (blind
-    # excepts to narrow, log.error->log.exception, etc.) that need per-site
-    # review, not a bulk --fix. Rules stay selected (not removed) so new code
-    # can't add fresh violations silently; remove this block in PR 2 once
-    # each site is fixed or given a reasoned `# noqa`.
-    "BLE001",  # blind-except - narrow or justify each of the 69 individually
-    "TRY400",  # log.error in except (loses traceback) - 28 sites
-    "TRY004",  # raise TypeError not ValueError - 4 sites
-    "SIM102", "SIM103", "SIM105", "SIM110", "SIM117",  # flake8-simplify - 10 sites total
-    "B007",    # unused loop var - 3 sites
-    "F841",    # unused variable - 3 sites
-    "B904",    # raise without `from` in except - 2 sites
-    "PT011",   # pytest.raises too broad - 2 sites
-    "RUF012",  # mutable class default - 2 sites
-    "C408",    # dict()/list() call instead of literal - 1 site
 ]
 
 exclude = [

--- a/src/conversation_memory.py
+++ b/src/conversation_memory.py
@@ -80,7 +80,7 @@ class ConversationMemoryServer:
                 self.search_db = SearchDatabase(str(db_path))
                 self.use_sqlite_search = True
                 self.logger.info("SQLite FTS search enabled")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - optional SQLite init: fall back to linear/JSON search rather than crash server startup
                 self.logger.warning(f"Failed to initialize SQLite search: {e}")
                 self.use_sqlite_search = False
 
@@ -110,12 +110,9 @@ class ConversationMemoryServer:
         if data_conversations.exists():
             return True
 
-        # If conversations exists in root, use legacy structure
-        if legacy_conversations.exists():
-            return False
-
-        # If neither exists, default to new structure for new installations
-        return True
+        # If neither exists, default to new structure for new installations.
+        # Legacy structure only applies when conversations/ exists in root.
+        return not legacy_conversations.exists()
 
     def _init_index_files(self):
         """Initialize index and topics files if they don't exist"""
@@ -433,7 +430,7 @@ class ConversationMemoryServer:
         try:
             file_path.unlink(missing_ok=True)
         except OSError as e:
-            self.logger.error(f"Rollback: failed to remove orphaned file: {e}")
+            self.logger.exception(f"Rollback: failed to remove orphaned file: {e}")
 
         self._remove_index_entry(conversation_id)
         # Reuse the topics-diff helper with an empty new_topics set: every
@@ -455,7 +452,7 @@ class ConversationMemoryServer:
                 json.dump(index_data, f, indent=2)
 
         except (OSError, ValueError, KeyError, TypeError) as e:
-            self.logger.error(f"Rollback: failed to remove index entry: {e}")
+            self.logger.exception(f"Rollback: failed to remove index entry: {e}")
 
     _CONVERSATION_ID_RE = re.compile(r"^conv_(\d{8})_(\d{6})_[\w]+$")
 
@@ -648,7 +645,7 @@ class ConversationMemoryServer:
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(original_raw)
         except OSError as e:
-            self.logger.error(f"Rollback: failed to restore prior content: {e}")
+            self.logger.exception(f"Rollback: failed to restore prior content: {e}")
 
     def _replace_index_entry(self, conversation_data: dict, file_path: Path):
         """Replace (or insert) the index.json entry for a conversation."""
@@ -687,7 +684,7 @@ class ConversationMemoryServer:
                 json.dump(index_data, f, indent=2)
 
         except (OSError, ValueError, KeyError, TypeError) as e:
-            self.logger.error(f"Error replacing index entry: {e}")
+            self.logger.exception(f"Error replacing index entry: {e}")
 
     def _resync_topics_index(
         self,
@@ -703,7 +700,7 @@ class ConversationMemoryServer:
             with open(self.topics_file) as f:
                 topics_data = json.load(f)
         except (OSError, ValueError) as e:
-            self.logger.error(f"Error loading topics index: {e}")
+            self.logger.exception(f"Error loading topics index: {e}")
             return
 
         topics_index = topics_data.get("topics", {})
@@ -742,7 +739,7 @@ class ConversationMemoryServer:
             with open(self.topics_file, "w") as f:
                 json.dump(topics_data, f, indent=2)
         except OSError as e:
-            self.logger.error(f"Error writing topics index: {e}")
+            self.logger.exception(f"Error writing topics index: {e}")
 
     def _calculate_search_score(
         self,
@@ -799,7 +796,7 @@ class ConversationMemoryServer:
         if self.use_sqlite_search and self.search_db:
             try:
                 return self.search_db.search_conversations(query, limit)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - documented fallback: SQLite search failure falls through to linear search below
                 self.logger.warning(f"SQLite search failed, falling back to linear search: {e}")
                 # Fall through to linear search
 
@@ -904,7 +901,7 @@ class ConversationMemoryServer:
                 json.dump(index_data, f, indent=2)
 
         except (OSError, ValueError, KeyError, TypeError) as e:
-            self.logger.error(f"Error updating index: {e}")
+            self.logger.exception(f"Error updating index: {e}")
 
     def _update_topics_index(self, topics: list[str], conversation_id: str):
         """Update the topics index with new conversation topics"""
@@ -937,7 +934,7 @@ class ConversationMemoryServer:
                 json.dump(topics_data, f, indent=2)
 
         except (OSError, ValueError, KeyError, TypeError) as e:
-            self.logger.error(f"Error updating topics index: {e}")
+            self.logger.exception(f"Error updating topics index: {e}")
 
     async def generate_weekly_summary(self, week_offset: int = 0) -> str:
         """Generate a weekly summary of conversations"""
@@ -1059,7 +1056,7 @@ class ConversationMemoryServer:
             try:
                 db_stats = self.search_db.get_conversation_stats()
                 stats.update(db_stats)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - read-only diagnostics endpoint: report sqlite_error rather than crash the stats call
                 stats["sqlite_error"] = str(e)
 
         return stats
@@ -1085,7 +1082,7 @@ class ConversationMemoryServer:
 
         except ImportError:
             return {"error": "Migration module not available"}
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - MCP tool handler: report migration failure rather than crash the server
             return {"error": f"Migration failed: {str(e)}"}
 
     async def search_by_topic(self, topic: str, limit: int = 10) -> list[dict[str, Any]]:
@@ -1093,7 +1090,7 @@ class ConversationMemoryServer:
         if self.use_sqlite_search and self.search_db:
             try:
                 return self.search_db.search_by_topic(topic, limit)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - documented fallback: SQLite topic search failure falls through to JSON topic search
                 self.logger.warning(f"SQLite topic search failed: {e}")
 
         # Fallback to JSON-based topic search
@@ -1109,7 +1106,7 @@ class ConversationMemoryServer:
         if self.use_sqlite_search and self.search_db:
             try:
                 return self.search_db.search_by_tag(tag, limit)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - MCP tool handler: report tag-search failure rather than crash the server (no JSON fallback exists)
                 self.logger.warning("SQLite tag search failed: %s", e)
                 return [{"error": f"Tag search failed: {e}"}]
 
@@ -1120,7 +1117,7 @@ class ConversationMemoryServer:
         if self.use_sqlite_search and self.search_db:
             try:
                 return self.search_db.search_by_session_id(session_id, limit)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - MCP tool handler: report session-search failure rather than crash the server (no JSON fallback exists)
                 self.logger.warning("SQLite session search failed: %s", e)
                 return [{"error": f"Session search failed: {e}"}]
 
@@ -1133,7 +1130,7 @@ class ConversationMemoryServer:
         if self.use_sqlite_search and self.search_db:
             try:
                 return self.search_db.search_by_conversation_type(conversation_type, limit)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - MCP tool handler: report conversation-type-search failure rather than crash the server (no JSON fallback exists)
                 self.logger.warning("SQLite conversation-type search failed: %s", e)
                 return [{"error": f"Conversation-type search failed: {e}"}]
 
@@ -1184,6 +1181,6 @@ class ConversationMemoryServer:
                     results.append({"error": "Conversation file not found"})
                     continue
                 results.append({"title": conv.get("title", "Unknown")})
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - legacy per-item analysis helper: report error per conversation rather than abort the whole batch
                 results.append({"error": str(e)})
         return results

--- a/src/exporters/base_exporter.py
+++ b/src/exporters/base_exporter.py
@@ -161,7 +161,7 @@ class BaseExporter(ABC):
             with open(index_file, encoding="utf-8") as f:
                 index_data = json.load(f)
         except (OSError, json.JSONDecodeError) as exc:
-            self.logger.error("Failed to read index.json: %s", exc)
+            self.logger.exception("Failed to read index.json: %s", exc)
             return []
 
         loaded: list[dict[str, Any]] = []

--- a/src/format_detector.py
+++ b/src/format_detector.py
@@ -65,8 +65,8 @@ class FormatDetector:
                     PlatformType.UNKNOWN, 0.0, f"Unsupported extension: {extension}"
                 )
 
-        except Exception as e:
-            self.logger.error(f"Error detecting format for {file_path}: {e}")
+        except Exception as e:  # noqa: BLE001 - best-effort platform classification: report UNKNOWN/0.0 rather than crash on arbitrary file content
+            self.logger.exception(f"Error detecting format for {file_path}: {e}")
             return self._create_result(PlatformType.UNKNOWN, 0.0, f"Detection error: {str(e)}")
 
     def _detect_json_format(self, file_path: Path) -> dict[str, Any]:
@@ -107,7 +107,7 @@ class FormatDetector:
 
         except json.JSONDecodeError as e:
             return self._create_result(PlatformType.UNKNOWN, 0.0, f"Invalid JSON: {str(e)}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - best-effort platform classification: report UNKNOWN/0.0 rather than crash on arbitrary file content
             return self._create_result(PlatformType.UNKNOWN, 0.0, f"JSON analysis error: {str(e)}")
 
     def _detect_text_format(self, file_path: Path) -> dict[str, Any]:
@@ -132,39 +132,38 @@ class FormatDetector:
 
             return self._create_result(PlatformType.UNKNOWN, 0.0, "Unknown text format")
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - best-effort platform classification: report UNKNOWN/0.0 rather than crash on arbitrary file content
             return self._create_result(PlatformType.UNKNOWN, 0.0, f"Text analysis error: {str(e)}")
 
     def _is_chatgpt_format(self, data: Any) -> bool:
         """Check if data matches ChatGPT export format."""
         # ChatGPT exports can be an array of conversations directly
-        if isinstance(data, list):
-            if data and isinstance(data[0], dict):
-                conv = data[0]
-                # Check for ChatGPT-specific structure (title, create_time, mapping)
-                return (
-                    isinstance(conv, dict)
-                    and "title" in conv
-                    and "create_time" in conv
-                    and "mapping" in conv
-                    and isinstance(conv["mapping"], dict)
-                )
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            conv = data[0]
+            # Check for ChatGPT-specific structure (title, create_time, mapping)
+            return (
+                isinstance(conv, dict)
+                and "title" in conv
+                and "create_time" in conv
+                and "mapping" in conv
+                and isinstance(conv["mapping"], dict)
+            )
 
         # Or wrapped in a 'conversations' key
         if (
             isinstance(data, dict)
             and "conversations" in data
             and isinstance(data["conversations"], list)
+            and data["conversations"]
         ):
             # Check a sample conversation structure
-            if data["conversations"]:
-                conv = data["conversations"][0]
-                return (
-                    isinstance(conv, dict)
-                    and "messages" in conv
-                    and isinstance(conv["messages"], list)
-                    and self._has_role_based_messages(conv["messages"])
-                )
+            conv = data["conversations"][0]
+            return (
+                isinstance(conv, dict)
+                and "messages" in conv
+                and isinstance(conv["messages"], list)
+                and self._has_role_based_messages(conv["messages"])
+            )
 
         return False
 
@@ -195,9 +194,13 @@ class FormatDetector:
         has_required = sum(1 for field in required_fields if field in data)
 
         # Check for our specific ID format
-        if "id" in data and isinstance(data["id"], str):
-            if data["id"].startswith("conv_") and len(data["id"]) > 15:
-                has_required += 1
+        if (
+            "id" in data
+            and isinstance(data["id"], str)
+            and data["id"].startswith("conv_")
+            and len(data["id"]) > 15
+        ):
+            has_required += 1
 
         return has_required >= 5
 

--- a/src/importers/base_importer.py
+++ b/src/importers/base_importer.py
@@ -349,8 +349,8 @@ class BaseImporter(ABC):
                 # Combine metadata
                 combined_metadata[str(file_path)] = result.metadata
 
-            except Exception as e:
-                self.logger.error(f"Failed to import {file_path}: {e}")
+            except Exception as e:  # noqa: BLE001 - resilience: skip unimportable file, keep processing the rest of the batch
+                self.logger.exception(f"Failed to import {file_path}: {e}")
                 all_errors.append(f"Failed to import {file_path}: {str(e)}")
                 total_failed += 1
 

--- a/src/importers/chatgpt_importer.py
+++ b/src/importers/chatgpt_importer.py
@@ -75,7 +75,7 @@ class ChatGPTImporter(BaseImporter):
                 imported_ids=[],
                 metadata={},
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - top-level import boundary: report failure via ImportResult instead of crashing the batch run
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -109,12 +109,12 @@ class ChatGPTImporter(BaseImporter):
                         f"Invalid conversation format for ID: {conversation.get('id', 'unknown')}"
                     )
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - resilience: skip unparseable conversation, keep processing the rest of the batch
                 failed_count += 1
                 conv_id = conversation.get("id", "unknown")
                 error_msg = f"Failed to process conversation {conv_id}: {str(e)}"
                 errors.append(error_msg)
-                self.logger.error(error_msg)
+                self.logger.exception(error_msg)
 
         return ImportResult(
             success=imported_count > 0,
@@ -151,7 +151,7 @@ class ChatGPTImporter(BaseImporter):
         }
         """
         if not isinstance(raw_data, dict):
-            raise ValueError("ChatGPT conversation data must be a dictionary")
+            raise TypeError("ChatGPT conversation data must be a dictionary")
 
         # Extract basic information
         platform_id = raw_data.get("id", "")

--- a/src/importers/claude_importer.py
+++ b/src/importers/claude_importer.py
@@ -70,7 +70,7 @@ class ClaudeImporter(BaseImporter):
                     metadata={},
                 )
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - top-level import boundary: report failure via ImportResult instead of crashing the batch run
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -139,7 +139,7 @@ class ClaudeImporter(BaseImporter):
                     metadata={},
                 )
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - best-effort text parse: report failure via ImportResult instead of crashing
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -178,7 +178,7 @@ class ClaudeImporter(BaseImporter):
                     metadata={},
                 )
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - top-level format-branch boundary: report failure via ImportResult instead of crashing
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -218,7 +218,7 @@ class ClaudeImporter(BaseImporter):
                     metadata={},
                 )
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - top-level format-branch boundary: report failure via ImportResult instead of crashing
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -258,7 +258,7 @@ class ClaudeImporter(BaseImporter):
                     metadata={},
                 )
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - top-level format-branch boundary: report failure via ImportResult instead of crashing
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -284,7 +284,7 @@ class ClaudeImporter(BaseImporter):
             else:
                 return self._parse_claude_json(raw_data)
         else:
-            raise ValueError("Claude conversation data must be string or dictionary")
+            raise TypeError("Claude conversation data must be string or dictionary")
 
     def _parse_claude_json(self, data: dict[str, Any]) -> dict[str, Any]:
         """Parse Claude JSON conversation data."""
@@ -463,9 +463,13 @@ class ClaudeImporter(BaseImporter):
         has_required = sum(1 for field in required_fields if field in data)
 
         # Check for our specific ID format
-        if "id" in data and isinstance(data["id"], str):
-            if data["id"].startswith("conv_") and len(data["id"]) > 15:
-                has_required += 1
+        if (
+            "id" in data
+            and isinstance(data["id"], str)
+            and data["id"].startswith("conv_")
+            and len(data["id"]) > 15
+        ):
+            has_required += 1
 
         return has_required >= 5
 

--- a/src/importers/cursor_importer.py
+++ b/src/importers/cursor_importer.py
@@ -95,9 +95,9 @@ class CursorImporter(BaseImporter):
                         metadata={},
                     )
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - per-session boundary: report failure via ImportResult instead of crashing the batch run
                 error_msg = f"Failed to process Cursor session: {str(e)}"
-                self.logger.error(error_msg)
+                self.logger.exception(error_msg)
                 return ImportResult(
                     success=False,
                     conversations_imported=0,
@@ -116,7 +116,7 @@ class CursorImporter(BaseImporter):
                 imported_ids=[],
                 metadata={},
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - top-level import boundary: report failure via ImportResult instead of crashing the batch run
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -153,7 +153,7 @@ class CursorImporter(BaseImporter):
         }
         """
         if not isinstance(raw_data, dict):
-            raise ValueError("Cursor session data must be a dictionary")
+            raise TypeError("Cursor session data must be a dictionary")
 
         # Extract basic session information
         session_id = raw_data.get("session_id", "")

--- a/src/importers/generic_importer.py
+++ b/src/importers/generic_importer.py
@@ -67,7 +67,7 @@ class GenericImporter(BaseImporter):
                 # Try to parse as text by default
                 return self._import_text_format(file_path)
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - top-level import boundary: report failure via ImportResult instead of crashing the batch run
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -127,7 +127,7 @@ class GenericImporter(BaseImporter):
 
             return self._save_conversations(conversations, file_path, "generic_text")
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - best-effort text parse: report failure via ImportResult instead of crashing
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -187,7 +187,7 @@ class GenericImporter(BaseImporter):
 
             return self._save_conversations(conversations, file_path, "generic_csv")
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - best-effort CSV parse: report failure via ImportResult instead of crashing
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -209,7 +209,7 @@ class GenericImporter(BaseImporter):
 
             return self._save_conversations(conversations, file_path, "generic_xml")
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - best-effort XML parse: report failure via ImportResult instead of crashing
             return ImportResult(
                 success=False,
                 conversations_imported=0,
@@ -232,7 +232,7 @@ class GenericImporter(BaseImporter):
         elif isinstance(raw_data, list):
             return self._parse_list_as_conversation(raw_data)
         else:
-            raise ValueError("Generic conversation data must be string, dict, or list")
+            raise TypeError("Generic conversation data must be string, dict, or list")
 
     def _parse_json_array(self, data: list[Any]) -> list[dict[str, Any]]:
         """Parse JSON array - could be conversations or messages."""
@@ -245,14 +245,14 @@ class GenericImporter(BaseImporter):
                 try:
                     conv = self.parse_conversation(item)
                     conversations.append(conv)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 - resilience: skip unparseable item, keep processing the rest of the batch
                     self.logger.warning(f"Failed to parse conversation item: {e}")
         else:
             # Array of messages or other data - combine into single conversation
             try:
                 combined_conv = self._parse_list_as_conversation(data)
                 conversations.append(combined_conv)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - resilience: skip unparseable item, keep processing the rest of the batch
                 self.logger.warning(f"Failed to combine array into conversation: {e}")
 
         return conversations
@@ -277,7 +277,7 @@ class GenericImporter(BaseImporter):
         try:
             conv = self.parse_conversation(data)
             return [conv]
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - resilience: skip unparseable item, keep processing the rest of the batch
             self.logger.warning("Failed to parse conversation object: %s", e)
             return []
 
@@ -285,7 +285,7 @@ class GenericImporter(BaseImporter):
         """Parse nested conversation arrays within object."""
         conversations = []
 
-        for key, value in data.items():
+        for value in data.values():
             if self._is_valid_conversation_array(value):
                 conversations.extend(self._process_conversation_array(value))
 
@@ -307,7 +307,7 @@ class GenericImporter(BaseImporter):
             try:
                 conv = self.parse_conversation(item)
                 conversations.append(conv)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - resilience: skip unparseable item, keep processing the rest of the batch
                 self.logger.warning("Failed to parse nested conversation: %s", e)
 
         return conversations
@@ -317,7 +317,7 @@ class GenericImporter(BaseImporter):
         try:
             conv = self._parse_dict_as_conversation(data)
             return [conv]
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - resilience: skip unparseable item, keep processing the rest of the batch
             self.logger.warning("Failed to parse object as conversation: %s", e)
             return []
 
@@ -402,7 +402,7 @@ class GenericImporter(BaseImporter):
                 try:
                     conv = self._parse_xml_element_as_conversation(elem)
                     conversations.append(conv)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 - resilience: skip unparseable item, keep processing the rest of the batch
                     self.logger.warning("Failed to parse XML conversation: %s", e)
 
         # If no conversations found, parse entire XML as single conversation
@@ -441,10 +441,7 @@ class GenericImporter(BaseImporter):
             r">\s*\w+:\s*",  # "> Speaker: message"
         ]
 
-        for pattern in patterns:
-            if re.search(pattern, content):
-                return True
-        return False
+        return any(re.search(pattern, content) for pattern in patterns)
 
     def _has_message_blocks(self, content: str) -> bool:
         """Check if text has message block structure."""
@@ -834,12 +831,12 @@ class GenericImporter(BaseImporter):
                         f"Invalid conversation format for ID: {conv.get('id', 'unknown')}"
                     )
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - resilience: skip unsaveable conversation, keep processing the rest of the batch
                 failed_count += 1
                 conv_id = conv.get("id", "unknown")
                 error_msg = f"Failed to save conversation {conv_id}: {str(e)}"
                 errors.append(error_msg)
-                self.logger.error(error_msg)
+                self.logger.exception(error_msg)
 
         return ImportResult(
             success=imported_count > 0,

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -14,7 +14,7 @@ import os
 import sys
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 # Import path utilities for dynamic path resolution
 try:
@@ -246,7 +246,7 @@ class JSONFormatter(logging.Formatter):
                 log_data["context"] = str(log_data["context"])
             try:
                 return json.dumps(log_data)
-            except Exception:
+            except Exception:  # noqa: BLE001 - ultimate JSON-serialization fallback: a Formatter.format() must never raise (breaks the whole logging pipeline)
                 # Ultimate fallback: return basic error message
                 return json.dumps(
                     {
@@ -261,7 +261,7 @@ class JSONFormatter(logging.Formatter):
 class ColoredFormatter(logging.Formatter):
     """Colored log formatter for console output"""
 
-    COLORS = {
+    COLORS: ClassVar[dict[str, str]] = {
         "DEBUG": "\033[36m",  # Cyan
         "INFO": "\033[32m",  # Green
         "WARNING": "\033[33m",  # Yellow
@@ -299,7 +299,7 @@ def _get_log_format(config: "Config | None" = None) -> str:
     try:
         cfg = _resolve_config(config)
         log_format = (cfg.log_format or "text").lower()
-    except Exception:
+    except Exception:  # noqa: BLE001 - defensive: malformed config must never break logging setup (see comment above)
         # Defensive: never let a malformed config bring down logging setup.
         log_format = os.getenv("CLAUDE_MCP_LOG_FORMAT", "text").lower()
 
@@ -326,7 +326,7 @@ def _get_log_sample_rates(config: "Config | None" = None) -> dict:
     try:
         cfg = _resolve_config(config)
         return dict(cfg.log_sample_rates or {})
-    except Exception:
+    except Exception:  # noqa: BLE001 - defensive: malformed config must never break logging setup (see comment above)
         return {}
 
 
@@ -440,7 +440,7 @@ def log_function_call(func_name: str, **kwargs):
             context = {"type": "function_call", "function": func_name, "params": kwargs}
             params = ", ".join(f"{k}={v}" for k, v in kwargs.items() if v is not None)
             logger.debug(f"Calling {func_name}({params})", extra={"context": context})
-    except Exception:
+    except Exception:  # noqa: BLE001 - fail silently to prevent logging from crashing the application (see comment above)
         # Fail silently to prevent logging from crashing the application
         pass
 
@@ -456,7 +456,7 @@ def log_performance(func_name: str, duration: float, **metrics):
             f"Performance: {func_name} completed in {duration:.3f}s | {metric_str}",
             extra={"context": context},
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 - fail silently to prevent logging from crashing the application (see comment above)
         # Fail silently to prevent logging from crashing the application
         pass
 
@@ -505,7 +505,7 @@ def log_security_event(event_type: str, details: str, severity: str = "WARNING")
             f"Security Event: {safe_event_type} | {safe_details}",
             extra={"context": context},
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 - fail silently to prevent logging from crashing the application (see comment above)
         # Fail silently to prevent logging from crashing the application
         pass
 
@@ -538,7 +538,7 @@ def log_validation_failure(field: str, value: str, reason: str):
             f"Validation failed: {safe_field}='{safe_value}' | Reason: {safe_reason}",
             extra={"context": context},
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 - fail silently to prevent logging from crashing the application (see comment above)
         # Fail silently to prevent logging from crashing the application
         pass
 
@@ -583,7 +583,7 @@ def log_file_operation(operation: str, file_path: str, success: bool, **details)
             f"File {operation}: {safe_file_path} | {status} | {detail_str}",
             extra={"context": context},
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 - fail silently to prevent logging from crashing the application (see comment above)
         # Fail silently to prevent logging from crashing the application
         pass
 

--- a/src/migrate_to_sqlite.py
+++ b/src/migrate_to_sqlite.py
@@ -56,9 +56,7 @@ class ConversationMigrator:
 
         if data_conversations.exists():
             return True
-        if legacy_conversations.exists():
-            return False
-        return True
+        return not legacy_conversations.exists()
 
     def migrate_all_conversations(self) -> dict[str, Any]:
         """Migrate all conversations from JSON to SQLite."""
@@ -97,8 +95,8 @@ class ConversationMigrator:
             self.logger.info(f"Migration completed: {stats}")
             return stats
 
-        except Exception as e:
-            self.logger.error(f"Migration failed: {e}")
+        except Exception as e:  # noqa: BLE001 - top-level migration boundary: report failure in stats rather than crash the migration run
+            self.logger.exception(f"Migration failed: {e}")
             stats["error"] = str(e)
             return stats
 
@@ -161,8 +159,10 @@ class ConversationMigrator:
 
             return success
 
-        except Exception as e:
-            self.logger.error(f"Error migrating conversation {conv_info.get('id', 'unknown')}: {e}")
+        except Exception as e:  # noqa: BLE001 - resilience: skip unmigratable conversation, keep processing the rest of the batch
+            self.logger.exception(
+                f"Error migrating conversation {conv_info.get('id', 'unknown')}: {e}"
+            )
             return False
 
     def _migrate_json_file(self, file_path: Path) -> bool:
@@ -192,8 +192,8 @@ class ConversationMigrator:
 
             return success
 
-        except Exception as e:
-            self.logger.error(f"Error migrating file {file_path}: {e}")
+        except Exception as e:  # noqa: BLE001 - resilience: skip unmigratable file, keep processing the rest of the batch
+            self.logger.exception(f"Error migrating file {file_path}: {e}")
             return False
 
     def verify_migration(self) -> dict[str, Any]:
@@ -232,8 +232,8 @@ class ConversationMigrator:
             self.logger.info(f"Verification results: {verification}")
             return verification
 
-        except Exception as e:
-            self.logger.error(f"Verification failed: {e}")
+        except Exception as e:  # noqa: BLE001 - top-level verification boundary: report failure rather than crash
+            self.logger.exception(f"Verification failed: {e}")
             return {"error": str(e)}
 
 

--- a/src/schemas/chatgpt_schema.py
+++ b/src/schemas/chatgpt_schema.py
@@ -318,7 +318,7 @@ def validate_chatgpt_export(data: Any) -> dict[str, Any]:
             "warnings": [],
             "conversation_count": 0,
         }
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - schema-validation boundary: return a structured {valid: False} result rather than crash the caller
         return {
             "valid": False,
             "errors": [f"Validation error: {str(e)}"],
@@ -394,7 +394,7 @@ if __name__ == "__main__":
                 stats = get_chatgpt_conversation_stats(data[0])
                 print(f"\nFirst Conversation Stats: {json.dumps(stats, indent=2)}")
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - CLI demo entry point: print and exit rather than an unhandled traceback
             print(f"Error: {e}")
     else:
         print("Usage: python chatgpt_schema.py <chatgpt_export.json>")

--- a/src/search_database.py
+++ b/src/search_database.py
@@ -10,7 +10,7 @@ import json
 import logging
 import sqlite3
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 
 class SearchDatabase:
@@ -28,7 +28,7 @@ class SearchDatabase:
     # Metadata columns added by PR adding FTS indexing of D2 universal fields.
     # Column name -> SQL type. All default to NULL (nullable) for backwards
     # compat with conversations imported before the metadata fields existed.
-    _METADATA_COLUMNS = {
+    _METADATA_COLUMNS: ClassVar[dict[str, str]] = {
         "session_id": "TEXT",
         "user_id": "TEXT",
         "conversation_type": "TEXT",
@@ -148,7 +148,7 @@ class SearchDatabase:
                 conn.commit()
 
         except sqlite3.Error as e:
-            self.logger.error(f"Database initialization failed: {e}")
+            self.logger.exception(f"Database initialization failed: {e}")
             raise
 
     def _migrate_metadata_columns(self, conn: sqlite3.Connection) -> None:
@@ -250,7 +250,7 @@ class SearchDatabase:
                 return True
 
         except sqlite3.Error as e:
-            self.logger.error("Failed to add conversation: %s", e)
+            self.logger.exception("Failed to add conversation: %s", e)
             return False
 
     def search_conversations(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
@@ -293,7 +293,7 @@ class SearchDatabase:
                 return results
 
         except sqlite3.Error as e:
-            self.logger.error(f"Search failed: {e}")
+            self.logger.exception(f"Search failed: {e}")
             return [{"error": f"Search failed: {str(e)}"}]
 
     def search_by_topic(self, topic: str, limit: int = 10) -> list[dict[str, Any]]:
@@ -328,7 +328,7 @@ class SearchDatabase:
                 return results
 
         except sqlite3.Error as e:
-            self.logger.error(f"Topic search failed: {e}")
+            self.logger.exception(f"Topic search failed: {e}")
             return []
 
     def search_by_tag(self, tag: str, limit: int = 10) -> list[dict[str, Any]]:
@@ -353,7 +353,7 @@ class SearchDatabase:
                 return [self._row_to_metadata_result(row) for row in cursor]
 
         except sqlite3.Error as e:
-            self.logger.error(f"Tag search failed: {e}")
+            self.logger.exception(f"Tag search failed: {e}")
             return []
 
     def search_by_session_id(self, session_id: str, limit: int = 10) -> list[dict[str, Any]]:
@@ -377,7 +377,7 @@ class SearchDatabase:
                 return [self._row_to_metadata_result(row) for row in cursor]
 
         except sqlite3.Error as e:
-            self.logger.error(f"Session search failed: {e}")
+            self.logger.exception(f"Session search failed: {e}")
             return []
 
     def search_by_conversation_type(
@@ -403,7 +403,7 @@ class SearchDatabase:
                 return [self._row_to_metadata_result(row) for row in cursor]
 
         except sqlite3.Error as e:
-            self.logger.error(f"Conversation-type search failed: {e}")
+            self.logger.exception(f"Conversation-type search failed: {e}")
             return []
 
     @staticmethod
@@ -474,7 +474,7 @@ class SearchDatabase:
                 }
 
         except sqlite3.Error as e:
-            self.logger.error(f"Stats query failed: {e}")
+            self.logger.exception(f"Stats query failed: {e}")
             return {"error": str(e)}
 
     def _sanitize_fts_query(self, query: str) -> str:
@@ -506,7 +506,7 @@ class SearchDatabase:
                 conn.commit()
 
         except sqlite3.Error as e:
-            self.logger.error(f"FTS index rebuild failed: {e}")
+            self.logger.exception(f"FTS index rebuild failed: {e}")
             raise
 
     def get_conversation_count(self) -> int:
@@ -517,5 +517,5 @@ class SearchDatabase:
                 return cursor.fetchone()[0]
 
         except sqlite3.Error as e:
-            self.logger.error(f"Count query failed: {e}")
+            self.logger.exception(f"Count query failed: {e}")
             return 0

--- a/src/validators.py
+++ b/src/validators.py
@@ -164,7 +164,7 @@ def validate_date(date_str: str | None) -> datetime | None:
         return parsed_date
 
     except (ValueError, TypeError) as e:
-        raise DateValidationError(f"Invalid date format: {str(e)}")
+        raise DateValidationError(f"Invalid date format: {str(e)}") from e
 
 
 def validate_search_query(query: str) -> str:
@@ -509,7 +509,7 @@ def validate_custom_fields(
     try:
         serialized = json.dumps(custom_fields)
     except (TypeError, ValueError) as e:
-        raise MetadataValidationError(f"custom_fields must be JSON-serializable: {e}")
+        raise MetadataValidationError(f"custom_fields must be JSON-serializable: {e}") from e
 
     # json.dumps escapes null bytes as a backslash-u0000 sequence rather
     # than emitting a raw null byte, so NULL_BYTE_PATTERN (which matches a

--- a/tests/analyze_json.py
+++ b/tests/analyze_json.py
@@ -72,7 +72,7 @@ def analyze_json_structure(file_path):
                 print(f"❌ JSON parsing failed: {e}")
                 print("🔍 This might be a streaming JSON format or malformed")
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
         print(f"❌ Error analyzing file: {e}")
 
 

--- a/tests/standalone_test.py
+++ b/tests/standalone_test.py
@@ -116,7 +116,7 @@ class ConversationMemoryServer:
                         content = f.read().lower()
                         for term in query_terms:
                             score += content.count(term)
-                except BaseException:
+                except BaseException:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
                     continue
 
                 if score > 0:
@@ -135,7 +135,7 @@ class ConversationMemoryServer:
             results.sort(key=lambda x: x["score"], reverse=True)
             return results[:limit]
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
             return [{"error": f"Search failed: {str(e)}"}]
 
     def _get_preview(self, file_path: Path, query_terms: list[str]) -> str:
@@ -160,7 +160,7 @@ class ConversationMemoryServer:
             preview = "\n".join(preview_lines[:10])  # Limit preview length
             return preview[:500] + "..." if len(preview) > 500 else preview
 
-        except BaseException:
+        except BaseException:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
             return "Preview unavailable"
 
     async def add_conversation(
@@ -204,7 +204,7 @@ class ConversationMemoryServer:
                 "message": f"Conversation saved successfully to {filename}",
             }
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
             return {
                 "status": "error",
                 "message": f"Failed to save conversation: {str(e)}",
@@ -237,7 +237,7 @@ class ConversationMemoryServer:
             # Update topics index
             await self._update_topics_index(topics)
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
             print(f"Failed to update index: {e}")
 
     async def _update_topics_index(self, topics: list[str]):
@@ -257,7 +257,7 @@ class ConversationMemoryServer:
             with open(self.topics_file, "w") as f:
                 json.dump(topics_data, f, indent=2)
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
             print(f"Failed to update topics index: {e}")
 
 

--- a/tests/test_100_percent_coverage.py
+++ b/tests/test_100_percent_coverage.py
@@ -4,6 +4,7 @@ Additional tests to achieve 100% coverage for the MCP server
 Targets the remaining 28 uncovered lines from previous coverage report
 """
 
+import contextlib
 import json
 import shutil
 import sys
@@ -1271,7 +1272,7 @@ class TestServerExceptionCoverage:
                 ConversationMemoryServer(temp_storage)
                 # If no exception is raised, the lines might not be covered
                 # But we're testing the path exists
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - mock raises plain Exception; asserting on its message is the point of this coverage test
                 # Exception handling should log and possibly continue
                 assert "JSON write failed" in str(e)
 
@@ -1279,17 +1280,13 @@ class TestServerExceptionCoverage:
         """Test index file creation permission errors"""
         from unittest.mock import patch
 
-        # Mock Path.mkdir to raise PermissionError
-        with patch(
-            "pathlib.Path.mkdir",
-            side_effect=PermissionError("Permission denied"),
+        # Mock Path.mkdir to raise PermissionError. Exception might be
+        # re-raised or handled by the server; either is acceptable.
+        with (
+            patch("pathlib.Path.mkdir", side_effect=PermissionError("Permission denied")),
+            contextlib.suppress(PermissionError),
         ):
-            try:
-                ConversationMemoryServer(temp_storage)
-                # Test that server handles permission errors gracefully
-            except PermissionError:
-                # Exception might be re-raised or handled
-                pass
+            ConversationMemoryServer(temp_storage)
 
     @pytest.mark.asyncio
     async def test_search_conversations_file_error_lines_212_215(self, server):

--- a/tests/test_base_importer_batch_error_handling.py
+++ b/tests/test_base_importer_batch_error_handling.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Test for BaseImporter.batch_import's ``except Exception`` boundary
+(line ~351), flagged as untested new code in PR #175.
+
+Every concrete importer in this repo (Claude/ChatGPT/Cursor/Generic)
+already wraps its own ``import_file`` in a top-level try/except and never
+raises (see the sibling *_error_handling.py test files), so this
+particular boundary can only be reached by a *faulty importer plugin*
+whose ``import_file`` raises directly -- exactly the scenario the
+docstring describes ("skip unimportable file, keep processing the rest of
+the batch"). This test exercises that documented contract with a
+deliberately-raising, real (non-mocked) BaseImporter subclass -- the same
+pattern tests/test_importers/test_base_importer.py already uses to test
+the abstract base class -- rather than mocking the exception on top of an
+existing importer, since no existing importer can trigger this path by
+design.
+"""
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from importers.base_importer import BaseImporter, ImportResult  # noqa: E402
+
+
+class _FlakyImporter(BaseImporter):
+    """A conforming BaseImporter subclass whose import_file raises for one
+    specific input, to exercise batch_import's per-file resilience
+    boundary the way a real (if buggy) importer plugin would."""
+
+    def __init__(self, storage_path: Path):
+        super().__init__(storage_path, "flaky")
+
+    def get_supported_formats(self) -> list[str]:
+        return [".json"]
+
+    def import_file(self, file_path: Path) -> ImportResult:
+        if file_path.name == "boom.json":
+            raise RuntimeError("simulated importer plugin bug")
+        return ImportResult(
+            success=True,
+            conversations_imported=1,
+            conversations_failed=0,
+            errors=[],
+            imported_ids=[file_path.stem],
+            metadata={},
+        )
+
+    def parse_conversation(self, raw_data: Any) -> dict[str, Any]:
+        return self.create_universal_conversation(
+            platform_id="x",
+            title="x",
+            content="x",
+            messages=[],
+            date=None,
+        )
+
+
+@pytest.fixture
+def temp_dir():
+    d = tempfile.mkdtemp(prefix="base_importer_batch_error_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def test_batch_import_skips_raising_file_and_keeps_processing_the_rest(temp_dir):
+    """A file whose import_file raises must be recorded as a failure with
+    the exception message in errors, while unrelated files in the same
+    batch still succeed -- not abort the whole batch."""
+    importer = _FlakyImporter(Path(temp_dir) / "storage")
+    good_one = Path(temp_dir) / "good1.json"
+    boom = Path(temp_dir) / "boom.json"
+    good_two = Path(temp_dir) / "good2.json"
+    for p in (good_one, boom, good_two):
+        p.write_text("{}")
+
+    result = importer.batch_import([good_one, boom, good_two])
+
+    assert result.conversations_imported == 2
+    assert result.conversations_failed == 1
+    assert any("simulated importer plugin bug" in e for e in result.errors)
+    assert any("boom.json" in e for e in result.errors)
+    # The two well-behaved files were still processed despite boom.json.
+    assert set(result.imported_ids) == {"good1", "good2"}

--- a/tests/test_bulk_import_enhanced.py
+++ b/tests/test_bulk_import_enhanced.py
@@ -557,7 +557,7 @@ class TestSaveAndReport:
             dry_run=True,
             detector=_make_detector(PlatformType.UNKNOWN, 0.0),
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Unknown importer label"):
             importer._build_importer("not-a-real-format", tmp_path)
 
 

--- a/tests/test_chatgpt_schema_validation_boundary.py
+++ b/tests/test_chatgpt_schema_validation_boundary.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Test for validate_chatgpt_export's generic ``except Exception`` boundary
+(distinct from its dedicated ImportError and jsonschema.ValidationError
+branches), flagged as untested new code in PR #175.
+
+Real (non-mocked) trigger: the schema's ``mapping`` field uses
+``patternProperties`` keyed on ``^[a-zA-Z0-9-_]+$`` -- a mapping key that
+does *not* match that pattern (e.g. contains a space) is never validated
+by jsonschema at all (patternProperties only constrains matching keys), so
+its value can be anything and jsonschema.validate() still passes. The
+post-schema semantic-validation loop then calls ``node.get("message")`` on
+that value assuming it's a dict, which raises a real AttributeError for a
+non-dict value -- exactly the kind of gap this boundary exists to catch.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from schemas.chatgpt_schema import validate_chatgpt_export  # noqa: E402
+
+
+def test_validate_chatgpt_export_reports_error_on_real_post_schema_failure():
+    """A mapping key that bypasses patternProperties validation (doesn't
+    match the pattern) can hold a non-dict value that passes schema
+    validation but breaks the semantic-validation loop -- must return
+    {"valid": False, "errors": [...]} rather than raise."""
+    data = [
+        {
+            "title": "Conversation with a schema-bypassing mapping key",
+            "create_time": 1700000000.0,
+            "conversation_id": "c1",
+            # "bad key!" contains characters outside ^[a-zA-Z0-9-_]+$, so
+            # jsonschema's patternProperties never validates its value --
+            # a plain string instead of the expected node object.
+            "mapping": {"bad key!": "not a dict"},
+        }
+    ]
+
+    result = validate_chatgpt_export(data)
+
+    assert result["valid"] is False
+    assert result["errors"]
+    assert "attribute 'get'" in result["errors"][0]
+    assert result["conversation_count"] == 0

--- a/tests/test_claude_importer_error_handling.py
+++ b/tests/test_claude_importer_error_handling.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tests for ClaudeImporter's top-level ``except Exception`` boundary in
+import_file (line ~73), flagged as untested new code in PR #175. Real
+(non-mocked) triggers:
+
+- a directory passed where a file is expected, so the shared
+  validate_import_file_path choke point raises MetadataValidationError.
+- a syntactically valid JSON file whose top-level value is a bare int
+  (not an object/array) -- ``_is_claude_memory_format``'s
+  ``"id" not in data`` raises a real TypeError for a non-iterable data
+  type. Note this is *not* wrapped by ``_import_json_format``'s own
+  try/except (which only catches json.JSONDecodeError), so it propagates
+  up to import_file's outer boundary rather than one of the inner
+  format-branch handlers.
+"""
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from importers.claude_importer import ClaudeImporter  # noqa: E402
+
+
+@pytest.fixture
+def temp_dir():
+    d = tempfile.mkdtemp(prefix="claude_importer_error_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture
+def importer(temp_dir):
+    return ClaudeImporter(Path(temp_dir) / "storage")
+
+
+def test_import_file_reports_failure_on_real_validation_error(importer, temp_dir):
+    """A directory passed as file_path makes validate_import_file_path
+    raise a real MetadataValidationError -- must be reported via
+    ImportResult(success=False), not propagate."""
+    result = importer.import_file(Path(temp_dir))
+
+    assert result.success is False
+    assert result.conversations_failed == 1
+    assert any("not a regular file" in e for e in result.errors)
+
+
+def test_import_file_reports_failure_on_real_non_dict_json_content(importer, temp_dir):
+    """A JSON file whose top-level value is a bare scalar (valid JSON, but
+    not an object/array) makes the format-detection helpers raise a real
+    TypeError -- must be reported via ImportResult(success=False), not
+    propagate."""
+    scalar_file = Path(temp_dir) / "weird.json"
+    scalar_file.write_text("42")
+
+    result = importer.import_file(scalar_file)
+
+    assert result.success is False
+    assert result.conversations_failed == 1
+    assert result.errors  # some failure message was recorded, not silently dropped

--- a/tests/test_conversation_memory_rollback_logging.py
+++ b/tests/test_conversation_memory_rollback_logging.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Tests for ConversationMemoryServer's best-effort rollback/index-repair
+handlers: ``_rollback_add_conversation``, ``_remove_index_entry``,
+``_rollback_update_conversation``, ``_replace_index_entry``, and
+``_resync_topics_index`` (both its read and write ``except`` branches),
+plus the legacy ``_analyze_conversations`` per-item handler. All were
+flagged as untested new code in PR #175 (the noqa-comment PR that also
+upgraded their ``logger.error`` calls to ``logger.exception`` for full
+tracebacks).
+
+Each handler is documented as "best-effort: logged, not raised" -- these
+run *inside* an already-failing rollback path, so a second failure there
+must not crash the caller or corrupt state further. Each test forces a
+*real* OSError/ValueError (a directory where a file is expected, a
+read-only file, malformed JSON on disk) rather than mocking the exception,
+and asserts both the logged record and that the method returns normally
+without raising or making things worse.
+"""
+
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from conversation_memory import ConversationMemoryServer  # noqa: E402
+
+
+@pytest.fixture
+def temp_storage():
+    d = tempfile.mkdtemp(prefix="claude_memory_rollback_logging_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture
+def server(temp_storage):
+    return ConversationMemoryServer(temp_storage)
+
+
+def test_rollback_add_conversation_logs_on_real_os_error_removing_file(server, caplog):
+    """_rollback_add_conversation (line ~433): file_path.unlink() must log
+    and swallow a real OSError rather than raise. Forced by pointing it at
+    a directory -- unlink(missing_ok=True) only suppresses
+    FileNotFoundError, not IsADirectoryError -- simulating a stray
+    directory left behind by something else at that path."""
+    stray_dir = server.conversations_path / "conv_20260101_000000_deadbeef.json"
+    stray_dir.mkdir()
+
+    with caplog.at_level(logging.ERROR):
+        # Must not raise.
+        server._rollback_add_conversation(stray_dir, "conv_20260101_000000_deadbeef", [])
+
+    assert stray_dir.exists()  # best-effort: not force-deleted some other way
+    assert any("Rollback: failed to remove orphaned file" in r.message for r in caplog.records)
+
+
+def test_remove_index_entry_logs_on_real_malformed_index(server, caplog):
+    """_remove_index_entry (line ~455): must log and swallow a real
+    json.JSONDecodeError from a genuinely corrupt index.json rather than
+    raise."""
+    server.index_file.write_text("{not valid json,,,")
+
+    with caplog.at_level(logging.ERROR):
+        server._remove_index_entry("conv_x")
+
+    # Best-effort: the corrupt file is left as-is, not silently blown away.
+    assert server.index_file.read_text() == "{not valid json,,,"
+    assert any("Rollback: failed to remove index entry" in r.message for r in caplog.records)
+
+
+def test_rollback_update_conversation_logs_on_real_os_error_restoring_content(server, caplog):
+    """_rollback_update_conversation (line ~648): the write-back must log
+    and swallow a real OSError rather than raise. Forced by pointing it at
+    a directory -- open(path, "w") on a directory raises
+    IsADirectoryError."""
+    stray_dir = server.conversations_path / "conv_20260101_000000_cafebabe.json"
+    stray_dir.mkdir()
+
+    with caplog.at_level(logging.ERROR):
+        server._rollback_update_conversation(stray_dir, "original content")
+
+    assert any("Rollback: failed to restore prior content" in r.message for r in caplog.records)
+
+
+def test_replace_index_entry_logs_on_real_malformed_index(server, caplog):
+    """_replace_index_entry (line ~687): must log and swallow a real
+    json.JSONDecodeError from a genuinely corrupt index.json rather than
+    raise."""
+    server.index_file.write_text("{not valid json,,,")
+    conversation_data = {
+        "id": "conv_x",
+        "title": "t",
+        "date": "2026-01-01T00:00:00",
+        "topics": [],
+    }
+    fake_file = server.conversations_path / "2026" / "01-january" / "conv_x.json"
+
+    with caplog.at_level(logging.ERROR):
+        server._replace_index_entry(conversation_data, fake_file)
+
+    assert server.index_file.read_text() == "{not valid json,,,"
+    assert any("Error replacing index entry" in r.message for r in caplog.records)
+
+
+def test_resync_topics_index_logs_on_real_malformed_topics_file(server, caplog):
+    """_resync_topics_index's read except (line ~703): must log and return
+    early on a real json.JSONDecodeError from a genuinely corrupt
+    topics.json, rather than raise or attempt the update."""
+    server.topics_file.write_text("{not valid json,,,")
+
+    with caplog.at_level(logging.ERROR):
+        result = server._resync_topics_index(["python"], ["docker"], "conv_x")
+
+    assert result is None
+    # Best-effort: corrupt file left untouched, no write attempted.
+    assert server.topics_file.read_text() == "{not valid json,,,"
+    assert any("Error loading topics index" in r.message for r in caplog.records)
+
+
+def test_resync_topics_index_logs_on_real_os_error_writing(server, caplog):
+    """_resync_topics_index's write except (line ~742): the read must
+    succeed (valid JSON) but the write must fail with a real OSError --
+    forced by making topics.json read-only -- and the handler must log
+    and swallow it rather than raise."""
+    server.topics_file.write_text(json.dumps({"topics": {}}))
+    os.chmod(server.topics_file, 0o444)
+    try:
+        with caplog.at_level(logging.ERROR):
+            # Must not raise even though the write below will fail.
+            server._resync_topics_index(["python"], ["docker"], "conv_x")
+
+        assert any("Error writing topics index" in r.message for r in caplog.records)
+    finally:
+        os.chmod(server.topics_file, 0o644)
+
+
+def test_analyze_conversations_reports_error_on_real_type_error(server):
+    """_analyze_conversations (line ~1184, legacy per-item helper): a
+    malformed entry (non-string file_path, e.g. from a hand-edited or
+    partially-written index) must produce a real TypeError from
+    ``Path / int`` that's caught and reported per-item, not crash the
+    whole batch."""
+    good = {"file_path": "does/not/exist.json", "title": "Fine"}
+    malformed = {"file_path": 12345, "title": "Bad"}  # not a str/PathLike
+
+    results = server._analyze_conversations([good, malformed])
+
+    assert len(results) == 2
+    assert results[0] == {"error": "Conversation file not found"}
+    assert "error" in results[1]

--- a/tests/test_conversation_memory_sqlite_fallback.py
+++ b/tests/test_conversation_memory_sqlite_fallback.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Tests for ConversationMemoryServer's SQLite-failure fallback/handler
+paths in search_conversations / search_by_topic / search_by_tag /
+search_by_session_id / search_by_conversation_type.
+
+Each of these wraps its call into ``self.search_db`` in a broad
+``except Exception`` -- flagged as untested new code in PR #175 -- with one
+of two documented contracts: fall through to the JSON-based search (topic
+and full-text search have a JSON mirror), or surface a
+``[{"error": ...}]`` result (tag/session/conversation_type have no JSON
+mirror, per PR #114).
+
+SearchDatabase's own methods already catch ``sqlite3.Error`` internally, so
+dropping a table does *not* reach these outer handlers -- it's absorbed one
+layer down (see test_search_database_error_handling.py). What *does* reach
+these outer handlers, without any mocking, is a row whose ``topics_json``
+column is not valid JSON: every SearchDatabase read method does an inline
+``json.loads(row["topics_json"])`` that is *not* wrapped by its own
+``except sqlite3.Error``, so a corrupted column genuinely raises
+``json.JSONDecodeError`` up through SearchDatabase into these handlers.
+This is a real gap (a corrupted DB row -- e.g. from a partial write --
+would otherwise crash the caller), not a contrived mock.
+"""
+
+import logging
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from conversation_memory import ConversationMemoryServer  # noqa: E402
+
+
+@pytest.fixture
+def temp_storage():
+    d = tempfile.mkdtemp(prefix="claude_memory_sqlite_fallback_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture
+def server(temp_storage):
+    return ConversationMemoryServer(temp_storage)
+
+
+def _corrupt_topics_json(server, conversation_id: str) -> None:
+    """Simulate a corrupted row (e.g. a partial/interrupted write) by
+    forcing the topics_json column to non-JSON text via a direct SQL
+    UPDATE -- not a mock of the exception, a genuine malformed row."""
+    with sqlite3.connect(server.search_db.db_path) as conn:
+        conn.execute(
+            "UPDATE conversations SET topics_json = 'not-json' WHERE id = ?",
+            (conversation_id,),
+        )
+        conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_search_conversations_falls_back_to_linear_on_real_sqlite_failure(server, caplog):
+    """search_conversations (line ~799): on a real (unmocked) SQLite
+    search failure it must log a warning and fall through to the linear
+    JSON search rather than raise or silently return nothing -- the linear
+    fallback must still find the conversation."""
+    if not server.use_sqlite_search:
+        pytest.skip("SQLite search unavailable")
+
+    added = await server.add_conversation(
+        content="Notes about python asyncio patterns", title="Async notes"
+    )
+    assert added["status"] == "success"
+    conv_id = Path(added["file_path"]).stem
+    _corrupt_topics_json(server, conv_id)
+
+    with caplog.at_level(logging.WARNING):
+        results = await server.search_conversations("asyncio", limit=5)
+
+    assert any("falling back to linear search" in r.message for r in caplog.records)
+    # The linear fallback must actually have found it -- not just "didn't crash".
+    assert any(r.get("id") == conv_id for r in results)
+
+
+@pytest.mark.asyncio
+async def test_search_by_topic_falls_back_to_json_on_real_sqlite_failure(server, caplog):
+    """search_by_topic (line ~1093): on a real SQLite topic-search failure
+    it must log a warning and fall through to _search_topic_json, which
+    must still find the conversation via topics.json."""
+    if not server.use_sqlite_search:
+        pytest.skip("SQLite search unavailable")
+
+    added = await server.add_conversation(
+        content="Deep dive into python generators", title="Generators"
+    )
+    assert added["status"] == "success"
+    conv_id = Path(added["file_path"]).stem
+    _corrupt_topics_json(server, conv_id)
+
+    with caplog.at_level(logging.WARNING):
+        results = await server.search_by_topic("python", limit=5)
+
+    assert any("SQLite topic search failed" in r.message for r in caplog.records)
+    assert any(r.get("id") == conv_id for r in results)
+
+
+@pytest.mark.asyncio
+async def test_search_by_tag_reports_error_on_real_sqlite_failure_no_json_fallback(server, caplog):
+    """search_by_tag (line ~1109) has no JSON mirror (tags are SQLite-only,
+    PR #114): on a real SQLite failure it must log a warning and return
+    the documented [{"error": ...}] shape rather than raise or return an
+    empty/misleading result."""
+    if not server.use_sqlite_search:
+        pytest.skip("SQLite search unavailable")
+
+    added = await server.add_conversation(
+        content="Tagged conversation content", title="Tagged", tags=["urgent"]
+    )
+    assert added["status"] == "success"
+    conv_id = Path(added["file_path"]).stem
+    _corrupt_topics_json(server, conv_id)
+
+    with caplog.at_level(logging.WARNING):
+        results = await server.search_by_tag("urgent", limit=5)
+
+    assert any("SQLite tag search failed" in r.message for r in caplog.records)
+    assert results == [{"error": results[0]["error"]}]
+    assert "Tag search failed" in results[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_by_session_id_reports_error_on_real_sqlite_failure(server, caplog):
+    """search_by_session_id (line ~1120) has no JSON mirror: on a real
+    SQLite failure it must log a warning and return the documented
+    [{"error": ...}] shape rather than raise."""
+    if not server.use_sqlite_search:
+        pytest.skip("SQLite search unavailable")
+
+    added = await server.add_conversation(
+        content="Session-scoped content", title="Session", session_id="sess-42"
+    )
+    assert added["status"] == "success"
+    conv_id = Path(added["file_path"]).stem
+    _corrupt_topics_json(server, conv_id)
+
+    with caplog.at_level(logging.WARNING):
+        results = await server.search_by_session_id("sess-42", limit=5)
+
+    assert any("SQLite session search failed" in r.message for r in caplog.records)
+    assert results == [{"error": results[0]["error"]}]
+    assert "Session search failed" in results[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_by_conversation_type_reports_error_on_real_sqlite_failure(server, caplog):
+    """search_by_conversation_type (line ~1133) has no JSON mirror: on a
+    real SQLite failure it must log a warning and return the documented
+    [{"error": ...}] shape rather than raise."""
+    if not server.use_sqlite_search:
+        pytest.skip("SQLite search unavailable")
+
+    added = await server.add_conversation(
+        content="Debugging session content",
+        title="Debug",
+        conversation_type="debugging",
+    )
+    assert added["status"] == "success"
+    conv_id = Path(added["file_path"]).stem
+    _corrupt_topics_json(server, conv_id)
+
+    with caplog.at_level(logging.WARNING):
+        results = await server.search_by_conversation_type("debugging", limit=5)
+
+    assert any("SQLite conversation-type search failed" in r.message for r in caplog.records)
+    assert results == [{"error": results[0]["error"]}]
+    assert "Conversation-type search failed" in results[0]["error"]

--- a/tests/test_cursor_importer_error_handling.py
+++ b/tests/test_cursor_importer_error_handling.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for CursorImporter's two ``except Exception`` boundaries in
+import_file: the per-session handler (parse/save failures) and the
+top-level handler (anything before that). Flagged as untested new code in
+PR #175. Both are resilience boundaries for bulk_import_enhanced.py
+processing arbitrary, possibly hand-edited Cursor session exports -- they
+must report failure via ImportResult rather than crash the batch run.
+
+Each test forces a genuine failure rather than mocking the exception:
+
+- per-session handler: a syntactically valid Cursor session (passes the
+  presence-based ``_validate_cursor_format`` check) whose "workspace"
+  field is an int instead of a string, so ``Path(workspace)`` in
+  parse_conversation raises a real TypeError.
+- top-level handler: a .json file containing bytes that are not valid
+  UTF-8, distinct from the dedicated json.JSONDecodeError branch.
+"""
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from importers.cursor_importer import CursorImporter  # noqa: E402
+
+
+@pytest.fixture
+def temp_dir():
+    d = tempfile.mkdtemp(prefix="cursor_importer_error_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture
+def importer(temp_dir):
+    return CursorImporter(Path(temp_dir) / "storage")
+
+
+def test_import_file_reports_failure_on_real_type_error_during_parse(importer, temp_dir):
+    """The per-session except: a session that passes format validation but
+    has a non-string "workspace" makes Path(workspace) raise a real
+    TypeError inside parse_conversation -- must be reported via
+    ImportResult(success=False), not propagate."""
+    session_file = Path(temp_dir) / "session.json"
+    session_file.write_text('{"session_id": "s1", "workspace": 12345, "interactions": []}')
+
+    result = importer.import_file(session_file)
+
+    assert result.success is False
+    assert result.conversations_failed == 1
+    assert result.conversations_imported == 0
+    assert any("Failed to process Cursor session" in e for e in result.errors)
+
+
+def test_import_file_reports_failure_on_real_undecodable_bytes(importer, temp_dir):
+    """The top-level except (distinct from the dedicated JSONDecodeError
+    branch): a .json file containing bytes that are not valid UTF-8 makes
+    the file read itself raise UnicodeDecodeError -- must be reported via
+    ImportResult(success=False), not propagate."""
+    session_file = Path(temp_dir) / "session.json"
+    session_file.write_bytes(b"\xff\xfe\x00 not utf8 \x80\x81")
+
+    result = importer.import_file(session_file)
+
+    assert result.success is False
+    assert result.conversations_failed == 1
+    assert any("Import failed" in e for e in result.errors)

--- a/tests/test_exporters/test_base_exporter.py
+++ b/tests/test_exporters/test_base_exporter.py
@@ -437,7 +437,12 @@ class TestWriteJson:
         # /proc is non-writable on Linux; using a known pseudo-fs path keeps
         # the test platform-portable since we only need the OSError raise.
         bad_path = Path("/proc/cannot-write-here/out.json")
-        with pytest.raises(OSError):
+        # The exact OSError subclass under /proc varies by kernel/mount setup
+        # (observed both FileNotFoundError and PermissionError) - narrowing to
+        # one subclass or matching an exact errno string would make this test
+        # environment-fragile. The contract under test is genuinely "some
+        # OSError", per write_json's own docstring.
+        with pytest.raises(OSError):  # noqa: PT011 - see comment above
             exp.write_json(bad_path, {"x": 1})
 
 

--- a/tests/test_format_detector_error_handling.py
+++ b/tests/test_format_detector_error_handling.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tests for FormatDetector's ``except Exception`` boundaries.
+
+detect_format() runs on arbitrary user-supplied files during bulk import --
+it must classify anything as UNKNOWN/0.0 rather than crash the import CLI.
+Flagged as untested new code in PR #175. Each test forces a genuinely
+malformed input rather than mocking the exception:
+
+- detect_format's own outer handler: pointed at a directory, so the shared
+  ``validate_import_file_path`` choke point raises MetadataValidationError
+  (it exists but is not a regular file).
+- _detect_json_format's generic handler (distinct from its dedicated
+  JSONDecodeError branch): a syntactically-valid JSON file whose
+  ``role`` field is not a string, so ``_has_role_based_messages``'s
+  ``msg["role"].lower()`` raises a real AttributeError.
+- _detect_text_format's handler: a .txt file containing bytes that are not
+  valid UTF-8, so the file read itself raises UnicodeDecodeError.
+"""
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from format_detector import FormatDetector, PlatformType  # noqa: E402
+
+
+@pytest.fixture
+def temp_dir():
+    d = tempfile.mkdtemp(prefix="format_detector_error_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture
+def detector():
+    return FormatDetector()
+
+
+def test_detect_format_reports_unknown_on_real_validation_error(detector, temp_dir):
+    """detect_format's outer except: a directory passed where a file is
+    expected makes validate_import_file_path raise a real
+    MetadataValidationError (not a mock) -- must be classified as
+    UNKNOWN/0.0 with a message, not propagate."""
+    directory_path = Path(temp_dir)  # exists, but is not a regular file
+
+    result = detector.detect_format(directory_path)
+
+    assert result["platform"] == PlatformType.UNKNOWN.value
+    assert result["confidence"] == 0.0
+    assert "not a regular file" in result["message"] or "Detection error" in result["message"]
+
+
+def test_detect_json_format_reports_unknown_on_real_non_json_decode_error(detector, temp_dir):
+    """_detect_json_format's generic except (distinct from its dedicated
+    json.JSONDecodeError branch): syntactically valid JSON whose "role"
+    field is a non-string int makes _has_role_based_messages's
+    ``msg["role"].lower()`` raise a real AttributeError -- must be
+    classified as UNKNOWN/0.0, not propagate."""
+    export_file = Path(temp_dir) / "export.json"
+    export_file.write_text(
+        json.dumps({"conversations": [{"messages": [{"role": 1}, {"role": 2}]}]})
+    )
+
+    result = detector.detect_format(export_file)
+
+    assert result["platform"] == PlatformType.UNKNOWN.value
+    assert result["confidence"] == 0.0
+    assert "JSON analysis error" in result["message"]
+
+
+def test_detect_text_format_reports_unknown_on_real_undecodable_bytes(detector, temp_dir):
+    """_detect_text_format's except: a .txt file containing bytes that are
+    not valid UTF-8 makes the file read itself raise a real
+    UnicodeDecodeError -- must be classified as UNKNOWN/0.0, not
+    propagate."""
+    notes_file = Path(temp_dir) / "notes.txt"
+    notes_file.write_bytes(b"\xff\xfe\x00invalid utf8 \x80\x81")
+
+    result = detector.detect_format(notes_file)
+
+    assert result["platform"] == PlatformType.UNKNOWN.value
+    assert result["confidence"] == 0.0
+    assert "Text analysis error" in result["message"]

--- a/tests/test_importers/test_base_importer.py
+++ b/tests/test_importers/test_base_importer.py
@@ -434,13 +434,13 @@ class TestUniversalMetadataFields:
 
     def _build(self, **kwargs):
         """Build a minimal universal conversation with overrides."""
-        defaults = dict(
-            platform_id="meta_test",
-            title="Meta",
-            content="content",
-            messages=[],
-            date=datetime(2026, 4, 18, 10, 0, 0),
-        )
+        defaults = {
+            "platform_id": "meta_test",
+            "title": "Meta",
+            "content": "content",
+            "messages": [],
+            "date": datetime(2026, 4, 18, 10, 0, 0),
+        }
         defaults.update(kwargs)
         return self.importer.create_universal_conversation(**defaults)
 

--- a/tests/test_importers/test_chatgpt_importer.py
+++ b/tests/test_importers/test_chatgpt_importer.py
@@ -119,7 +119,7 @@ class TestChatGPTImporter:
 
     def test_parse_conversation_invalid_data(self):
         """Test parsing invalid conversation data."""
-        with pytest.raises(ValueError, match="ChatGPT conversation data must be a dictionary"):
+        with pytest.raises(TypeError, match="ChatGPT conversation data must be a dictionary"):
             self.importer.parse_conversation("not a dict")
 
     def test_parse_conversation_missing_messages(self):

--- a/tests/test_importers/test_claude_importer.py
+++ b/tests/test_importers/test_claude_importer.py
@@ -206,8 +206,8 @@ class TestClaudeImporterParsingMethods:
         assert len(result["messages"]) == 1
 
     def test_parse_conversation_invalid_type(self):
-        """Test parsing invalid type raises ValueError."""
-        with pytest.raises(ValueError, match="Claude conversation data must be"):
+        """Test parsing invalid type raises TypeError."""
+        with pytest.raises(TypeError, match="Claude conversation data must be"):
             self.importer.parse_conversation(123)
 
     def test_detect_claude_format_memory(self):

--- a/tests/test_importers/test_cursor_importer.py
+++ b/tests/test_importers/test_cursor_importer.py
@@ -251,7 +251,7 @@ class TestCursorImporterParsing:
         """Test parsing invalid conversation data."""
         data = "not a dictionary"
 
-        with pytest.raises(ValueError, match="Cursor session data must be a dictionary"):
+        with pytest.raises(TypeError, match="Cursor session data must be a dictionary"):
             self.importer.parse_conversation(data)
 
     def test_parse_conversation_missing_interactions(self):

--- a/tests/test_importers/test_generic_importer.py
+++ b/tests/test_importers/test_generic_importer.py
@@ -447,8 +447,8 @@ class TestGenericImporterParsingMethods:
         assert len(result["messages"]) == 2
 
     def test_parse_conversation_invalid_type(self):
-        """Test parsing invalid type raises ValueError."""
-        with pytest.raises(ValueError, match="Generic conversation data must be"):
+        """Test parsing invalid type raises TypeError."""
+        with pytest.raises(TypeError, match="Generic conversation data must be"):
             self.importer.parse_conversation(123)
 
     def test_looks_like_conversation_positive(self):
@@ -602,7 +602,7 @@ class TestGenericImporterHelperMethods:
         """Test XML element conversation detection."""
         # Create XML elements
         conv_elem = ET.Element("conversation")
-        for i in range(5):
+        for _ in range(5):
             ET.SubElement(conv_elem, "message")
 
         random_elem = ET.Element("data")

--- a/tests/test_importers/test_import_integration.py
+++ b/tests/test_importers/test_import_integration.py
@@ -105,7 +105,7 @@ class TestImportIntegration:
             pytest.fail("Expected ChatGPT format detection")
 
         # Import with detected importer
-        with patch.object(importer, "_save_conversation") as mock_save:
+        with patch.object(importer, "_save_conversation"):
             result = importer.import_file(test_file)
 
         assert result.success is True
@@ -190,9 +190,11 @@ class TestImportIntegration:
                 return False
             return original_validate(conv)
 
-        with patch.object(importer, "_validate_conversation", side_effect=mock_validate):
-            with patch.object(importer, "_save_conversation") as mock_save:
-                result = importer.import_file(test_file)
+        with (
+            patch.object(importer, "_validate_conversation", side_effect=mock_validate),
+            patch.object(importer, "_save_conversation"),
+        ):
+            result = importer.import_file(test_file)
 
         # Should have partial success
         assert result.conversations_imported >= 1
@@ -283,7 +285,7 @@ class TestImportIntegration:
 
         importer = ChatGPTImporter(self.storage_path)
 
-        with patch.object(importer, "_save_conversation") as mock_save:
+        with patch.object(importer, "_save_conversation"):
             start_time = time.time()
             result = importer.import_file(test_file)
             end_time = time.time()

--- a/tests/test_json_formatter_ultimate_fallback.py
+++ b/tests/test_json_formatter_ultimate_fallback.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Test for JSONFormatter.format's *ultimate* fallback (line ~248),
+flagged as untested new code in PR #175.
+
+tests/test_json_logging.py already covers the first-level fallback: a
+non-serializable ``context`` value gets stringified and the retry
+succeeds. This test covers the deeper handler -- reached only when the
+retry *still* fails because some other field (not "context") is
+non-serializable, so stringifying context alone doesn't fix it. A
+Formatter.format() must never raise (it would break the whole logging
+pipeline), so even this double-failure case must still produce valid
+JSON. Forced with a real (non-mocked) unserializable value assigned to
+``correlation_id`` via a genuine LogRecord, not a mock of json.dumps.
+"""
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from logging_config import JSONFormatter  # noqa: E402
+
+
+def test_format_falls_back_to_basic_error_message_when_retry_still_fails():
+    """A non-serializable ``correlation_id`` (not "context") survives the
+    first fallback's context-stringification untouched, so the retry
+    ``json.dumps`` genuinely fails a second time -- forcing the ultimate
+    fallback. The result must still be valid, parseable JSON with an
+    error message, not raise."""
+    record = logging.LogRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=42,
+        msg="hello",
+        args=None,
+        exc_info=None,
+    )
+    record.correlation_id = {1, 2, 3}  # a set: not JSON serializable
+
+    output = JSONFormatter().format(record)
+
+    parsed = json.loads(output)  # must not raise -- proves valid JSON was produced
+    assert parsed["level"] == "ERROR"
+    assert "Failed to serialize log record" in parsed["message"]
+    # The unserializable field must not have leaked into the fallback output.
+    assert "correlation_id" not in parsed

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,6 @@
 """Test logging functionality for Claude Memory MCP system"""
 
+import contextlib
 import logging
 import os
 import tempfile
@@ -361,10 +362,8 @@ class TestLoggingIntegration:
             finally:
                 # Clean up potential backup files
                 for suffix in ["", ".1", ".2"]:
-                    try:
+                    with contextlib.suppress(FileNotFoundError):
                         os.unlink(f"{temp_file.name}{suffix}")
-                    except FileNotFoundError:
-                        pass
 
 
 class TestLoggingExceptionHandling:
@@ -382,7 +381,7 @@ class TestLoggingExceptionHandling:
             try:
                 log_function_call("test_function", param1="value1", param2="value2")
                 # Should not raise an exception due to silent failure
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - test asserts the function fails silently: catch-and-fail is the assertion
                 pytest.fail(f"log_function_call should fail silently, but raised: {e}")
 
     def test_log_performance_exception_handling(self):
@@ -396,7 +395,7 @@ class TestLoggingExceptionHandling:
             try:
                 log_performance("test_function", 1.234, results=10)
                 # Should not raise an exception due to silent failure
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - test asserts the function fails silently: catch-and-fail is the assertion
                 pytest.fail(f"log_performance should fail silently, but raised: {e}")
 
     def test_log_security_event_exception_handling(self):
@@ -410,7 +409,7 @@ class TestLoggingExceptionHandling:
             try:
                 log_security_event("TEST_EVENT", "Test message", "ERROR")
                 # Should not raise an exception due to silent failure
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - test asserts the function fails silently: catch-and-fail is the assertion
                 pytest.fail(f"log_security_event should fail silently, but raised: {e}")
 
     def test_security_event_path_redaction_failure(self):
@@ -428,7 +427,7 @@ class TestLoggingExceptionHandling:
                     "ERROR",
                 )
                 # Should not raise an exception - should use fallback path redaction
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - test asserts the function fails silently: catch-and-fail is the assertion
                 pytest.fail(
                     f"log_security_event should handle path operation errors, but raised: {e}"
                 )
@@ -448,7 +447,7 @@ class TestLoggingExceptionHandling:
                     "WARNING",
                 )
                 # Should not raise an exception - should use fallback
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - test asserts the function fails silently: catch-and-fail is the assertion
                 pytest.fail(f"log_security_event should handle OSError, but raised: {e}")
 
     def test_file_operation_path_redaction_failure(self):
@@ -459,7 +458,7 @@ class TestLoggingExceptionHandling:
             try:
                 log_file_operation("read", "/some/file/path.txt", True)
                 # Should not raise an exception
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - test asserts the function fails silently: catch-and-fail is the assertion
                 pytest.fail(f"log_file_operation should handle path errors, but raised: {e}")
 
 

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -341,7 +341,7 @@ class TestFastMCPServer:
         try:
             results = await server.search_conversations("test", limit=1)
             assert isinstance(results, list)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - environment-dependent smoke test: skip rather than fail when preconditions aren't met
             pytest.skip(f"FastMCP search test skipped due to: {e}")
 
 

--- a/tests/test_migrate_to_sqlite_error_handling.py
+++ b/tests/test_migrate_to_sqlite_error_handling.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Tests for ConversationMigrator's ``except Exception`` boundaries.
+
+migrate_to_sqlite.py's job is to walk a directory of untrusted, possibly
+hand-edited JSON files and load them into SQLite without one bad file
+aborting the whole run. Each handler here is either a per-item resilience
+boundary (skip this item, keep going) or a top-level boundary (report
+failure in the returned dict rather than raise). These were flagged as
+untested new code in PR #175. Each test forces a *real* failure (malformed
+JSON on disk, a missing required key, a corrupted DB column) rather than
+mocking the exception, and asserts the documented degradation contract:
+the batch keeps going and the specific error surfaces in the stats/result
+dict.
+"""
+
+import json
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from migrate_to_sqlite import ConversationMigrator  # noqa: E402
+
+
+@pytest.fixture
+def temp_storage():
+    d = tempfile.mkdtemp(prefix="migrate_error_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def _write_conversation_file(conversations_dir: Path, conv_id: str) -> Path:
+    year_dir = conversations_dir / "2025" / "01-january"
+    year_dir.mkdir(parents=True, exist_ok=True)
+    path = year_dir / f"{conv_id}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "id": conv_id,
+                "title": "Valid conversation",
+                "content": "some real content about python",
+                "date": "2025-01-01T00:00:00",
+                "created_at": "2025-01-01T00:00:00",
+                "topics": ["python"],
+            }
+        )
+    )
+    return path
+
+
+def test_detect_data_directory_structure_defaults_to_new_layout(temp_storage):
+    """_detect_data_directory_structure (line ~59, simplified in PR #175
+    from an if/return chain to a single boolean expression) is not an
+    exception handler but is new code from the same PR: exercise its
+    auto-detect path (use_data_dir=None) directly, rather than the other
+    tests' explicit use_data_dir=True, to cover the actual branch."""
+    # Neither data/conversations nor conversations exists yet -> must
+    # default to the new data/ layout.
+    migrator = ConversationMigrator(temp_storage, use_data_dir=None)
+    assert migrator.conversations_path == Path(temp_storage) / "data" / "conversations"
+
+
+def test_migrate_all_conversations_reports_error_on_malformed_index_json(temp_storage):
+    """migrate_all_conversations's top-level except (line ~98) must catch a
+    genuinely malformed index.json (not a mock) and report the failure in
+    the returned stats dict rather than raising out of the MCP tool call."""
+    conversations_dir = Path(temp_storage) / "data" / "conversations"
+    conversations_dir.mkdir(parents=True, exist_ok=True)
+    (conversations_dir / "index.json").write_text("{not valid json,,,")
+
+    migrator = ConversationMigrator(temp_storage, use_data_dir=True)
+    stats = migrator.migrate_all_conversations()
+
+    assert "error" in stats
+    assert stats["successfully_migrated"] == 0
+
+
+def test_migrate_single_conversation_skips_entry_missing_file_path_and_keeps_batch_going(
+    temp_storage,
+):
+    """_migrate_single_conversation's except (line ~162) must catch a real
+    KeyError from an index entry that's missing the required "file_path"
+    key -- e.g. a hand-edited or partially-written index.json -- and skip
+    just that entry, not abort the whole migration. Verified end-to-end
+    through migrate_all_conversations with one good entry alongside the
+    malformed one."""
+    conversations_dir = Path(temp_storage) / "data" / "conversations"
+    conversations_dir.mkdir(parents=True, exist_ok=True)
+    good_path = _write_conversation_file(conversations_dir, "conv_good")
+
+    index_data = {
+        "conversations": [
+            {
+                "id": "conv_good",
+                "file_path": str(good_path.relative_to(Path(temp_storage))),
+            },
+            {
+                # Missing "file_path" entirely -> conv_info["file_path"]
+                # raises a real KeyError inside _migrate_single_conversation.
+                "id": "conv_malformed",
+            },
+        ]
+    }
+    (conversations_dir / "index.json").write_text(json.dumps(index_data))
+
+    migrator = ConversationMigrator(temp_storage, use_data_dir=True)
+    stats = migrator.migrate_all_conversations()
+
+    assert "error" not in stats
+    assert stats["total_found"] == 2
+    assert stats["successfully_migrated"] == 1
+    assert stats["failed_migrations"] == 1
+
+
+def test_migrate_json_file_skips_unparseable_file_and_keeps_batch_going(temp_storage):
+    """_migrate_json_file's except (line ~195) must catch a real
+    json.JSONDecodeError from a genuinely corrupt file on disk (not a
+    mock) during the no-index directory scan, and skip just that file."""
+    conversations_dir = Path(temp_storage) / "data" / "conversations"
+    conversations_dir.mkdir(parents=True, exist_ok=True)
+    _write_conversation_file(conversations_dir, "conv_good")
+
+    garbage_dir = conversations_dir / "2025" / "01-january"
+    (garbage_dir / "corrupt.json").write_text("this is not { valid json at all")
+
+    # No index.json written -> migrate_all_conversations falls through to
+    # the directory-scan path (_migrate_without_index -> _migrate_json_file).
+    migrator = ConversationMigrator(temp_storage, use_data_dir=True)
+    stats = migrator.migrate_all_conversations()
+
+    assert "error" not in stats
+    assert stats["total_found"] == 2
+    assert stats["successfully_migrated"] == 1
+    assert stats["failed_migrations"] == 1
+
+
+def test_verify_migration_reports_error_on_real_search_failure(temp_storage):
+    """verify_migration's top-level except (line ~235) must catch a
+    genuine, unmocked failure surfacing from the search layer and report
+    it via {"error": ...} rather than raising. Forced by corrupting the
+    topics_json column directly (simulating a partially-written/corrupted
+    row) so search_conversations's inline json.loads raises a
+    JSONDecodeError that SearchDatabase's own except sqlite3.Error does
+    not catch."""
+    conversations_dir = Path(temp_storage) / "data" / "conversations"
+    conversations_dir.mkdir(parents=True, exist_ok=True)
+
+    migrator = ConversationMigrator(temp_storage, use_data_dir=True)
+    assert migrator.search_db.add_conversation(
+        {
+            "id": "conv_1",
+            "title": "t",
+            "content": "python notes",
+            "date": "2025-01-01T00:00:00",
+            "created_at": "2025-01-01T00:00:00",
+            "topics": ["python"],
+        },
+        "2025/01-january/conv_1.json",
+    )
+
+    with sqlite3.connect(migrator.search_db.db_path) as conn:
+        conn.execute("UPDATE conversations SET topics_json = 'not-json' WHERE id = 'conv_1'")
+        conn.commit()
+
+    result = migrator.verify_migration()
+
+    assert "error" in result
+    assert "sqlite_count" not in result

--- a/tests/test_performance_benchmarks.py
+++ b/tests/test_performance_benchmarks.py
@@ -247,7 +247,7 @@ class TestSearchPerformance:
         # Perform multiple searches to check for memory leaks
         performance_metrics.start()
 
-        for i in range(100):
+        for _ in range(100):
             await server.search_conversations("python testing", limit=20)
 
         metrics = performance_metrics.stop()

--- a/tests/test_search_database_error_handling.py
+++ b/tests/test_search_database_error_handling.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Tests for SearchDatabase's ``except sqlite3.Error`` handlers.
+
+Every method in SearchDatabase wraps its SQL in a broad
+``except sqlite3.Error`` that logs and returns a documented fallback
+(``[]``, ``0``, ``{"error": ...}``) instead of letting a corrupt/locked
+database crash the caller -- or, for ``_init_database``/``rebuild_fts_index``,
+re-raises after logging so the caller can react. These handlers were flagged
+as untested new code in PR #175 (the noqa-comment PR). Each test here forces
+a *real* sqlite3.Error (dropped table, directory-as-db-file) rather than
+mocking the exception into existence, and asserts the documented fallback
+value -- not merely "it didn't raise".
+"""
+
+import logging
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from search_database import SearchDatabase  # noqa: E402
+
+SAMPLE_CONVERSATION = {
+    "id": "conv_1",
+    "title": "Python asyncio notes",
+    "content": "Discussion about python asyncio and docker",
+    "date": "2025-01-01T00:00:00",
+    "created_at": "2025-01-01T00:00:00",
+    "topics": ["python", "asyncio"],
+    "tags": ["work"],
+}
+
+
+@pytest.fixture
+def temp_dir():
+    d = tempfile.mkdtemp(prefix="search_db_error_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture
+def db(temp_dir):
+    sdb = SearchDatabase(str(Path(temp_dir) / "search.db"))
+    assert sdb.add_conversation(dict(SAMPLE_CONVERSATION), "path/conv_1.json")
+    return sdb
+
+
+def _drop(db, table):
+    with sqlite3.connect(db.db_path) as conn:
+        conn.execute(f"DROP TABLE {table}")
+        conn.commit()
+
+
+def test_init_database_raises_and_logs_on_real_sqlite_error(temp_dir, caplog):
+    """_init_database's except (line ~151) must log and *re-raise* rather
+    than silently swallow a real init failure. Force a genuine
+    sqlite3.OperationalError by pointing db_path at a pre-existing
+    directory -- sqlite3.connect() cannot open a directory as a database
+    file. No mocking: this is what happens if deployment creates the
+    parent path as a directory by mistake."""
+    dir_as_db = Path(temp_dir) / "search.db"
+    dir_as_db.mkdir()
+
+    with caplog.at_level(logging.ERROR), pytest.raises(sqlite3.Error):
+        SearchDatabase(str(dir_as_db))
+
+    assert any("Database initialization failed" in r.message for r in caplog.records)
+
+
+def test_search_conversations_falls_back_on_real_sqlite_error(db, caplog):
+    """search_conversations (line ~296) must log and return the documented
+    ``[{"error": ...}]`` shape, not raise, when the FTS table backing the
+    query is gone."""
+    _drop(db, "conversations_fts")
+
+    with caplog.at_level(logging.ERROR):
+        result = db.search_conversations("python", limit=5)
+
+    assert result == [{"error": result[0]["error"]}]
+    assert "Search failed" in result[0]["error"]
+    assert any("Search failed" in r.message for r in caplog.records)
+
+
+def test_search_by_topic_falls_back_on_real_sqlite_error(db, caplog):
+    """search_by_topic (line ~331) must log and return ``[]`` (its
+    documented fallback) when the topics join table is gone, not raise."""
+    _drop(db, "conversation_topics")
+
+    with caplog.at_level(logging.ERROR):
+        result = db.search_by_topic("python", limit=5)
+
+    assert result == []
+    assert any("Topic search failed" in r.message for r in caplog.records)
+
+
+def test_search_by_tag_falls_back_on_real_sqlite_error(db, caplog):
+    """search_by_tag (line ~356) must log and return ``[]`` when the tags
+    join table is gone, not raise."""
+    _drop(db, "conversation_tags")
+
+    with caplog.at_level(logging.ERROR):
+        result = db.search_by_tag("work", limit=5)
+
+    assert result == []
+    assert any("Tag search failed" in r.message for r in caplog.records)
+
+
+def test_search_by_session_id_falls_back_on_real_sqlite_error(db, caplog):
+    """search_by_session_id (line ~380) must log and return ``[]`` when the
+    conversations table itself is gone, not raise."""
+    _drop(db, "conversations")
+
+    with caplog.at_level(logging.ERROR):
+        result = db.search_by_session_id("sess-1", limit=5)
+
+    assert result == []
+    assert any("Session search failed" in r.message for r in caplog.records)
+
+
+def test_search_by_conversation_type_falls_back_on_real_sqlite_error(db, caplog):
+    """search_by_conversation_type (line ~406) must log and return ``[]``
+    when the conversations table itself is gone, not raise."""
+    _drop(db, "conversations")
+
+    with caplog.at_level(logging.ERROR):
+        result = db.search_by_conversation_type("chat", limit=5)
+
+    assert result == []
+    assert any("Conversation-type search failed" in r.message for r in caplog.records)
+
+
+def test_get_conversation_stats_falls_back_on_real_sqlite_error(db, caplog):
+    """get_conversation_stats (line ~477) must log and return
+    ``{"error": ...}`` (not the normal stats dict) when the conversations
+    table is gone, not raise -- this backs the ``get_search_stats`` MCP
+    diagnostics tool."""
+    _drop(db, "conversations")
+
+    with caplog.at_level(logging.ERROR):
+        result = db.get_conversation_stats()
+
+    assert "error" in result
+    assert "total_conversations" not in result
+    assert any("Stats query failed" in r.message for r in caplog.records)
+
+
+def test_rebuild_fts_index_raises_and_logs_on_real_sqlite_error(db, caplog):
+    """rebuild_fts_index (line ~509) must log *and re-raise* -- unlike the
+    search methods, a failed rebuild cannot be silently swallowed because
+    the caller (migrate_to_sqlite.py) depends on knowing it failed."""
+    _drop(db, "conversations_fts")
+
+    with caplog.at_level(logging.ERROR), pytest.raises(sqlite3.Error):
+        db.rebuild_fts_index()
+
+    assert any("FTS index rebuild failed" in r.message for r in caplog.records)
+
+
+def test_get_conversation_count_falls_back_on_real_sqlite_error(db, caplog):
+    """get_conversation_count (line ~520) must log and return ``0`` (its
+    documented fallback), not raise, when the conversations table is
+    gone."""
+    _drop(db, "conversations")
+
+    with caplog.at_level(logging.ERROR):
+        result = db.get_conversation_count()
+
+    assert result == 0
+    assert any("Count query failed" in r.message for r in caplog.records)

--- a/tests/validate_system.py
+++ b/tests/validate_system.py
@@ -49,7 +49,7 @@ async def validate_memory_system():
                             print(f"   📄 Top result: {title}...")
                 else:
                     print(f"⚠️  Search '{query}': No results found")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
                 print(f"❌ Search '{query}' failed: {e}")
 
         # Test 2: Add a test conversation
@@ -75,7 +75,7 @@ This is a test conversation to validate the memory system is working.
                 print("✅ Add conversation: Success")
             else:
                 print(f"❌ Add conversation failed: {result.get('message', 'Unknown error')}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
             print(f"❌ Add conversation failed: {e}")
 
         # Test 3: Search for the test conversation
@@ -94,7 +94,7 @@ This is a test conversation to validate the memory system is working.
                     print("⚠️  Test conversation not found in search results")
             else:
                 print("⚠️  No search results for test conversation")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
             print(f"❌ Search for test conversation failed: {e}")
 
         # Test 4: Weekly summary generation
@@ -113,14 +113,14 @@ This is a test conversation to validate the memory system is working.
                 print(f"   📄 Preview: {preview[:100]}...")
             else:
                 print("⚠️  Weekly summary: No summary generated")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
             print(f"❌ Weekly summary failed: {e}")
 
         print("\n🎯 Validation Complete")
         print("=" * 40)
         print("💡 If all tests show ✅, your memory system is working correctly!")
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
         print(f"❌ Critical error during validation: {e}")
         return False
 
@@ -162,7 +162,7 @@ async def show_system_stats():
                     total_results += count
                     print(f"🏷️  '{term}': {count} conversations")
                 total_searches += 1
-            except Exception:
+            except Exception:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
                 pass
 
         if total_searches > 0:
@@ -171,7 +171,7 @@ async def show_system_stats():
 
         print("\n💾 Memory system is operational and searchable!")
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - manual CLI diagnostic script: print/report and continue rather than crash mid-run
         print(f"❌ Error getting system stats: {e}")
 
 


### PR DESCRIPTION
Replaces #168, which GitHub auto-closed when its base branch (`chore/strict-lint-config`) was deleted on merge of #167. Same commit, cherry-picked onto current `main`. (My error — retarget before deleting a parent branch. Second time tonight.)

## What

The 124 violations #167 deferred because they need judgment, not `--fix`.

## BLE001 — 69 blind `except Exception:` sites: **0 narrowed, 69 justified**

That ratio looks like a rationalization, so I audited it rather than accept it. It holds up. This codebase is built around graceful degradation, and the reasons are site-specific:

| reason | n |
|---|---|
| resilience: skip unparseable item, keep processing the batch | 6 |
| fail silently to prevent logging from crashing the application | 5 |
| top-level import boundary: report via `ImportResult`, don't crash the run | 4 |
| top-level format-branch boundary | 3 |
| best-effort platform classification: report UNKNOWN rather than crash | 3 |
| `Formatter.format()` must never raise (breaks the whole logging pipeline) | 1 |
| …and 47 more, each with its own reason | |

**Zero bare `noqa`s** — verified: `grep -rcE 'noqa: BLE001\s*$'` → 0. Every one carries a justification.

That "Formatter.format() must never raise" case is not hypothetical: a formatter raising is precisely what killed all application logging in #157, fixed in #164. Narrowing these would manufacture the crashes the design exists to prevent.

## Two real behavior changes

1. **TRY004**: 4 importers' `parse_conversation()` now raise `TypeError` (not `ValueError`) for bad input types. **Verified safe end-to-end**: the boundary handler catches `Exception`, so bad input still yields `ImportResult(success=False)` with the error surfaced and no crash. Ironically, the justified blind-excepts above are what make this safe.
2. **TRY400**: `logging.error` → `logging.exception` inside `except` blocks — these were throwing away tracebacks.

## One PT011 left broad, deliberately

`Path("/proc/...").mkdir()`'s OSError subclass varies by kernel/mount, so narrowing would make the test environment-fragile. Kept `pytest.raises(OSError)` with a justified noqa.

## Verification

```
ruff check .                          All checks passed!
ruff format --check .                 57 files already formatted
mypy --config-file=pyproject.toml src Success: no issues found in 23 source files
ruff check --select BLE001 src/ tests/  All checks passed!
bare noqa (no reason)                 0
cd src && python3 -c "import server_fastmcp"   no error, no "--- Logging error ---"
scripts/bulk_import_enhanced.py --help          OK
pytest                                813 passed, 1 skipped
```

Smoke test run explicitly because this PR changes exception handling — 813 passing tests would not have caught a boundary that stopped degrading gracefully.