### PR TITLE
fix: migrate_to_sqlite() has always been dead (relative import in a bare module)

### DIFF
--- a/src/conversation_memory.py
+++ b/src/conversation_memory.py
@@ -1070,7 +1070,7 @@ class ConversationMemoryServer:
             return {"error": "SQLite search not enabled"}
 
         try:
-            from .migrate_to_sqlite import ConversationMigrator
+            from migrate_to_sqlite import ConversationMigrator
 
             # Determine directory structure
             use_data_dir = self.conversations_path.parent.name == "data"

--- a/tests/test_migrate_to_sqlite_error_handling.py
+++ b/tests/test_migrate_to_sqlite_error_handling.py
@@ -25,6 +25,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+from conversation_memory import ConversationMemoryServer  # noqa: E402
 from migrate_to_sqlite import ConversationMigrator  # noqa: E402
 
 
@@ -172,3 +173,32 @@ def test_verify_migration_reports_error_on_real_search_failure(temp_storage):
 
     assert "error" in result
     assert "sqlite_count" not in result
+
+
+@pytest.mark.asyncio
+async def test_migrate_to_sqlite_import_is_not_dead(tmp_path):
+    """ConversationMemoryServer.migrate_to_sqlite() must actually import the migrator.
+
+    Regression: the method used a RELATIVE import (``from .migrate_to_sqlite
+    import ConversationMigrator``) inside conversation_memory.py, which is
+    always loaded as a top-level module (``__package__`` is ""). So the import
+    raised ImportError on every call, the method's own ``except ImportError``
+    swallowed it, and the whole migration feature silently returned
+    {"error": "Migration module not available"} forever. #156 converted the
+    module-level imports to the canonical bare style but missed this one
+    because it lives inside a function body.
+
+    This asserts the import path resolves -- i.e. the feature is reachable at
+    all. It fails if anyone reintroduces the relative form.
+    """
+    server = ConversationMemoryServer(str(tmp_path), enable_sqlite=True)
+
+    result = await server.migrate_to_sqlite()
+
+    assert result.get("error") != "Migration module not available", (
+        "migrate_to_sqlite() cannot import ConversationMigrator -- the feature "
+        "is dead. Check for a relative import inside the method body."
+    )
+    # An empty store migrates zero conversations, but it must actually report
+    # stats rather than an import failure.
+    assert "total_found" in result


### PR DESCRIPTION
## The whole migration feature has never run

`ConversationMemoryServer.migrate_to_sqlite()` did:

```python
from .migrate_to_sqlite import ConversationMigrator   # relative
```

`conversation_memory.py` is always loaded as a **top-level** module (`__package__ == ""`), so this raises:

```
ImportError: attempted relative import with no known parent package
```

...which the method's own `except ImportError` catches, returning `{"error": "Migration module not available"}` — **every time, forever**.

Proven, not inferred:

```
before:  migrate_to_sqlite() -> {'error': 'Migration module not available'}
after:   migrate_to_sqlite() -> {'total_found': 0, 'successfully_migrated': 0, 'failed_migrations': 0, 'skipped': 0}
```

The module was always importable *absolutely*. Only the relative form failed.

## Why it survived #156

#156 fixed exactly this defect class — it converted `conversation_memory.py`'s module-level imports to the canonical bare style, resolving #147's dual-import problem. It missed this one because it's **inside a function body**, where a sweep of top-level imports doesn't reach.

## How it surfaced

While writing coverage for the `except Exception` boundary on the line below it (#175), an agent noticed that handler is **unreachable** — the `ImportError` always fires first. Dead code guarding dead code. That's what a coverage requirement is actually for.

## Regression test

`test_migrate_to_sqlite_import_is_not_dead` asserts the feature is reachable at all. **Verified it bites:**

```
# reverted to the relative import:
E   AssertionError: migrate_to_sqlite() cannot import ConversationMigrator -- the
    feature is dead. Check for a relative import inside the method body.

# restored:
1 passed
```

## Verification

- Suite: **850 passed, 1 skipped** (849 + this test)
- `ruff check .` clean, `mypy --config-file=pyproject.toml src` clean
- Smoke: `cd src && python3 -c "import server_fastmcp"` → no error, no `--- Logging error ---`

## Note

CLAUDE.md says the `migrate_to_sqlite` MCP **tool** is disabled by default ("SQLite auto-migrates on first use"), so user impact was likely nil — but the method is public API on the core server class and `scripts/` can reach it. It should work, or not exist.