### PR TITLE
test: stop the suite writing into the developer's real memory store

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Suite-wide storage isolation.
+
+``src/server_fastmcp.py`` builds its module-level ``memory_server`` singleton
+at import time, and several test modules call the MCP tool functions
+(``server_fastmcp.add_conversation`` and friends) directly rather than through
+a fixture-built server. Those calls hit whatever store the singleton was
+constructed with, which — with no override — is the user's real
+``~/claude-memory``.
+
+That is not theoretical: the live store had accumulated 611 junk rows
+("MCP Add Test" x402, "Error Test" x209) out of 1381, written by ordinary
+suite runs.
+
+The redirect has to happen at conftest *module* scope, not in a fixture:
+pytest imports conftest before it imports any test module, and the test
+module's own ``import server_fastmcp`` is what constructs the singleton. An
+autouse fixture — even session-scoped — runs after collection and is too late.
+
+``CLAUDE_MEMORY_PATH`` is the highest-precedence storage input (env > config
+file > profile > default, see ``src/config.py``), so setting it here wins over
+any real config the developer has. Tests that exercise path/config precedence
+themselves clear or patch the environment explicitly and are unaffected.
+"""
+
+import atexit
+import os
+import shutil
+import tempfile
+
+# ponytail: mkdtemp matches the temp-dir pattern already used by the fixtures
+# in test_fastmcp_coverage.py; it honours TMPDIR if a runner needs to relocate.
+_TEST_STORAGE_PATH = tempfile.mkdtemp(prefix="claude_memory_suite_")
+
+os.environ["CLAUDE_MEMORY_PATH"] = _TEST_STORAGE_PATH
+atexit.register(shutil.rmtree, _TEST_STORAGE_PATH, ignore_errors=True)

--- a/tests/test_storage_isolation.py
+++ b/tests/test_storage_isolation.py
@@ -1,0 +1,46 @@
+"""Guard: the suite must never write to the developer's real memory store.
+
+Regression cover for conftest.py. If the module-scope redirect there is
+removed, reordered into a fixture, or shadowed by a nested conftest, these
+fail loudly instead of silently polluting ~/claude-memory again.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import conftest  # noqa: E402  (the suite's own conftest, imported as a module)
+
+import server_fastmcp  # noqa: E402
+
+
+def _real_store() -> Path:
+    return (Path.home() / "claude-memory").resolve()
+
+
+def test_env_points_at_the_throwaway_store():
+    assert os.environ["CLAUDE_MEMORY_PATH"] == conftest._TEST_STORAGE_PATH
+
+
+def test_module_level_singleton_avoids_the_real_store():
+    """The singleton is built at import time — the case a fixture can't cover."""
+    resolved = server_fastmcp.memory_server.storage_path.expanduser().resolve()
+    assert resolved != _real_store()
+    assert resolved.is_relative_to(Path(conftest._TEST_STORAGE_PATH).resolve())
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_writes_land_in_the_throwaway_store():
+    """The exact call shape that leaked 611 rows into the live store."""
+    result = await server_fastmcp.add_conversation(
+        "isolation guard", "Isolation Guard Test", "2026-01-01T00:00:00Z"
+    )
+    assert "Status: success" in result
+
+    written = list(Path(conftest._TEST_STORAGE_PATH).rglob("*.json"))
+    assert written, "add_conversation wrote nothing under the throwaway store"
+    assert not any(p.is_relative_to(_real_store()) for p in written)


### PR DESCRIPTION
## Problem

Several test modules call the MCP tool functions on `server_fastmcp` directly — `server_fastmcp.add_conversation(...)`, `server_fastmcp.search_conversations(...)` — rather than through a fixture-built server. Example: `tests/test_fastmcp_coverage.py::test_mcp_add_conversation_tool`.

Those calls hit the module-level singleton:

```python
# src/server_fastmcp.py:176
memory_server = FastMCPConversationMemoryServer()
```

which is constructed **at import time** from `Config.storage_path`, i.e. the developer's real `~/claude-memory`. No fixture, no temp dir.

So every suite run ever has written live conversations into the user's actual memory store. The live store had **611 junk rows out of 1381 (44%)**: `MCP Add Test` x402, `Error Test` x209.

This is also the engine behind the FTS5 external-content desync fixed in #190 — each re-saved test row leaked an orphaned index entry, and that corruption was papered over with manual rebuilds on 2026-05-24 and 2026-05-28.

## Fix

`tests/conftest.py` redirects `CLAUDE_MEMORY_PATH` to a throwaway directory, cleaned up via `atexit`.

**This cannot be a fixture.** pytest imports `conftest.py` before it imports any test module, and the test module's own `import server_fastmcp` is what constructs the singleton. An autouse fixture — even session-scoped — runs after collection and is too late. Module scope in conftest is the only hook that lands first.

`CLAUDE_MEMORY_PATH` is the highest-precedence storage input (env > config file > profile > default, per `src/config.py`), so it wins over any real config on the machine. The tests that exercise path/config precedence themselves (`test_path_utils.py`, `test_config.py`) clear or patch the environment explicitly and are unaffected.

## Testing

`tests/test_storage_isolation.py` — 3 guards: the env var points at the throwaway store, the import-time singleton resolves inside it (the case a fixture can't cover), and an actual MCP-tool write lands there rather than in `~/claude-memory`.

**All 3 fail with the conftest redirect commented out**, verified.

Suite: **864 passed, 1 skipped**. The same 6 `test_performance_benchmarks.py::test_search_performance_scaling` failures occur before and after this change — pre-existing and environmental (the local benchmark dataset dir is empty; CI runs these in `performance.yml` with the dataset generated, and `build.yml` ignores that file).

## Follow-up

Purging the 611 junk rows already on disk is a separate change — this PR has to land first or the store just refills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2ho6frj6eKmnYDqQNhZC4