### PR TITLE
fix(migrate): verify_migration passed stores that shared no members

### DIFF
--- a/src/migrate_to_sqlite.py
+++ b/src/migrate_to_sqlite.py
@@ -20,6 +20,10 @@ from search_database import SearchDatabase
 INDEX_JSON_FILENAME = "index.json"
 TOPICS_JSON_FILENAME = "topics.json"
 
+# Example paths reported per drift direction — enough to start investigating,
+# not enough to bury the verification output.
+VERIFY_SAMPLE_LIMIT = 5
+
 # Add src to path for imports
 sys.path.append(str(Path(__file__).parent))
 
@@ -197,19 +201,34 @@ class ConversationMigrator:
             return False
 
     def verify_migration(self) -> dict[str, Any]:
-        """Verify migration by comparing counts and testing search."""
+        """Verify migration by comparing the two stores by identity.
+
+        This used to report ``counts_match`` from ``sqlite_count ==
+        json_count`` and ``main()`` printed "Migration verified
+        successfully!" on the strength of it. Equal totals are not equal
+        sets: a store with one unmigrated file and one stale row has matching
+        counts and shares no members. That is not hypothetical — a live store
+        was found holding 31 files no index row referenced, and this check
+        would have called it verified.
+
+        ``contents_match`` is therefore the verdict; ``counts_match`` is kept
+        only because it is cheap and shows *how* a store drifted (equal counts
+        with unequal contents means writes were lost in both directions).
+        """
         self.logger.info("Verifying migration...")
 
         try:
-            # Count conversations in SQLite
-            sqlite_count = self.search_db.get_conversation_count()
+            # Compare the same identities SQLite stores: paths relative to
+            # storage_path, which is the basis add_conversation writes.
+            json_files = {
+                str(f.relative_to(self.storage_path))
+                for f in self.conversations_path.rglob("*.json")
+                if f.name not in (INDEX_JSON_FILENAME, TOPICS_JSON_FILENAME)
+            }
+            indexed = self.search_db.get_indexed_file_paths()
 
-            # Count JSON files
-            json_files = list(self.conversations_path.rglob("*.json"))
-            conversation_files = [
-                f for f in json_files if f.name not in [INDEX_JSON_FILENAME, TOPICS_JSON_FILENAME]
-            ]
-            json_count = len(conversation_files)
+            missing_from_index = sorted(json_files - indexed)
+            missing_from_disk = sorted(indexed - json_files)
 
             # Get database stats
             db_stats = self.search_db.get_conversation_stats()
@@ -221,9 +240,16 @@ class ConversationMigrator:
             )
 
             verification = {
-                "sqlite_count": sqlite_count,
-                "json_count": json_count,
-                "counts_match": sqlite_count == json_count,
+                "sqlite_count": len(indexed),
+                "json_count": len(json_files),
+                "counts_match": len(indexed) == len(json_files),
+                "contents_match": not missing_from_index and not missing_from_disk,
+                "missing_from_index": len(missing_from_index),
+                "missing_from_disk": len(missing_from_disk),
+                "samples": {
+                    "missing_from_index": missing_from_index[:VERIFY_SAMPLE_LIMIT],
+                    "missing_from_disk": missing_from_disk[:VERIFY_SAMPLE_LIMIT],
+                },
                 "database_stats": db_stats,
                 "search_test_passed": search_working,
                 "search_results_count": len(test_results) if search_working else 0,
@@ -302,10 +328,16 @@ def main():
     verification = migrator.verify_migration()
     print(json.dumps(verification, indent=2))
 
-    if verification.get("counts_match") and verification.get("search_test_passed"):
+    # Gate on contents_match, not counts_match: equal totals over unequal sets
+    # is precisely the state this check used to pass.
+    if verification.get("contents_match") and verification.get("search_test_passed"):
         print("\n✅ Migration verified successfully!")
     else:
         print("\n❌ Migration verification failed!")
+        if verification.get("missing_from_index"):
+            print(f"   {verification['missing_from_index']} file(s) not in the index")
+        if verification.get("missing_from_disk"):
+            print(f"   {verification['missing_from_disk']} indexed row(s) with no file")
         sys.exit(1)
 
 

--- a/tests/test_migrate_verify_identity.py
+++ b/tests/test_migrate_verify_identity.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""verify_migration must compare stores by identity, not by total.
+
+It previously reported ``counts_match`` from ``sqlite_count == json_count``,
+and ``main()`` printed "Migration verified successfully!" on that basis —
+then exited 0. A store with one unmigrated file and one stale row satisfies
+that check while sharing no members, so a genuinely broken migration was
+reported as verified. A live store was found in exactly that shape (31 files
+no index row referenced).
+"""
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from conversation_memory import ConversationMemoryServer  # noqa: E402
+from migrate_to_sqlite import VERIFY_SAMPLE_LIMIT, ConversationMigrator  # noqa: E402
+
+
+@pytest.fixture
+def storage():
+    d = tempfile.mkdtemp(prefix="migrate_verify_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture
+def server(storage):
+    return ConversationMemoryServer(storage)
+
+
+def _migrator(storage):
+    return ConversationMigrator(storage, use_data_dir=True)
+
+
+def _stray_file(server, suffix):
+    """A conversation file on disk that no index row references."""
+    path = server.conversations_path / "2026" / "01-january" / f"conv_2026011500000{suffix}_1.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"id": f"conv_2026011500000{suffix}_1", "title": "Stray"}))
+    return path
+
+
+async def _add(server, title):
+    result = await server.add_conversation("content about python", title, "2026-01-15T10:00:00")
+    assert result["status"] == "success", result
+
+
+@pytest.mark.asyncio
+async def test_clean_store_verifies(server, storage):
+    await _add(server, "First")
+    await _add(server, "Second")
+
+    verification = _migrator(storage).verify_migration()
+
+    assert verification["contents_match"] is True
+    assert verification["counts_match"] is True
+    assert verification["missing_from_index"] == 0
+    assert verification["missing_from_disk"] == 0
+
+
+@pytest.mark.asyncio
+async def test_equal_counts_over_disjoint_sets_fails_verification(server, storage):
+    """The exact state the old count comparison passed.
+
+    One indexed conversation whose file is deleted, plus one file that was
+    never indexed: totals match at 1 and 1, membership overlaps at zero.
+    """
+    await _add(server, "Doomed")
+    next(server.conversations_path.rglob("conv_*.json")).unlink()
+    _stray_file(server, "7")
+
+    verification = _migrator(storage).verify_migration()
+
+    assert verification["counts_match"] is True, "precondition: the old check would have passed"
+    assert verification["contents_match"] is False, "identity comparison must catch it"
+    assert verification["missing_from_index"] == 1
+    assert verification["missing_from_disk"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unmigrated_file_is_reported_with_evidence(server, storage):
+    await _add(server, "Indexed")
+    stray = _stray_file(server, "9")
+
+    verification = _migrator(storage).verify_migration()
+
+    assert verification["contents_match"] is False
+    assert verification["missing_from_index"] == 1
+    assert stray.name in verification["samples"]["missing_from_index"][0]
+
+
+@pytest.mark.asyncio
+async def test_indexed_row_without_a_file_is_reported(server, storage):
+    await _add(server, "Doomed")
+    next(server.conversations_path.rglob("conv_*.json")).unlink()
+
+    verification = _migrator(storage).verify_migration()
+
+    assert verification["contents_match"] is False
+    assert verification["missing_from_disk"] == 1
+    assert verification["json_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_samples_are_capped(server, storage):
+    for i in range(VERIFY_SAMPLE_LIMIT + 2):
+        _stray_file(server, i)
+
+    verification = _migrator(storage).verify_migration()
+
+    assert verification["missing_from_index"] == VERIFY_SAMPLE_LIMIT + 2
+    assert len(verification["samples"]["missing_from_index"]) == VERIFY_SAMPLE_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_index_and_topics_files_are_not_counted_as_conversations(server, storage):
+    """index.json / topics.json live alongside conversations and must not
+    register as unmigrated files."""
+    await _add(server, "First")
+
+    verification = _migrator(storage).verify_migration()
+
+    assert verification["json_count"] == 1
+    assert verification["contents_match"] is True

--- a/tests/test_migrate_verify_identity.py
+++ b/tests/test_migrate_verify_identity.py
@@ -130,3 +130,84 @@ async def test_index_and_topics_files_are_not_counted_as_conversations(server, s
 
     assert verification["json_count"] == 1
     assert verification["contents_match"] is True
+
+
+class TestCliGate:
+    """main()'s exit code is the actual product of this change.
+
+    The old gate was ``counts_match and search_test_passed``, so a store with
+    equal totals and zero overlap printed "Migration verified successfully!"
+    and exited 0. ``--verify-only`` returns before the gate, so these drive
+    the full path and stub verify_migration to place the store in an exact
+    state — the gate is the unit under test, not the scan.
+    """
+
+    @staticmethod
+    def _run(monkeypatch, storage, verification):
+        import migrate_to_sqlite
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["migrate_to_sqlite.py", "--storage-path", str(storage), "--use-data-dir"],
+        )
+        monkeypatch.setattr(
+            migrate_to_sqlite.ConversationMigrator,
+            "migrate_all_conversations",
+            lambda _self: {"migrated": 0},
+        )
+        monkeypatch.setattr(
+            migrate_to_sqlite.ConversationMigrator,
+            "verify_migration",
+            lambda _self: verification,
+        )
+        return migrate_to_sqlite.main()
+
+    def test_equal_counts_over_disjoint_sets_now_exits_nonzero(self, storage, monkeypatch, capsys):
+        """The regression case: the old gate passed this exact dict."""
+        verification = {
+            "counts_match": True,  # what the old gate consulted
+            "contents_match": False,  # what it should have consulted
+            "missing_from_index": 1,
+            "missing_from_disk": 1,
+            "search_test_passed": True,
+        }
+
+        with pytest.raises(SystemExit) as exit_info:
+            self._run(monkeypatch, storage, verification)
+
+        assert exit_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "verification failed" in out.lower()
+        assert "1 file(s) not in the index" in out
+        assert "1 indexed row(s) with no file" in out
+
+    def test_matching_contents_exits_clean(self, storage, monkeypatch, capsys):
+        verification = {
+            "counts_match": True,
+            "contents_match": True,
+            "missing_from_index": 0,
+            "missing_from_disk": 0,
+            "search_test_passed": True,
+        }
+
+        self._run(monkeypatch, storage, verification)
+
+        assert "verified successfully" in capsys.readouterr().out
+
+    def test_broken_search_still_fails_even_when_contents_match(self, storage, monkeypatch, capsys):
+        """contents_match replaced counts_match; it did not replace the
+        search smoke test, which is the check that would have caught the
+        FTS5 desync in #190."""
+        verification = {
+            "counts_match": True,
+            "contents_match": True,
+            "missing_from_index": 0,
+            "missing_from_disk": 0,
+            "search_test_passed": False,
+        }
+
+        with pytest.raises(SystemExit) as exit_info:
+            self._run(monkeypatch, storage, verification)
+
+        assert exit_info.value.code == 1


### PR DESCRIPTION
Fourth instance this session of one bug class: **two stores agreeing on a total while disagreeing on contents** (#190, #193, #194).

## Problem

`verify_migration` reported `counts_match` from `sqlite_count == json_count`, and `main()` gated its verdict on it:

```python
if verification.get("counts_match") and verification.get("search_test_passed"):
    print("\n✅ Migration verified successfully!")
else:
    sys.exit(1)
```

Equal totals are not equal sets. One unmigrated file plus one stale row gives matching counts over **zero overlap**. Demonstrated on a store in exactly that shape:

```
counts_match=True  search_test_passed=True
OLD gate  -> PASS  ✅ Migration verified successfully! (exit 0)
NEW gate  -> FAIL (exit 1)
  reality: 1 file(s) unindexed, 1 row(s) with no file
```

**This is reachable today.** I previously assumed it was inert because the `migrate_to_sqlite` MCP tool is disabled at `server_fastmcp.py:413` — that was wrong. #182 revived this module after years of being dead, so `python src/migrate_to_sqlite.py` and `--verify-only` both run it. And the live store was found holding 31 files that no index row referenced; this check would have called it verified.

## Fix

Compare identities, reusing `SearchDatabase.get_indexed_file_paths()` added in #194 — no new query surface.

- `contents_match` is the verdict; `main()` now gates on it.
- `counts_match` is kept deliberately. It's cheap, and the *combination* is diagnostic: equal counts with unequal contents means writes were lost in **both** directions, which is a different fault from a plain shortfall.
- Failure output names the direction and a few example paths rather than just refusing.

## Testing

`tests/test_migrate_verify_identity.py` — 6 tests. The load-bearing one is `test_equal_counts_over_disjoint_sets_fails_verification`, which asserts `counts_match is True` as an explicit **precondition** (that is what the old gate passed on) and then asserts `contents_match is False`.

Note on verification method: stashing `src/` only produces an ImportError here, since `contents_match` didn't exist before — so the old behaviour was demonstrated by running the old gate expression against a live disjoint store, quoted above, rather than by claiming a red-to-green flip.

Also covered: clean store, unmigrated file with sample evidence, indexed row with no file, sample capping, and that `index.json`/`topics.json` aren't miscounted as conversations.

Suite: **893 passed, 1 skipped, 0 failed.** ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2ho6frj6eKmnYDqQNhZC4