### PR TITLE
docs: reconcile todos.md and CLAUDE.md through #194

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,44 @@
 
 **Claude Memory MCP** is a universal conversation memory system that provides persistent storage and intelligent search across multiple AI platforms. Originally designed for Claude, it now supports ChatGPT, Cursor AI, and custom formats through an extensible architecture.
 
-## Current Status (April 18, 2026)
+## Current Status (August 11, 2026)
 
 **Branch**: `main`
-**Recent Work**: Universal Memory MCP parallel push — 8 PRs merged in one session (#109-#116)
-**Test Coverage**: 803 passed, 1 skipped (local suite, verified `pytest -q` July 2026); 88.1% overall coverage (SonarCloud, verified via API); ≥80% coverage required on new code
+**Recent Work**: Store-integrity series (#190-#194) — see `todos.md` for the full write-up
+**Test Coverage**: 887 passed, 1 skipped (local suite, verified `pytest -q` August 11 2026); 88% overall coverage (SonarCloud); ≥80% coverage required on new code
+
+> Local benchmark tests need a generated dataset: `python scripts/generate_test_data.py --conversations 500`.
+> Without it, 6 `test_performance_benchmarks.py::test_search_performance_scaling` cases fail locally with
+> "No conversation files copied". CI generates it in `performance.yml`, and `build.yml` `--ignore`s that file,
+> so this is a local-only papercut and not a regression.
 **Code Quality**: 9 code smells, 0 security hotspots (SonarCloud, verified via API); quality gate status OK
 **Architecture**: Importer/Exporter mirror pattern (`src/importers/` ↔ `src/exporters/`); `src/config.py` is the single source of configuration truth (env > file > profile > default)
+
+### Store integrity — the bug class to watch for (August 2026)
+
+Three separate bugs in this repo were the same shape: **two stores agreeing on a total while
+disagreeing on contents.** Count comparisons cannot detect that, which is why each survived for
+months. When you touch anything that keeps two stores aligned, compare identities, not counts.
+
+- **#190** — `conversations_fts` is an external-content FTS5 table (`content='conversations'`), so
+  rowid alignment is the whole contract. Broken triggers plus `INSERT OR REPLACE` leaked one
+  orphaned index entry per re-saved conversation, and any `MATCH` hitting an orphan failed the
+  read-back — breaking **all** content search while tag/topic search kept working. Note the trap:
+  `PRAGMA integrity_check` returns `ok`, because the database file was never corrupt.
+- **#193** — `_sync_index_from_files` returned early when file count == index count, so swapping one
+  conversation for another left the replacement unindexed.
+- **#194** — `check_consistency()` now set-differences files / `index.json` / SQLite and reports
+  drift through `get_search_stats`. **Read-only by design**: never wire index repair into startup;
+  a mis-set `CLAUDE_MEMORY_PATH` or unmounted directory makes every file look missing.
+
+Related: `migrate_to_sqlite.py::verify_migration` still compares counts and can report a drifted
+store as healthy. Don't trust it.
+
+**Tests must never touch the real store.** `tests/conftest.py` redirects `CLAUDE_MEMORY_PATH` to a
+temp dir at *module* scope — not in a fixture, because `server_fastmcp` builds its `memory_server`
+singleton at import time, before any fixture runs. Before #191 every suite run wrote live
+conversations into `~/claude-memory` (611 junk rows out of 1381). `tests/test_storage_isolation.py`
+guards this; if it fails, stop and fix it rather than working around it.
 
 ### Recent Major Implementations
 - ✅ **Centralized Configuration** (PRs #111, #116): `src/config.py` `Config` dataclass with env/file/profile precedence and validation, wired into `server_fastmcp.py`/`logging_config.py`/`path_utils.py`. Replaces scattered `os.getenv()` reads.
@@ -37,7 +68,7 @@
 - **aiofiles**: Async file I/O operations for proper async/await compliance
 - **SQLite FTS5**: Full-text search with relevance scoring
 - **JSON Schema**: Platform format validation with jsonschema library
-- **pytest**: Comprehensive testing framework with 803 test cases (803 passed, 1 skipped, verified `pytest -q` July 2026)
+- **pytest**: Comprehensive testing framework with 887 tests (887 passed, 1 skipped, verified `pytest -q` August 11 2026)
 
 **AI Platform Support:**
 - **ChatGPT**: Complete OpenAI export format support
@@ -289,7 +320,7 @@ This prevents back-and-forth in PRs due to test failures.
   ```bash
   source claude-memory-mcp-venv/bin/activate && python -m pytest tests/ --cov=src --cov-report=term -v
   ```
-- [ ] **2. Verify All Tests Pass** (expect 803+ passing tests, 1 skipped — verified July 2026)
+- [ ] **2. Verify All Tests Pass** (expect 887+ passing tests, 1 skipped — verified August 11 2026)
 - [ ] **3. Check Coverage Baseline** (expect ≥88% coverage per SonarCloud, not local `.coverage`)
 - [ ] **4. Test Supporting Scripts** (if modified any scripts/ files)
 - [ ] **5. Validate Async Compatibility** (if modified async methods)

--- a/todos.md
+++ b/todos.md
@@ -2,6 +2,62 @@
 
 This file maintains persistent todos across Claude Code sessions.
 
+## Recent Session (August 10-11, 2026) ✅ COMPLETED
+
+**Store integrity — one bug class, found three times (PRs #190-#194)**
+
+All three were the same shape: **two stores agreeing on a total while disagreeing on
+contents.** Count comparisons cannot see it, which is why each hid for months.
+
+- [x] **#190** fix(search): keep the FTS5 index in sync with its external content table.
+  `conversations_fts` is `content='conversations'`, so rowid alignment is the entire contract.
+  All three maintenance triggers were written for a standalone FTS table (no explicit rowid on
+  insert; plain `DELETE`/`UPDATE` instead of the `'delete'` command form), and `add_conversation`
+  used `INSERT OR REPLACE`, which reassigns the rowid and — with `recursive_triggers` off, the
+  default — skips the AFTER DELETE trigger entirely. One orphaned index entry leaked per re-saved
+  conversation; any `MATCH` hitting an orphan failed the read-back and broke **all** content search
+  while tag/topic search kept working. `PRAGMA integrity_check` returns `ok` throughout, because
+  the base file was never corrupt. Same corruption had been papered over with manual rebuilds on
+  2026-05-24 and 2026-05-28. Adds `_repair_fts_desync` (init-time rebuild when docsize != row count).
+- [x] **#191** test: stop the suite writing into the developer's real memory store. Test modules
+  called the module-level MCP tool functions, which hit the `memory_server` singleton built at
+  import time from the real `~/claude-memory`. Every suite run ever wrote live conversations —
+  611 junk rows out of 1381 (44%). This was the engine feeding the desync above. Fixed via
+  `CLAUDE_MEMORY_PATH` redirect at **conftest module scope**; a fixture is too late, because the
+  test module's own `import server_fastmcp` is what constructs the singleton.
+- [x] **#193** fix(memory): index sync missed drift that nets to zero. `_sync_index_from_files`
+  short-circuited on `len(conv_files) <= len(indexed_ids)`. Delete one conversation and add
+  another and the totals stay equal, so the replacement was never written to `index.json`.
+  Now diffs by path, which is also cheaper than the old fallback.
+- [x] **#194** feat(search): report store drift by identity, not by count. `check_consistency()`
+  set-differences the three stores (files / `index.json` / SQLite) and surfaces orphan files,
+  dangling rows and index drift through `get_search_stats`. Found a real 643-entry `index.json`
+  drift on its first live run. Deliberately **read-only** — see the follow-up below.
+
+**Housekeeping in the same session**
+- [x] **#192** chore(deps): bump ruff to 0.16.1; excluded `*.md` because 0.16 began formatting
+  Python code blocks inside Markdown and was rewriting historical design docs. Supersedes #187.
+- [x] **#189** deps: cryptography 48.0.1 → 50.0.0.
+- [x] Purged 611 indexed junk rows + 31 unindexed orphan files from the live store, then pruned
+  643 stale `index.json` entries. All four stores now agree at 770. Backups in `.agent-notes/`.
+- [x] Generated the local benchmark dataset — the 6 long-standing local
+  `test_performance_benchmarks.py` failures were an empty dataset dir, not a code fault.
+- [x] Deleted 13 merged branches. Four unmerged ones deliberately left (see below).
+
+**Follow-ups this session opened**
+- [ ] Repair path for detected drift. `check_consistency()` reports only. Re-indexing an orphaned
+  *file* is additive and safe; deleting a *row* whose file is missing is not — a mis-set
+  `CLAUDE_MEMORY_PATH` or unmounted directory makes every file look missing, and an init-time
+  repair would take the whole index with it. If built, it must be explicitly invoked, never
+  automatic. `.agent-notes/prune-stale-index-entries.py` is the throwaway version of this.
+- [ ] Decide the fate of four unmerged branches: `chore/strict-lint-manual` (#168 closed),
+  `feature/log-sampling-15` (#159 closed), `feature/staged-pipeline` (#55 closed),
+  `dependabot/sonarqube-v6` (no PR). Plus local-only `cleanup/remove-test-directories`
+  (43 commits, never pushed, 14 months old).
+- [ ] `migrate_to_sqlite.py::verify_migration` still compares counts (`counts_match`) and sits
+  behind an MCP tool disabled at `server_fastmcp.py:413`. Either point it at
+  `check_consistency()` or delete it — as written it can report a drifted store as healthy.
+
 ## Recent Session (April 18, 2026) ✅ COMPLETED
 
 **Universal Memory MCP — high-priority parallel push (PRs #109-#116, 8 PRs)**
@@ -183,7 +239,8 @@ answer before it's buildable. Captured here so they don't get silently implement
   - [x] Wire `Config.load()` into `server_fastmcp.py` / `logging_config.py` / `path_utils.py` (replace direct `os.getenv` calls) — PR #116
   - [ ] CLI commands for config management (`get`, `set`, `show`, `init`) — follow-up (todos 3.2.2)
   - [ ] Per-platform topic extraction patterns and date-format handling (todos 3.1.2 / 3.1.3) — follow-up
-  - [ ] Document configuration file format in README — follow-up
+  - [x] Document configuration file format in README — PR #154 (README "Config file" precedence
+    section and `~/.claude-memory/config.json` reference)
 - [x] **Add proper logging throughout the application** ✅ COMPLETED
   - ✅ PR #13: Implemented comprehensive logging system
   - ✅ Security-focused logging with log injection prevention
@@ -510,7 +567,8 @@ Transform this project from Claude-specific to universal AI assistant memory sys
 - [ ] 5.3.4 Add search result grouping by platform/model
 
 **5.4** Metadata Management
-- [ ] 5.4.1 Create metadata validation and sanitization
+- [x] 5.4.1 Create metadata validation and sanitization — PR #158: `validate_session_id`,
+  `validate_conversation_type`, `validate_tags`, `validate_custom_fields` in `src/validators.py`
 - [x] 5.4.2 Add metadata updating and editing capabilities
 - [x] 5.4.3 Implement metadata indexing for performance
 - [ ] 5.4.4 Add metadata export and reporting tools


### PR DESCRIPTION
Both files were stale at **#118** — roughly 45 merged PRs unrecorded, including the entire store-integrity series from this session. `todos.md` was last reconciled in #153, which fixed item *accuracy* but left the session log topped out at April 18.

## todos.md

**New session entry for #190–#194**, written around the pattern rather than as a PR list. All three bugs were the same shape: *two stores agreeing on a total while disagreeing on contents.* That's why count comparisons missed them for months, and it's the reusable lesson.

**Closed two items, both verified against the code rather than assumed:**

| item | evidence |
|---|---|
| `5.4.1` metadata validation and sanitization | #158 added `validate_session_id`, `validate_conversation_type`, `validate_tags`, `validate_custom_fields` to `src/validators.py` |
| "Document configuration file format in README" | #154 added the config-precedence section and `~/.claude-memory/config.json` reference |

I checked several other open items (`2.4.3` import rollback, `3.3.1` per-platform storage, `7.1.4` multi-platform perf tests) and left them open — the PRs that looked related covered adjacent ground, not the item as written.

**Three follow-ups this session actually opened:**

- The deliberate absence of a repair path for detected drift, and why it must never be automatic.
- Four unmerged branches awaiting a decision (three from closed PRs, one orphan).
- `migrate_to_sqlite.py::verify_migration` still compares counts and sits behind an MCP tool disabled at `server_fastmcp.py:413` — as written it can report a drifted store as healthy.

## CLAUDE.md

- Status block April 18 → August 11; test count 803 → **887**.
- **New "Store integrity" section.** The traps here aren't visible from the code: `PRAGMA integrity_check` returns `ok` throughout an FTS5 external-content desync, and index repair must never be wired into startup.
- Recorded that tests must not touch the real store, and specifically *why* the redirect lives at conftest module scope rather than in a fixture — the singleton is built at import time, so a fixture is too late. That's the detail someone would otherwise "simplify" back into a bug.
- Noted the local benchmark dataset command, so the 6 local-only failures stop reading as a regression.

## Testing

Docs only — no code touched. Suite unchanged at **887 passed, 1 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2ho6frj6eKmnYDqQNhZC4