### PR TITLE
feat(search): report store drift by identity, not by count

### DIFF
--- a/src/conversation_memory.py
+++ b/src/conversation_memory.py
@@ -1070,9 +1070,74 @@ class ConversationMemoryServer:
 
         return "\n".join(summary_parts)
 
+    # Only this many example paths are reported per drift category — enough to
+    # start investigating, not enough to flood an MCP response.
+    CONSISTENCY_SAMPLE_LIMIT = 5
+
+    def check_consistency(self) -> dict[str, Any]:
+        """Compare the conversation stores by identity and report the drift.
+
+        A conversation lives in three places: its JSON file on disk, an entry
+        in ``index.json``, and a row in SQLite (which in turn backs the FTS5
+        index). Nothing kept them honest against each other. The checks that
+        existed compared *totals* — ``verify_migration``'s ``counts_match``,
+        and the old ``_sync_index_from_files`` guard fixed in #193 — and equal
+        totals over non-equal sets is precisely how drift stayed invisible.
+        A live store was found holding 31 JSON files that no index row
+        referenced; a count comparison called it healthy.
+
+        This is deliberately **read-only**. Re-indexing an orphaned file is
+        additive and safe, but deleting a row whose file is missing is not:
+        a mis-set ``CLAUDE_MEMORY_PATH`` or an unmounted storage directory
+        makes *every* file look missing, and a repair wired into startup would
+        take the whole index with it. Report here; let repair be explicit.
+        """
+        on_disk = {
+            str(f.relative_to(self.storage_path))
+            for f in self.conversations_path.rglob("conv_*.json")
+        }
+
+        try:
+            with open(self.index_file) as f:
+                index_entries = json.load(f).get("conversations", [])
+            in_index = {c["file_path"] for c in index_entries if c.get("file_path")}
+        except (OSError, ValueError, KeyError, TypeError):
+            index_entries = []
+            in_index = set()
+
+        report: dict[str, Any] = {
+            "json_files": len(on_disk),
+            "index_entries": len(index_entries),
+            "index_missing": sorted(on_disk - in_index),
+            "index_stale": sorted(in_index - on_disk),
+        }
+
+        if self.use_sqlite_search and self.search_db:
+            in_db = self.search_db.get_indexed_file_paths()
+            report["db_rows"] = len(in_db)
+            report["orphan_files"] = sorted(on_disk - in_db)
+            report["dangling_rows"] = sorted(in_db - on_disk)
+        else:
+            report["db_rows"] = None
+            report["orphan_files"] = []
+            report["dangling_rows"] = []
+
+        # Report counts, keep only a handful of paths as evidence.
+        samples = {}
+        for key in ("orphan_files", "dangling_rows", "index_missing", "index_stale"):
+            paths = report[key]
+            report[key] = len(paths)
+            if paths:
+                samples[key] = paths[: self.CONSISTENCY_SAMPLE_LIMIT]
+
+        report["consistent"] = not samples
+        if samples:
+            report["samples"] = samples
+        return report
+
     async def get_search_stats(self) -> dict[str, Any]:
         """Get search engine statistics and status."""
-        stats = {
+        stats: dict[str, Any] = {
             "sqlite_available": SQLITE_AVAILABLE,
             "sqlite_enabled": self.use_sqlite_search,
             "search_engine": ("sqlite_fts" if self.use_sqlite_search else "linear_json"),
@@ -1084,6 +1149,14 @@ class ConversationMemoryServer:
                 stats.update(db_stats)
             except Exception as e:  # noqa: BLE001 - read-only diagnostics endpoint: report sqlite_error rather than crash the stats call
                 stats["sqlite_error"] = str(e)
+
+        # Walks the store, so it is meaningfully more expensive than the rest
+        # of this call. Acceptable here because get_search_stats is invoked by
+        # a user asking after the store's health, not on the init path.
+        try:
+            stats["consistency"] = self.check_consistency()
+        except Exception as e:  # noqa: BLE001 - read-only diagnostics endpoint: a failed consistency scan must not take down the stats call
+            stats["consistency_error"] = str(e)
 
         return stats
 

--- a/src/search_database.py
+++ b/src/search_database.py
@@ -599,3 +599,19 @@ class SearchDatabase:
         except sqlite3.Error as e:
             self.logger.exception(f"Count query failed: {e}")
             return 0
+
+    def get_indexed_file_paths(self) -> set[str]:
+        """Return every ``file_path`` in the index, as stored (relative).
+
+        Counts are not enough to tell whether the index matches the files on
+        disk — equal totals over non-equal sets is exactly how the FTS5
+        desync (#190) and the index-sync drift (#193) both stayed invisible.
+        Callers that need to compare stores need the identities.
+        """
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                return {row[0] for row in conn.execute("SELECT file_path FROM conversations")}
+
+        except sqlite3.Error as e:
+            self.logger.exception(f"file_path query failed: {e}")
+            return set()

--- a/src/server_fastmcp.py
+++ b/src/server_fastmcp.py
@@ -404,6 +404,28 @@ async def get_search_stats() -> str:
         for type_info in stats["conversation_types"]:
             response += f"  - {type_info['type']}: {type_info['count']}\n"
 
+    # Only speak up about consistency when something is actually wrong — a
+    # healthy store gets one line, not a table of zeros.
+    consistency = stats.get("consistency")
+    if consistency and not consistency.get("consistent", True):
+        response += "\n⚠ Store Consistency — drift detected:\n"
+        labels = {
+            "orphan_files": "files on disk missing from the search index",
+            "dangling_rows": "indexed rows whose file is gone",
+            "index_missing": "files on disk missing from index.json",
+            "index_stale": "index.json entries whose file is gone",
+        }
+        for key, label in labels.items():
+            if consistency.get(key):
+                response += f"  - {consistency[key]} {label}\n"
+        for key, paths in consistency.get("samples", {}).items():
+            response += f"    e.g. {key}: {', '.join(paths)}\n"
+    elif consistency:
+        response += f"\n• Store Consistency: OK ({consistency['json_files']} files)\n"
+
+    if "consistency_error" in stats:
+        response += f"\nConsistency Check Error: {stats['consistency_error']}\n"
+
     if "sqlite_error" in stats:
         response += f"\nSQLite Error: {stats['sqlite_error']}\n"
 

--- a/tests/test_store_consistency.py
+++ b/tests/test_store_consistency.py
@@ -146,6 +146,52 @@ async def test_get_search_stats_carries_the_report(server):
 
 
 @pytest.mark.asyncio
+async def test_unreadable_index_json_does_not_raise(server):
+    """A corrupt index.json must degrade to "nothing indexed", not crash."""
+    await _add(server, "First")
+    server.index_file.write_text("{not json")
+
+    report = server.check_consistency()
+
+    assert report["index_entries"] == 0
+    assert report["index_missing"] == 1
+    assert report["db_rows"] == 1, "SQLite is unaffected by a corrupt index.json"
+
+
+@pytest.mark.asyncio
+async def test_sqlite_disabled_reports_files_only(server):
+    """Without SQLite there is nothing to diff rows against."""
+    await _add(server, "First")
+    server.use_sqlite_search = False
+
+    report = server.check_consistency()
+
+    assert report["db_rows"] is None
+    assert report["orphan_files"] == 0
+    assert report["dangling_rows"] == 0
+    assert report["json_files"] == 1
+
+
+@pytest.mark.asyncio
+async def test_stats_survives_a_failing_consistency_scan(server, monkeypatch):
+    """The scan is diagnostics; it must never take down the stats call."""
+    monkeypatch.setattr(
+        server, "check_consistency", lambda: (_ for _ in ()).throw(OSError("storage unreachable"))
+    )
+
+    stats = await server.get_search_stats()
+
+    assert "storage unreachable" in stats["consistency_error"]
+    assert stats["search_engine"], "the rest of the stats still came back"
+
+
+def test_indexed_file_paths_survives_a_broken_database(server):
+    server.search_db.db_path = "/nonexistent/dir/search.db"
+
+    assert server.search_db.get_indexed_file_paths() == set()
+
+
+@pytest.mark.asyncio
 async def test_index_json_drift_is_reported_separately(server):
     """index.json is its own store and drifts independently of SQLite."""
     await _add(server, "First")
@@ -157,3 +203,56 @@ async def test_index_json_drift_is_reported_separately(server):
     assert report["index_missing"] == 1
     assert report["orphan_files"] == 0, "SQLite is still in sync; only index.json drifted"
     assert report["consistent"] is False
+
+
+class TestSearchStatsRendering:
+    """The MCP tool's presentation of the report.
+
+    Drift is only worth surfacing if the user actually sees it, so the
+    rendering is covered as its own surface rather than trusted.
+    """
+
+    @pytest.fixture
+    def tool(self, server, monkeypatch):
+        import server_fastmcp
+
+        monkeypatch.setattr(server_fastmcp, "memory_server", server)
+        return server_fastmcp.get_search_stats
+
+    @pytest.mark.asyncio
+    async def test_healthy_store_gets_one_line(self, tool, server):
+        await _add(server, "First")
+
+        response = await tool()
+
+        assert "Store Consistency: OK (1 files)" in response
+        assert "drift detected" not in response
+
+    @pytest.mark.asyncio
+    async def test_drift_is_broken_down_with_evidence(self, tool, server):
+        await _add(server, "Keeper")
+        orphan = (
+            server.conversations_path / "2026" / "01-january" / "conv_20260115_000000_4242.json"
+        )
+        orphan.parent.mkdir(parents=True, exist_ok=True)
+        orphan.write_text(json.dumps({"id": "conv_20260115_000000_4242", "title": "Orphan"}))
+
+        response = await tool()
+
+        assert "drift detected" in response
+        assert "1 files on disk missing from the search index" in response
+        assert "conv_20260115_000000_4242.json" in response, "sample path is the evidence"
+        # Categories at zero stay out of the way.
+        assert "indexed rows whose file is gone" not in response
+
+    @pytest.mark.asyncio
+    async def test_scan_failure_is_surfaced_not_swallowed(self, tool, server, monkeypatch):
+        monkeypatch.setattr(
+            server,
+            "check_consistency",
+            lambda: (_ for _ in ()).throw(OSError("storage unreachable")),
+        )
+
+        response = await tool()
+
+        assert "Consistency Check Error: storage unreachable" in response

--- a/tests/test_store_consistency.py
+++ b/tests/test_store_consistency.py
@@ -1,0 +1,159 @@
+"""Identity-based consistency checking across the conversation stores.
+
+A conversation lives in three places — its JSON file, an ``index.json`` entry,
+and a SQLite row backing the FTS5 index. The checks that existed before this
+compared totals, and equal totals over non-equal sets is how the FTS5 desync
+(#190) and the index-sync drift (#193) both stayed invisible.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from conversation_memory import ConversationMemoryServer  # noqa: E402
+
+
+@pytest.fixture
+def server():
+    temp_dir = tempfile.mkdtemp(prefix="claude_memory_consistency_")
+    yield ConversationMemoryServer(temp_dir)
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+async def _add(server, title, content="content about python and testing"):
+    result = await server.add_conversation(content, title, "2026-01-15T10:00:00")
+    assert result["status"] == "success", result
+    return result
+
+
+@pytest.mark.asyncio
+async def test_clean_store_reports_consistent(server):
+    await _add(server, "First")
+    await _add(server, "Second")
+
+    report = server.check_consistency()
+
+    assert report["consistent"] is True
+    assert report["json_files"] == 2
+    assert report["db_rows"] == 2
+    assert report["orphan_files"] == 0
+    assert report["dangling_rows"] == 0
+    assert "samples" not in report
+
+
+@pytest.mark.asyncio
+async def test_orphan_file_is_detected(server):
+    """A JSON file no index row references — the real-world case (31 of them)."""
+    await _add(server, "Indexed")
+
+    orphan = server.conversations_path / "2026" / "01-january" / "conv_20260115_000000_9999.json"
+    orphan.parent.mkdir(parents=True, exist_ok=True)
+    orphan.write_text(json.dumps({"id": "conv_20260115_000000_9999", "title": "Orphan"}))
+
+    report = server.check_consistency()
+
+    assert report["consistent"] is False
+    assert report["orphan_files"] == 1
+    assert report["dangling_rows"] == 0
+    assert "conv_20260115_000000_9999.json" in report["samples"]["orphan_files"][0]
+
+
+@pytest.mark.asyncio
+async def test_dangling_row_is_detected(server):
+    """An indexed row whose file was removed underneath it."""
+    await _add(server, "Doomed")
+
+    next(server.conversations_path.rglob("conv_*.json")).unlink()
+
+    report = server.check_consistency()
+
+    assert report["consistent"] is False
+    assert report["dangling_rows"] == 1
+    assert report["json_files"] == 0
+
+
+@pytest.mark.asyncio
+async def test_equal_counts_with_disjoint_sets_is_not_consistent(server):
+    """The case every count-based check reports as healthy.
+
+    One orphan file and one dangling row net to identical totals — 1 file,
+    1 row — while sharing no members at all.
+    """
+    await _add(server, "Doomed")
+    next(server.conversations_path.rglob("conv_*.json")).unlink()
+
+    orphan = server.conversations_path / "2026" / "01-january" / "conv_20260115_000000_7777.json"
+    orphan.parent.mkdir(parents=True, exist_ok=True)
+    orphan.write_text(json.dumps({"id": "conv_20260115_000000_7777", "title": "Orphan"}))
+
+    report = server.check_consistency()
+
+    assert report["json_files"] == report["db_rows"], "precondition: counts must match"
+    assert report["consistent"] is False, "equal counts hid disjoint sets"
+    assert report["orphan_files"] == 1
+    assert report["dangling_rows"] == 1
+
+
+@pytest.mark.asyncio
+async def test_check_is_read_only(server):
+    """Detection must never mutate. Repair is deliberately not wired in here."""
+    await _add(server, "Keeper")
+
+    orphan = server.conversations_path / "2026" / "01-january" / "conv_20260115_000000_5555.json"
+    orphan.parent.mkdir(parents=True, exist_ok=True)
+    orphan.write_text(json.dumps({"id": "conv_20260115_000000_5555", "title": "Orphan"}))
+
+    before_files = sorted(p.name for p in server.conversations_path.rglob("conv_*.json"))
+    before_index = server.index_file.read_text()
+    before_rows = server.search_db.get_indexed_file_paths()
+
+    server.check_consistency()
+    server.check_consistency()
+
+    assert sorted(p.name for p in server.conversations_path.rglob("conv_*.json")) == before_files
+    assert server.index_file.read_text() == before_index
+    assert server.search_db.get_indexed_file_paths() == before_rows
+
+
+@pytest.mark.asyncio
+async def test_samples_are_capped(server):
+    """Evidence, not a full dump — an MCP response shouldn't carry the store."""
+    for i in range(server.CONSISTENCY_SAMPLE_LIMIT + 3):
+        orphan = server.conversations_path / "2026" / "01-january" / f"conv_2026011500000{i}_1.json"
+        orphan.parent.mkdir(parents=True, exist_ok=True)
+        orphan.write_text(json.dumps({"id": f"conv_2026011500000{i}_1", "title": f"Orphan {i}"}))
+
+    report = server.check_consistency()
+
+    assert report["orphan_files"] == server.CONSISTENCY_SAMPLE_LIMIT + 3
+    assert len(report["samples"]["orphan_files"]) == server.CONSISTENCY_SAMPLE_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_get_search_stats_carries_the_report(server):
+    await _add(server, "First")
+
+    stats = await server.get_search_stats()
+
+    assert stats["consistency"]["consistent"] is True
+    assert "consistency_error" not in stats
+
+
+@pytest.mark.asyncio
+async def test_index_json_drift_is_reported_separately(server):
+    """index.json is its own store and drifts independently of SQLite."""
+    await _add(server, "First")
+
+    server.index_file.write_text(json.dumps({"conversations": [], "last_updated": "2026-01-01"}))
+
+    report = server.check_consistency()
+
+    assert report["index_missing"] == 1
+    assert report["orphan_files"] == 0, "SQLite is still in sync; only index.json drifted"
+    assert report["consistent"] is False


### PR DESCRIPTION
Follow-up to #190 and #193.

## Problem

A conversation lives in three places: its JSON file on disk, an entry in `index.json`, and a SQLite row (which in turn backs the FTS5 index). Nothing compared them against each other **by identity**.

The two checks that existed compared **totals**:

- `migrate_to_sqlite.py:199 verify_migration()` returns `counts_match: sqlite_count == json_count` — and it sits behind the `migrate_to_sqlite` MCP tool that's **disabled** at `server_fastmcp.py:413`, so it's unreachable in normal operation.
- The `_sync_index_from_files` guard fixed in #193.

Equal totals over non-equal sets is exactly how both the FTS5 desync (#190) and that index drift stayed invisible. Concretely: a live store was found holding **31 JSON files that no index row referenced**, and a count comparison called it healthy.

## What this adds

`ConversationMemoryServer.check_consistency()` set-differences the three stores and reports drift in both directions:

| field | meaning |
|---|---|
| `orphan_files` | on disk, absent from SQLite |
| `dangling_rows` | in SQLite, file gone |
| `index_missing` | on disk, absent from `index.json` |
| `index_stale` | in `index.json`, file gone |

Plus `consistent: bool` and up to 5 sample paths per category as evidence. All three stores record `file_path` relative to `storage_path`, so they share a comparison basis with no normalisation.

Surfaced through the existing `get_search_stats` MCP tool — no new tool, no new script. A healthy store gets one line; drift gets a breakdown.

`SearchDatabase.get_indexed_file_paths()` is new because there was previously no way to list indexed paths, only count them.

## Read-only, deliberately

Re-indexing an orphaned file is additive and safe. **Deleting a row whose file is missing is not.** A mis-set `CLAUDE_MEMORY_PATH` or an unmounted storage directory makes *every* file look missing, and a repair wired into startup would take the entire index with it. This session repointed storage via that exact env var several times — the hazard isn't hypothetical.

So: detection here, repair stays explicit. `test_check_is_read_only` enforces it.

## It earned itself immediately

First run against the live store:

```json
{
  "json_files": 770,
  "db_rows": 770,
  "orphan_files": 0,
  "dangling_rows": 0,
  "index_entries": 1413,
  "index_stale": 643,
  "consistent": false
}
```

SQLite and the filesystem are in perfect sync at 770/770 — and `index.json` is still carrying **643 entries for files that no longer exist**. No count comparison could see that, and nothing else in the codebase would have reported it.

## Cost

`get_search_stats` now walks the store, so it's meaningfully more expensive than before. That's acceptable *here* specifically because it's user-invoked when someone asks after the store's health, not on the init path. Flagging it rather than burying it.

## Testing

`tests/test_store_consistency.py` — 8 tests. The one that matters:

- `test_equal_counts_with_disjoint_sets_is_not_consistent` — one orphan file plus one dangling row gives identical totals (1 file, 1 row) over sets sharing no members. Asserts `json_files == db_rows` as a precondition, then asserts the report is still `consistent: false`. This is the exact case every count-based check reports as healthy.

Also covers: clean store, orphan detection, dangling detection, read-only enforcement, sample capping, `get_search_stats` wiring, and `index.json` drifting independently of SQLite.

Suite: **880 passed, 1 skipped, 0 failed.** ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2ho6frj6eKmnYDqQNhZC4