### PR TITLE
fix: pytest.ini uses [tool:pytest] instead of [pytest] -- config is inert

### DIFF
--- a/data/config/pytest.ini
+++ b/data/config/pytest.ini
@@ -1,6 +1,5 @@
-[tool:pytest]
+[pytest]
 testpaths = tests
-python_paths = src
 addopts = -v --tb=short
-asyncio_mode = auto
+asyncio_mode = strict
 asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
## Summary

**Stacked on #180** (`chore/remove-standalone-test`) -- base branch is that PR's branch, not `main`.

`data/config/pytest.ini` (symlinked to `pytest.ini` at repo root) used `[tool:pytest]`, which is the **setup.cfg** section name. A `pytest.ini` file must use `[pytest]`. pytest found the file (hence `configfile: pytest.ini` and a correct `rootdir`) but silently read **none** of its options.

Proven empirically before the fix:
- `pytest tests/test_config.py` produced **0 PASSED lines** despite `addopts = -v`
- `pytest --collect-only` picked up a throwaway root-level `test_decoy_root.py` despite `testpaths = tests`
- `pytest --help | grep -c python_paths` -> 0 (plugin not installed; option dead twice over)

Fixing the header activates every option for the first time, so each one got a real decision instead of a silent carry-forward:

- **`asyncio_mode`**: was `auto`, but auto never took effect -- `strict` (pytest-asyncio's built-in default when no config loads) is what actually ran. All 158 `async def test_*` functions already carry explicit `@pytest.mark.asyncio`, and there are zero async fixtures in the suite. Verified auto and strict produce identical results (813 passed, 1 skipped, both modes). Set to `strict` to match today's real behavior exactly, per "preserving real current behavior is the safer default -- 'the config always said auto' is not a reason, because it never took effect."
- **`python_paths = src`**: deleted, not replaced with `pythonpath = src`. It's dead twice over (setup.cfg-only option name, and `pytest-pythonpath` isn't installed). `src/` already reaches `sys.path` locally via the editable install's `.pth` file, and CI sets `PYTHONPATH=$PWD:$PWD/src` explicitly in `build.yml`. Verified bare `pytest` with `PYTHONPATH` unset still passes `tests/test_memory_server.py`, using only the editable-install `.pth`.
- **`testpaths = tests`** and **`addopts = -v --tb=short`**: now genuinely active (see proof below). Kept `-v` -- matches the file's evident original intent, harmless (verbosity only, no behavior change), and CI's own pytest invocation doesn't otherwise set `-q`.
- **`--ignore=tests/standalone_test.py`**: already gone, handled in #180.
- No competing `[tool.pytest.ini_options]` in `pyproject.toml` -- `data/config/pytest.ini` remains the single source of truth.

## Proof each option now takes effect

**Before (broken `[tool:pytest]`) vs after (`[pytest]`), same repo state:**
```
=== BROKEN header: PASSED line count ===
0
.....                                                                    [100%]
============================== 56 passed in 0.18s ==============================

=== FIXED header: PASSED line count ===
tests/test_config.py::TestHelpers::test_valid_constants_exposed PASSED   [100%]
...
============================== 56 passed in 0.22s ==============================
(56 PASSED lines, matching the 56 passed count)
```

**`testpaths` -- decoy file at repo root:**
```
--- with broken [tool:pytest] header ---
1        # decoy collected -- testpaths not honored
--- with fixed [pytest] header ---
0        # decoy excluded -- testpaths honored
```

**`python_paths` deletion is safe:**
```
$ env -u PYTHONPATH .venv-worktree/bin/python -m pytest tests/test_memory_server.py -q
21 passed in 1.64s
```

**`asyncio_mode` auto vs strict, full suite, identical:**
```
auto:   813 passed, 1 skipped
strict: 813 passed, 1 skipped
```

## Test plan
- [x] `PYTHONPATH=. python -m pytest tests/ --ignore=tests/test_performance_benchmarks.py -q` -> 813 passed, 1 skipped (the `standalone_test.py` ignore is gone now that #180 deleted the file)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy --config-file=pyproject.toml src` clean
- [x] `cd src && python3 -c "import server_fastmcp"` -> no traceback, no logging error
- [x] `grep -n "\[tool.pytest" pyproject.toml` -> no match, confirmed single source of truth
- [x] Ran in the same throwaway worktree venv as #180 (`.venv-worktree/`), `conversation_memory.__file__` resolves inside this worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)