### PR TITLE
docs: mark the mypy-hook architectural follow-up done

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,8 @@
 
 ### Open architectural follow-ups (see `todos.md` for full list)
 - Round-trip-able ChatGPT export — current exporter emits `mapping` structure but importer expects flat `messages` list (asymmetric).
-- Project-wide mypy hook fix (dual `src.foo` ↔ `foo` import naming).
 
-(Metadata-field FTS indexing — `tags`/`session_id`/`conversation_type` in `src/search_database.py` — was completed in PR #118; this section previously listed it as open in error.)
+(Metadata-field FTS indexing — `tags`/`session_id`/`conversation_type` in `src/search_database.py` — was completed in PR #118. The project-wide mypy hook fix, dual `src.foo` ↔ `foo` import naming, was completed in PRs #156/#175 — the canonical bare-import migration; the hook now passes across all 68 files. Both previously listed here as open.)
 
 ## Technology Stack
 


### PR DESCRIPTION
One-line CLAUDE.md correction. The 'project-wide mypy hook fix (dual `src.foo` <-> `foo` import naming)' listed under Open architectural follow-ups was resolved this session (#156 root-cause bare-import migration, #175 the judgment-call lint pass). `pre-commit run mypy --all-files` now passes across all 68 files. Docs-only.