### PR TITLE
fix(search): keep the FTS5 index in sync with its external content table

### DIFF
--- a/src/search_database.py
+++ b/src/search_database.py
@@ -118,38 +118,100 @@ class SearchDatabase:
                     "ON conversations(conversation_type)"
                 )
 
-                # Create triggers to maintain FTS5 table
+                # Create triggers to maintain the FTS5 table.
+                #
+                # ``conversations_fts`` is an EXTERNAL CONTENT table
+                # (``content='conversations'``), so it stores only the index
+                # and reads column values back from ``conversations`` by
+                # rowid. That makes rowid alignment the whole contract:
+                # entries must be written with an explicit ``rowid`` and
+                # removed with the ``'delete'`` command carrying the ORIGINAL
+                # column values. Ordinary INSERT/DELETE/UPDATE statements
+                # against the virtual table silently desync the index, and a
+                # later MATCH that hits an orphaned entry fails the read-back
+                # with "database disk image is malformed".
+                #
+                # These are dropped and recreated unconditionally so databases
+                # carrying the earlier (non-external-content) trigger bodies
+                # are migrated in place.
+                conn.execute("DROP TRIGGER IF EXISTS conversations_ai")
+                conn.execute("DROP TRIGGER IF EXISTS conversations_ad")
+                conn.execute("DROP TRIGGER IF EXISTS conversations_au")
+
                 conn.execute("""
-                    CREATE TRIGGER IF NOT EXISTS conversations_ai
+                    CREATE TRIGGER conversations_ai
                     AFTER INSERT ON conversations BEGIN
-                        INSERT INTO conversations_fts(id, title, content, topics_text)
-                        VALUES (new.id, new.title, new.content, new.topics_text);
+                        INSERT INTO conversations_fts(
+                            rowid, id, title, content, topics_text)
+                        VALUES (new.rowid, new.id, new.title, new.content,
+                                new.topics_text);
                     END
                 """)
 
                 conn.execute("""
-                    CREATE TRIGGER IF NOT EXISTS conversations_ad
+                    CREATE TRIGGER conversations_ad
                     AFTER DELETE ON conversations BEGIN
-                        DELETE FROM conversations_fts WHERE id = old.id;
+                        INSERT INTO conversations_fts(
+                            conversations_fts, rowid, id, title, content, topics_text)
+                        VALUES ('delete', old.rowid, old.id, old.title, old.content,
+                                old.topics_text);
                     END
                 """)
 
                 conn.execute("""
-                    CREATE TRIGGER IF NOT EXISTS conversations_au
+                    CREATE TRIGGER conversations_au
                     AFTER UPDATE ON conversations BEGIN
-                        UPDATE conversations_fts SET
-                            title = new.title,
-                            content = new.content,
-                            topics_text = new.topics_text
-                        WHERE id = new.id;
+                        INSERT INTO conversations_fts(
+                            conversations_fts, rowid, id, title, content, topics_text)
+                        VALUES ('delete', old.rowid, old.id, old.title, old.content,
+                                old.topics_text);
+                        INSERT INTO conversations_fts(
+                            rowid, id, title, content, topics_text)
+                        VALUES (new.rowid, new.id, new.title, new.content,
+                                new.topics_text);
                     END
                 """)
 
                 conn.commit()
 
+                # Heal databases that already desynced under the old triggers.
+                self._repair_fts_desync(conn)
+
         except sqlite3.Error as e:
             self.logger.exception(f"Database initialization failed: {e}")
             raise
+
+    def _repair_fts_desync(self, conn: sqlite3.Connection) -> None:
+        """Rebuild the FTS index if it holds more documents than the table.
+
+        Databases written under the pre-external-content triggers leaked one
+        orphaned index entry per re-saved conversation. Those orphans are
+        invisible until a MATCH happens to hit one, at which point the
+        read-back against ``conversations`` fails the whole query with
+        "database disk image is malformed" — so every search breaks at once
+        while tag and topic lookups keep working.
+
+        Comparing indexed-document count against row count is cheap enough to
+        run at init; the rebuild only fires when they actually disagree.
+        """
+        try:
+            rows = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+            docs = conn.execute("SELECT COUNT(*) FROM conversations_fts_docsize").fetchone()[0]
+        except sqlite3.Error:
+            # ``columnsize=0`` builds have no docsize shadow table. Nothing to
+            # compare against, so leave the index alone.
+            return
+
+        if docs == rows:
+            return
+
+        self.logger.warning(
+            "FTS index desynced (%d indexed documents vs %d rows); rebuilding",
+            docs,
+            rows,
+        )
+        conn.execute("INSERT INTO conversations_fts(conversations_fts) VALUES('rebuild')")
+        conn.commit()
 
     def _migrate_metadata_columns(self, conn: sqlite3.Connection) -> None:
         """Add metadata columns to pre-existing ``conversations`` tables.
@@ -189,14 +251,32 @@ class SearchDatabase:
             custom_fields_json = json.dumps(custom_fields) if custom_fields else None
 
             with sqlite3.connect(self.db_path) as conn:
-                # Insert into main table
+                # Upsert rather than INSERT OR REPLACE: REPLACE deletes and
+                # re-inserts the row, which assigns a NEW rowid and (with
+                # recursive_triggers off, the default) skips the AFTER DELETE
+                # trigger entirely. Both halves break the external-content
+                # FTS5 contract — the old index entry is orphaned and the new
+                # one lands under a rowid the content table no longer uses.
+                # ON CONFLICT keeps the rowid stable and fires AFTER UPDATE.
                 conn.execute(
                     """
-                    INSERT OR REPLACE INTO conversations
+                    INSERT INTO conversations
                     (id, title, content, date, created_at, file_path,
                      topics_json, topics_text, session_id, user_id,
                      conversation_type, custom_fields_json)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(id) DO UPDATE SET
+                        title = excluded.title,
+                        content = excluded.content,
+                        date = excluded.date,
+                        created_at = excluded.created_at,
+                        file_path = excluded.file_path,
+                        topics_json = excluded.topics_json,
+                        topics_text = excluded.topics_text,
+                        session_id = excluded.session_id,
+                        user_id = excluded.user_id,
+                        conversation_type = excluded.conversation_type,
+                        custom_fields_json = excluded.custom_fields_json
                 """,
                     (
                         conversation_data["id"],

--- a/tests/test_fts_external_content_sync.py
+++ b/tests/test_fts_external_content_sync.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Tests that the FTS5 index stays in sync with the ``conversations`` table.
+
+``conversations_fts`` is an EXTERNAL CONTENT table: it stores only the index
+and reads column values back from ``conversations`` by rowid. Rowid alignment
+is therefore the whole contract, and breaking it is silent until a MATCH
+happens to hit an orphaned entry — at which point SQLite fails the query with
+"database disk image is malformed" and *every* content search breaks while
+tag/topic lookups keep working, because those never touch FTS.
+
+The live index desynced exactly this way: the triggers were written for a
+standalone FTS table (no explicit rowid, plain DELETE/UPDATE against the
+virtual table), and ``INSERT OR REPLACE`` re-assigned the rowid while skipping
+the AFTER DELETE trigger entirely. One orphan leaked per re-saved conversation.
+"""
+
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from search_database import SearchDatabase  # noqa: E402
+
+
+def _conversation(conv_id: str, title: str, content: str) -> dict:
+    return {
+        "id": conv_id,
+        "title": title,
+        "content": content,
+        "date": "2026-08-10T18:00:00",
+        "created_at": "2026-08-10T18:00:00",
+        "topics": ["testing"],
+        "tags": ["fts"],
+    }
+
+
+@pytest.fixture
+def db():
+    with tempfile.TemporaryDirectory() as tmp:
+        yield SearchDatabase(str(Path(tmp) / "search.db"))
+
+
+def _counts(db: SearchDatabase) -> tuple[int, int]:
+    """Return (row count, indexed-document count)."""
+    with sqlite3.connect(db.db_path) as conn:
+        rows = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+        docs = conn.execute("SELECT COUNT(*) FROM conversations_fts_docsize").fetchone()[0]
+    return rows, docs
+
+
+def test_resave_does_not_orphan_an_index_entry(db):
+    """Re-saving the same id must update in place, not leak an FTS document."""
+    db.add_conversation(_conversation("a", "First", "hello world"), "/tmp/a.json")
+    db.add_conversation(_conversation("a", "Second", "goodbye moon"), "/tmp/a.json")
+
+    assert _counts(db) == (1, 1)
+
+
+def test_search_survives_a_resave(db):
+    """The regression itself: search must not raise after a re-save."""
+    db.add_conversation(_conversation("a", "First", "hello world"), "/tmp/a.json")
+    db.add_conversation(_conversation("a", "Second", "goodbye moon"), "/tmp/a.json")
+
+    # Superseded content is gone from the index, current content is findable.
+    assert db.search_conversations("hello") == []
+    assert [r["id"] for r in db.search_conversations("goodbye")] == ["a"]
+
+
+def test_resave_preserves_rowid(db):
+    """Rowid stability is what keeps the external-content read-back valid."""
+    db.add_conversation(_conversation("a", "First", "hello world"), "/tmp/a.json")
+    with sqlite3.connect(db.db_path) as conn:
+        before = conn.execute("SELECT rowid FROM conversations WHERE id='a'").fetchone()[0]
+
+    db.add_conversation(_conversation("a", "Second", "goodbye moon"), "/tmp/a.json")
+    with sqlite3.connect(db.db_path) as conn:
+        after = conn.execute("SELECT rowid FROM conversations WHERE id='a'").fetchone()[0]
+
+    assert before == after
+
+
+def test_delete_removes_the_index_entry(db):
+    """A row delete must retract its terms, not strand them in the index."""
+    db.add_conversation(_conversation("a", "First", "hello world"), "/tmp/a.json")
+    db.add_conversation(_conversation("b", "Other", "unrelated text"), "/tmp/b.json")
+
+    with sqlite3.connect(db.db_path) as conn:
+        conn.execute("DELETE FROM conversations WHERE id='a'")
+        conn.commit()
+
+    assert _counts(db) == (1, 1)
+    assert db.search_conversations("hello") == []
+    assert [r["id"] for r in db.search_conversations("unrelated")] == ["b"]
+
+
+def test_init_repairs_a_desynced_index(tmp_path):
+    """An already-broken database heals on open instead of needing an operator."""
+    db_path = tmp_path / "search.db"
+    db = SearchDatabase(str(db_path))
+    db.add_conversation(_conversation("a", "First", "hello world"), "/tmp/a.json")
+
+    # Forge the exact damage the old triggers caused: an index entry whose
+    # rowid no longer exists in the content table.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO conversations_fts(rowid, id, title, content, topics_text) "
+            "VALUES (999, 'ghost', 'Ghost', 'phantom text', '')"
+        )
+        conn.commit()
+
+    with (
+        sqlite3.connect(db_path) as conn,
+        pytest.raises(sqlite3.DatabaseError, match="malformed"),
+    ):
+        conn.execute(
+            "SELECT id FROM conversations_fts WHERE conversations_fts MATCH 'phantom'"
+        ).fetchall()
+
+    SearchDatabase(str(db_path))  # re-open: _repair_fts_desync rebuilds
+
+    assert _counts(SearchDatabase(str(db_path))) == (1, 1)
+    assert [r["id"] for r in db.search_conversations("hello")] == ["a"]

--- a/tests/test_fts_external_content_sync.py
+++ b/tests/test_fts_external_content_sync.py
@@ -113,9 +113,13 @@ def test_init_repairs_a_desynced_index(tmp_path):
         )
         conn.commit()
 
+    # Older SQLite reports the generic "database disk image is malformed";
+    # newer builds name the orphan outright ("fts5: missing row N from content
+    # table"). Accept either — the assertion is that the forged desync is
+    # detectable as an error, not which wording this SQLite happens to use.
     with (
         sqlite3.connect(db_path) as conn,
-        pytest.raises(sqlite3.DatabaseError, match="malformed"),
+        pytest.raises(sqlite3.DatabaseError, match="malformed|missing row"),
     ):
         conn.execute(
             "SELECT id FROM conversations_fts WHERE conversations_fts MATCH 'phantom'"


### PR DESCRIPTION
## Problem

Every content search against the memory store was failing with:

```
Error: Search failed: database disk image is malformed
```

while `search_by_tag` / `search_by_topic` kept working. `PRAGMA integrity_check` returned `ok`, because the base file was never corrupt.

`conversations_fts` is declared with `content='conversations'` — an **external content** FTS5 table. It stores only the index and reads column values back from `conversations` by rowid, so rowid alignment is the entire contract. Break it and a `MATCH` that happens to hit an orphaned entry fails the read-back and takes down every content search at once.

Two independent bugs broke it:

1. **All three maintenance triggers were written for a standalone FTS table.** The insert trigger supplied no explicit `rowid`; the delete and update triggers issued plain `DELETE`/`UPDATE` against the virtual table instead of the `'delete'` command form that external-content tables require.
2. **`INSERT OR REPLACE` on re-save.** REPLACE deletes and re-inserts, assigning a **new rowid**, and with `recursive_triggers` off (the default) it skips the AFTER DELETE trigger entirely. So a re-saved conversation orphaned its old index entry and landed its new one under a rowid the content table no longer used.

Net: one orphaned index entry leaked per re-saved conversation. The live index had drifted to **1383 indexed documents against 1378 rows**.

Reproduced in two statements:

```python
c.execute("INSERT INTO conversations VALUES('a','t1','hello world','x')")
c.execute("INSERT OR REPLACE INTO conversations VALUES('a','t2','goodbye moon','x')")
c.execute("SELECT id FROM conversations_fts WHERE conversations_fts MATCH 'hello'")
# sqlite3.DatabaseError: database disk image is malformed
```

## Fix

- Triggers rewritten to the canonical external-content form: explicit `rowid` on insert, `'delete'` command carrying the original column values on delete, delete-then-insert on update. Dropped and recreated unconditionally so existing databases migrate in place (`CREATE TRIGGER IF NOT EXISTS` would have left the broken bodies).
- `INSERT OR REPLACE` to `ON CONFLICT(id) DO UPDATE`, which keeps the rowid stable and fires AFTER UPDATE normally.
- `_repair_fts_desync` compares indexed-document count against row count at init and rebuilds when they disagree, so an already-broken database heals on open rather than needing an operator.

The first two stop new desync; the third clears damage already on disk.

## Testing

`tests/test_fts_external_content_sync.py` — 5 tests covering re-save, search-after-re-save, rowid stability, delete, and self-repair of a forged desync.

**All 5 fail against the previous code and pass against this one** (verified by stashing the `src/` change).

Full suite: **861 passed**, with the same 6 pre-existing `test_performance_benchmarks.py` failures before and after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFM5tKeJWEMxZZWwK9Ff6y
