### PR TITLE
fix(memory): index sync missed drift that nets to zero

### DIFF
--- a/src/conversation_memory.py
+++ b/src/conversation_memory.py
@@ -139,17 +139,43 @@ class ConversationMemoryServer:
             with open(self.index_file) as f:
                 index_data = json.load(f)
             indexed_ids = {c["id"] for c in index_data.get("conversations", [])}
+            indexed_paths = {
+                c.get("file_path")
+                for c in index_data.get("conversations", [])
+                if c.get("file_path")
+            }
         except (OSError, ValueError, KeyError, TypeError):
             indexed_ids = set()
+            indexed_paths = set()
             index_data = {
                 "conversations": [],
                 "last_updated": datetime.now().isoformat(),
             }
 
-        # Scan all conversation JSON files on disk
-        conv_files = list(self.conversations_path.rglob("conv_*.json"))
-        if len(conv_files) <= len(indexed_ids):
-            return  # Already in sync or no files to add
+        # Scan all conversation JSON files on disk.
+        #
+        # Narrow to files whose path is absent from index.json rather than
+        # comparing counts. The previous guard was
+        # ``if len(conv_files) <= len(indexed_ids): return``, which is wrong
+        # whenever drift nets to zero: delete one conversation and add
+        # another and the counts stay equal, so the new file was never
+        # indexed. Same failure shape as the FTS5 desync fixed in #190 —
+        # equal totals over non-equal sets.
+        #
+        # Diffing by path is also cheaper than the old code's fallback, which
+        # opened every conversation on disk once the guard let it through.
+        # ``conv_id`` lives inside the JSON, so a path-level filter is the
+        # most we can decide without reading; the id check in the loop stays
+        # as the authority. An index entry with no ``file_path`` (older
+        # format) just makes its file a candidate and costs one extra read
+        # before the id check skips it.
+        conv_files = [
+            f
+            for f in self.conversations_path.rglob("conv_*.json")
+            if str(f.relative_to(self.storage_path)) not in indexed_paths
+        ]
+        if not conv_files:
+            return  # Every file on disk is already indexed
 
         added = 0
         for conv_file in conv_files:

--- a/tests/test_100_percent_coverage.py
+++ b/tests/test_100_percent_coverage.py
@@ -892,6 +892,82 @@ class TestConversationMemoryServerDirect:
             second_sync = json.load(f)
         assert len(second_sync["conversations"]) == count_after_first
 
+    def _write_conv(self, server, folder, conv_id, title):
+        """Drop a conversation file on disk without going through add_conversation."""
+        date_folder = server.conversations_path / "2025" / folder
+        date_folder.mkdir(parents=True, exist_ok=True)
+        conv_file = date_folder / f"{conv_id}.json"
+        with open(conv_file, "w") as f:
+            json.dump(
+                {
+                    "id": conv_id,
+                    "title": title,
+                    "content": "Content",
+                    "date": "2025-04-01T12:00:00",
+                    "topics": ["test"],
+                    "created_at": "2025-04-01T12:00:00",
+                },
+                f,
+            )
+        return conv_file
+
+    def test_sync_index_from_files_detects_equal_count_drift(self, server):
+        """Drift that nets to zero must still be indexed.
+
+        The old guard was `if len(conv_files) <= len(indexed_ids): return`.
+        Delete one conversation and add another and the totals stay equal, so
+        the replacement was silently never indexed — equal totals over
+        non-equal sets, the same shape as the FTS5 desync in #190.
+        """
+        first = self._write_conv(server, "04-april", "conv_20250401_120000_1111", "First")
+        server._sync_index_from_files()
+
+        with open(server.index_file) as f:
+            assert len(json.load(f)["conversations"]) == 1
+
+        # Swap one for one: file count and index count both stay at 1.
+        first.unlink()
+        self._write_conv(server, "04-april", "conv_20250402_120000_2222", "Replacement")
+
+        server._sync_index_from_files()
+
+        with open(server.index_file) as f:
+            indexed = {c["id"] for c in json.load(f)["conversations"]}
+        assert "conv_20250402_120000_2222" in indexed, (
+            "replacement conversation was never indexed — equal-count drift missed"
+        )
+
+    def test_sync_index_from_files_handles_entry_without_file_path(self, server):
+        """Older index entries have no file_path; the id check must still hold.
+
+        Such an entry can't be matched by path, so its file becomes a
+        candidate and gets re-read — that must not produce a duplicate.
+        """
+        self._write_conv(server, "05-may", "conv_20250501_120000_3333", "Legacy")
+        with open(server.index_file, "w") as f:
+            json.dump(
+                {
+                    "conversations": [
+                        {
+                            "id": "conv_20250501_120000_3333",
+                            "title": "Legacy",
+                            "date": "2025-05-01T12:00:00",
+                            "topics": [],
+                            # no file_path — pre-dates the field
+                            "added_at": "2025-05-01T12:00:00",
+                        }
+                    ],
+                    "last_updated": "2025-05-01T12:00:00",
+                },
+                f,
+            )
+
+        server._sync_index_from_files()
+
+        with open(server.index_file) as f:
+            conversations = json.load(f)["conversations"]
+        assert len(conversations) == 1, "re-read of a file_path-less entry duplicated it"
+
     def test_sync_index_from_files_handles_corrupt_file(self, server):
         """Test that _sync_index_from_files skips corrupt JSON files"""
         date_folder = server.conversations_path / "2025" / "03-march"


### PR DESCRIPTION
## Problem

`_sync_index_from_files` (`src/conversation_memory.py:150`) short-circuited on a count comparison:

```python
conv_files = list(self.conversations_path.rglob("conv_*.json"))
if len(conv_files) <= len(indexed_ids):
    return  # Already in sync or no files to add
```

Equal totals are not equal sets. Delete one conversation and add another — file count and index count both stay put, the guard returns early, and the new conversation is **never written into `index.json`**. No error, no log line; it's just missing.

This is the same failure shape as the FTS5 external-content desync fixed in #190: two stores agreeing on a total while disagreeing on contents. Found while auditing what else compares by count after that fix.

## Fix

Narrow the scan to files whose path is absent from `index.json`, rather than comparing totals:

```python
conv_files = [
    f
    for f in self.conversations_path.rglob("conv_*.json")
    if str(f.relative_to(self.storage_path)) not in indexed_paths
]
if not conv_files:
    return
```

The loop body already did the authoritative `conv_id not in indexed_ids` check, so this replaces a wrong short-circuit with a correct one — it doesn't change what gets indexed once the scan runs.

It's also **cheaper than the old path**. The previous code opened and parsed every conversation on disk whenever the guard let it through; this opens only the candidates. `conv_id` lives inside the JSON, so a path-level filter is the most that can be decided without reading, and the id check remains the authority.

An index entry with no `file_path` (older format) can't be matched by path, so its file becomes a candidate and costs one extra read before the id check skips it. Covered by a test.

## Not in scope

A **deleted** file still leaves its `index.json` entry behind. Removing entries is destructive and does not belong in an init-time path — a mis-set `CLAUDE_MEMORY_PATH` or an unmounted directory would make every file look missing. That belongs behind an explicit, reported consistency check, which is the follow-up PR.

## Testing

- `test_sync_index_from_files_detects_equal_count_drift` — swaps one conversation for another and asserts the replacement is indexed. **Fails on the old guard** (verified by stashing `src/`): `assert 'conv_20250402_120000_2222' in {'conv_20250401_120000_1111'}`.
- `test_sync_index_from_files_handles_entry_without_file_path` — legacy entry gets re-read and must not duplicate.

Suite: **872 passed, 1 skipped, 0 failed.** `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2ho6frj6eKmnYDqQNhZC4