### PR TITLE
test: scratch PR to verify changes-job code gate (throwaway)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,65 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
+    # NO paths-ignore here on purpose (mirrors job-agent's ci.yml). A skipped
+    # WORKFLOW never reports a required status check, so a docs/.github-only
+    # PR would sit at "Expected — waiting for status" forever. Instead the
+    # workflow always starts and the `changes` job below decides whether the
+    # heavy jobs run; a skipped JOB still reports (passing) to branch
+    # protection.
+    types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:
+  # Mirrors job-agent's `changes` job: always runs, computes whether this PR
+  # touches anything beyond docs/config, and gates the heavy jobs below on
+  # that plus draft status. See the pull_request trigger comment above for why.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    timeout-minutes: 3
+    outputs:
+      code: ${{ steps.set.outputs.code }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      # `code` = "anything that isn't a docs/config-only change".
+      # predicate-quantifier: every is required for the `!` exclusions to
+      # bind (default `some` matches `**` trivially and ignores them).
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter_code
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!*.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!.github/**'
+      - name: Resolve flags
+        id: set
+        # Non-PR events (push, workflow_dispatch) have no base to diff
+        # against, so default to running everything.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "code=${{ steps.filter_code.outputs.code }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # Stage 1: Quick validation checks (30-60 seconds)
   quick-checks:
     name: Quick Validation
+    needs: [changes]
+    # Skip (-> reports passing) on draft PRs and docs/.github-only PRs; run on
+    # push/workflow_dispatch and on non-draft PRs that touch code.
+    if: >-
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request')
+      && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -56,7 +109,13 @@ jobs:
   # Stage 2: Tests and SonarQube analysis (2-3 minutes)
   sonarqube:
     name: Tests & SonarQube Analysis
-    needs: quick-checks  # Only run if quick checks pass
+    needs: [changes, quick-checks]  # Only run if quick checks pass
+    # Same gate as quick-checks. quick-checks being skipped would cascade
+    # this to skipped anyway (default `needs` behavior), but state it
+    # explicitly so the condition is legible without cross-referencing.
+    if: >-
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request')
+      && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,10 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+    # NO paths-ignore here on purpose — see build.yml's pull_request comment.
+    # A skipped WORKFLOW never reports a required status check; the `changes`
+    # job below always runs and gates `analyze` instead.
+    types: [opened, reopened, ready_for_review, synchronize]
   schedule:
     - cron: '0 12 * * 1'
 
@@ -13,8 +17,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Mirrors job-agent's `changes` job (also used in build.yml/performance.yml).
+  # Always runs; gates `analyze` on code changes + draft status.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    timeout-minutes: 3
+    outputs:
+      code: ${{ steps.set.outputs.code }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter_code
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!*.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!.github/**'
+      - name: Resolve flags
+        id: set
+        # Non-PR events (push, schedule, workflow_dispatch) have no base to
+        # diff against, so default to running everything.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "code=${{ steps.filter_code.outputs.code }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          fi
+
   analyze:
     name: Analyze (python)
+    needs: [changes]
+    if: >-
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request')
+      && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -6,13 +6,58 @@ on:
     paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   pull_request:
     branches: [ main ]
-    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
+    # NO paths-ignore here on purpose — see build.yml's pull_request comment.
+    # A skipped WORKFLOW never reports a required status check; the `changes`
+    # job below always runs and gates the heavy jobs instead.
+    types: [opened, reopened, ready_for_review, synchronize]
   schedule:
     # Run weekly on Sundays at 6 AM UTC
     - cron: '0 6 * * 0'
 
 jobs:
+  # Mirrors job-agent's `changes` job (also used in build.yml). Always runs;
+  # gates performance-tests/performance-comparison on code changes + draft.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    timeout-minutes: 3
+    outputs:
+      code: ${{ steps.set.outputs.code }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter_code
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!*.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!.github/**'
+      - name: Resolve flags
+        id: set
+        # Non-PR events (push, schedule, workflow_dispatch) have no base to
+        # diff against, so default to running everything.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "code=${{ steps.filter_code.outputs.code }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          fi
+
   performance-tests:
+    name: performance-tests
+    needs: [changes]
+    if: >-
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request')
+      && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -133,6 +178,11 @@ jobs:
           });
 
   performance-comparison:
+    name: performance-comparison
+    needs: [changes]
+    if: >-
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request')
+      && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,11 +170,9 @@ pip install pytest pytest-cov pytest-asyncio
 - Target: 90%+ coverage maintained through layered testing approach
 
 **PR Quality Gate Enforcement:**
-- All PRs trigger GitHub Actions workflow with SonarCloud analysis
-- PRs are blocked if tests fail or SonarCloud quality gate fails
-- Quality gate enforces: Coverage on New Code ≥ 90%
-- Failed quality gates prevent PR merging (requires branch protection rules)
-- This ensures all new code meets quality standards before merge
+- All PRs run 5 required status checks: `Quick Validation`, `Tests & SonarQube Analysis`, `performance-tests`, `performance-comparison`, `Analyze (python)` (wired as required checks on branch protection alongside the `ci/mirror-job-agent` CI rework — verify current state with `gh api repos/adamkwhite/claude-memory-mcp/rulesets/5957219`)
+- `Tests & SonarQube Analysis` fails the PR if the SonarCloud quality gate is red. The gate ("Sonar way", verified via the SonarCloud API) requires coverage on new code ≥ **80%**, not 90% as this doc previously (incorrectly) claimed — also new duplicated lines ≤ 3% and A ratings on new security/reliability/maintainability
+- Draft PRs skip all 5 checks until flipped ready (`gh pr ready`); a skipped required check reports as passing, so a draft never blocks merge, it just hasn't been checked yet
 
 ## Git Workflow
 
@@ -198,14 +196,16 @@ python -m pytest tests/ --cov=src --cov-report=term -v
 git push origin feature/your-feature-name
 
 # 5. Open Pull Request on GitHub
+# - Open it ready (not draft) if you want CI to run now — draft PRs skip
+#   all 5 required checks until you run `gh pr ready`
 # - ALWAYS mention @claude in PR body or comments for review
 # - PR triggers automated testing and SonarCloud analysis
-# - Must pass all quality gates before merge is allowed
-# - Coverage on new code must be ≥ 90%
+# - Must pass all 5 required status checks before merge unlocks
+# - SonarCloud's new-code coverage threshold is 80%, not 90%
 
-# 6. Merge PR (only after quality gates pass)
-# - Tests must pass ✅
-# - SonarCloud quality gate must pass ✅
+# 6. Merge PR (only after all 5 required checks are green)
+# - Quick Validation, Tests & SonarQube Analysis, performance-tests,
+#   performance-comparison, Analyze (python) must all pass
 # - PR conversations must be resolved ✅
 ```
 
@@ -217,13 +217,12 @@ git push origin feature/your-feature-name
 - ⚠️ **This applies to todos.md, README.md, and ALL files without exception**
 
 ### **Quality Gate Requirements:**
-- All tests must pass
-- SonarCloud analysis must pass
-- Coverage on new code ≥ 90%
+- All 5 required status checks must pass: `Quick Validation`, `Tests & SonarQube Analysis`, `performance-tests`, `performance-comparison`, `Analyze (python)`
+- SonarCloud coverage on new code ≥ **80%** (not 90%)
 - No unresolved PR conversations
 - Linear history maintained
 
-**Note:** Even repository owners cannot bypass these rules - this ensures enterprise-grade quality standards.
+**Note:** Branch protection (`current_user_can_bypass: never`, verified via `gh api .../rulesets/5957219`) blocks deletion, force-push, and non-fast-forward pushes to main for everyone including repository owners — that part was already true. Whether a *red CI check* also blocks merge depends on the required-status-checks rule described above, not on this bypass setting.
 
 ### **Mandatory Testing Requirements**
 

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,4 +1,6 @@
 """Custom exceptions for Claude Memory MCP system"""
+# scratch: verifying the changes-job code filter for PR #183; this branch is
+# throwaway and will be closed unmerged.
 
 
 class ValidationError(ValueError):


### PR DESCRIPTION
Throwaway verification PR for the changes-job/code-gate logic in #183. Touches src/exceptions.py so `code=true`, to observe skip-while-draft vs run-when-ready. Will be closed without merging.