### PR TITLE
fix(dependabot): use the uv ecosystem so bumps regenerate uv.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,13 @@
 
 version: 2
 updates:
-  # Python dependencies (pyproject.toml)
-  - package-ecosystem: "pip"
+  # Python dependencies. Must be "uv", not "pip": CI installs via
+  # `uv sync --locked` (#171), so a bump that touches pyproject.toml WITHOUT
+  # regenerating uv.lock fails the lockfile-drift guard and the PR can never
+  # go green. The pip ecosystem does not know about uv.lock; the uv ecosystem
+  # updates pyproject.toml and uv.lock together. (#173/#174 both failed this
+  # way -- the guard was right, the config was wrong.)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -35,9 +40,9 @@ updates:
       dev-dependencies:
         patterns:
           - "pytest*"
-          - "black*"
-          - "flake8*"
+          - "ruff*"
           - "mypy*"
+          - "types-*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Every Dependabot PR is currently unmergeable

CI installs with `uv sync --locked` (#171), which fails closed if `uv.lock` drifts from `pyproject.toml`. But `dependabot.yml` says `package-ecosystem: "pip"` — which edits `pyproject.toml` and knows nothing about `uv.lock`:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

Both open Dependabot PRs hit exactly this — #173 (mypy 1.16→2.3) and #174 (ruff 0.15.0→0.15.22). **The guard was right; the config was wrong.** The `uv` ecosystem updates `pyproject.toml` and `uv.lock` together.

## Also: the group was stale

```diff
   dev-dependencies:
     patterns:
       - "pytest*"
-      - "black*"      # deleted in #167 — ruff replaced them
-      - "flake8*"
+      - "ruff*"       # was missing, which is why #174 arrived ungrouped
       - "mypy*"
+      - "types-*"
```

## Both pending bumps verified safe on their merits

Tested directly in clean venvs, not inferred from CI:

| bump | result |
|---|---|
| mypy 2.3.0 (major) | `Success: no issues found in 69 source files` (src + tests + scripts) |
| ruff 0.15.22 | `All checks passed!` / `57 files already formatted` |

So the major mypy bump is a non-event for this codebase — it just couldn't prove it.

## Honest caveat

GitHub validates `dependabot.yml` on its own schedule. **This change is verified by Dependabot's next run, not by CI here.** If the ecosystem name were wrong, Dependabot would silently stop updating rather than fail loudly — worth a glance at the repo's Dependabot page after this lands.