### PR TITLE
TEMP: required-checks gate probe (auto-close)

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,3 +419,5 @@ MIT License - see LICENSE file for details
 **Status**: Production ready ✅
 **Last Updated**: April 2026
 **Version**: 2.0.0
+
+<!-- gate probe: temporary, will be removed -->

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -28,3 +28,6 @@ class MetadataValidationError(ValidationError):
     ``user_id``, ``conversation_type``, ``custom_fields``) introduced for
     cross-platform imports.
     """
+
+
+import os  # deliberate unused import — ruff F401 should fail Quick Validation


### PR DESCRIPTION
Throwaway. Docs-only diff so `code == false` and the heavy jobs skip. Verifying a *skipped* required check counts as passing rather than blocking forever. Closing immediately.