### PR TITLE
chore: rename to universal-memory-mcp (identity only, no runtime paths)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ guards this; if it fails, stop and fix it rather than working around it.
 **As of June 2025, the project uses a consolidated data/ directory structure:**
 
 ```
-claude-memory-mcp/
+universal-memory-mcp/
 ├── data/                    # Consolidated application data
 │   ├── conversations/       # Local conversation storage
 │   ├── summaries/          # Weekly summary storage
@@ -200,7 +200,7 @@ pip install pytest pytest-cov pytest-asyncio
 - Target: 90%+ coverage maintained through layered testing approach
 
 **PR Quality Gate Enforcement:**
-- All PRs run 5 required status checks: `Quick Validation`, `Tests & SonarQube Analysis`, `performance-tests`, `performance-comparison`, `Analyze (python)` (wired as required checks on branch protection alongside the `ci/mirror-job-agent` CI rework — verify current state with `gh api repos/adamkwhite/claude-memory-mcp/rulesets/5957219`)
+- All PRs run 5 required status checks: `Quick Validation`, `Tests & SonarQube Analysis`, `performance-tests`, `performance-comparison`, `Analyze (python)` (wired as required checks on branch protection alongside the `ci/mirror-job-agent` CI rework — verify current state with `gh api repos/adamkwhite/universal-memory-mcp/rulesets/5957219`)
 - `Tests & SonarQube Analysis` fails the PR if the SonarCloud quality gate is red. The gate ("Sonar way", verified via the SonarCloud API) requires coverage on new code ≥ **80%**, not 90% as this doc previously (incorrectly) claimed — also new duplicated lines ≤ 3% and A ratings on new security/reliability/maintainability
 - Draft PRs skip all 5 checks until flipped ready (`gh pr ready`); a skipped required check reports as passing, so a draft never blocks merge, it just hasn't been checked yet
 
@@ -646,8 +646,8 @@ Add to Claude Desktop MCP configuration:
   "mcpServers": {
     "claude-memory": {
       "command": "python",
-      "args": ["/absolute/path/to/claude-memory-mcp/src/server_fastmcp.py"],
-      "cwd": "/absolute/path/to/claude-memory-mcp"
+      "args": ["/absolute/path/to/universal-memory-mcp/src/server_fastmcp.py"],
+      "cwd": "/absolute/path/to/universal-memory-mcp"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_claude-memory-mcp&metric=coverage)](https://sonarcloud.io/summary/new_code?id=adamkwhite_claude-memory-mcp)
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_claude-memory-mcp&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=adamkwhite_claude-memory-mcp)
 
-# Claude Memory MCP — Universal AI Conversation Memory
+# Universal Memory MCP — AI Conversation Memory
 
-A Model Context Protocol (MCP) server that provides persistent, searchable conversation memory across multiple AI platforms. Store, search, and retrieve conversation history with sub-millisecond full-text search powered by SQLite FTS5.
+A Model Context Protocol (MCP) server that provides persistent, searchable conversation memory across multiple AI platforms. Store, search, and retrieve conversation history with fast full-text search powered by SQLite FTS5.
 
 ## Features
 
-- 🔍 **Sub-millisecond full-text search** via SQLite FTS5 with relevance ranking
+- 🔍 **Fast full-text search** via SQLite FTS5 with relevance ranking — ~10x faster than a linear scan ([measured](#performance))
 - 🏷️ **Automatic topic extraction** — 574+ unique topics across 2,000+ associations
 - 📊 **Weekly summaries** with insights and patterns
 - 🗃️ **Organized file storage** by date and topic
@@ -22,7 +22,7 @@ A Model Context Protocol (MCP) server that provides persistent, searchable conve
 
 ### Prerequisites
 
-- Python 3.11+ (tested with 3.11.12)
+- Python 3.10+ (CI runs 3.14)
 - Ubuntu/WSL environment recommended
 - Claude Desktop (for MCP integration)
 
@@ -33,22 +33,22 @@ A Model Context Protocol (MCP) server that provides persistent, searchable conve
 **Quick Install** - Copy and paste this into Claude Code:
 
 ```bash
-claude mcp add --transport stdio claude-memory -- sh -c "cd $HOME/Code/claude-memory-mcp && python3 src/server_fastmcp.py"
+claude mcp add --transport stdio claude-memory -- sh -c "cd $HOME/Code/universal-memory-mcp && python3 src/server_fastmcp.py"
 ```
 
-**Important**: Replace `$HOME/Code/claude-memory-mcp` with the actual path where you cloned this repository.
+**Important**: Replace `$HOME/Code/universal-memory-mcp` with the actual path where you cloned this repository.
 
 **Examples for different locations:**
 
 ```bash
-# If cloned to ~/Code/claude-memory-mcp (default)
-claude mcp add --transport stdio claude-memory -- sh -c "cd $HOME/Code/claude-memory-mcp && python3 src/server_fastmcp.py"
+# If cloned to ~/Code/universal-memory-mcp (default)
+claude mcp add --transport stdio claude-memory -- sh -c "cd $HOME/Code/universal-memory-mcp && python3 src/server_fastmcp.py"
 
-# If cloned to ~/projects/claude-memory-mcp
-claude mcp add --transport stdio claude-memory -- sh -c "cd $HOME/projects/claude-memory-mcp && python3 src/server_fastmcp.py"
+# If cloned to ~/projects/universal-memory-mcp
+claude mcp add --transport stdio claude-memory -- sh -c "cd $HOME/projects/universal-memory-mcp && python3 src/server_fastmcp.py"
 
-# If cloned to ~/dev/claude-memory-mcp
-claude mcp add --transport stdio claude-memory -- sh -c "cd $HOME/dev/claude-memory-mcp && python3 src/server_fastmcp.py"
+# If cloned to ~/dev/universal-memory-mcp
+claude mcp add --transport stdio claude-memory -- sh -c "cd $HOME/dev/universal-memory-mcp && python3 src/server_fastmcp.py"
 ```
 
 **What this does:**
@@ -65,8 +65,8 @@ Documentation: https://code.claude.com/docs/en/mcp
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/yourusername/claude-memory-mcp.git
-   cd claude-memory-mcp
+   git clone https://github.com/adamkwhite/universal-memory-mcp.git
+   cd universal-memory-mcp
    ```
 
 2. **Set up virtual environment:**
@@ -166,8 +166,8 @@ Add to your Claude Desktop MCP config:
   "mcpServers": {
     "claude-memory": {
       "command": "python",
-      "args": ["/absolute/path/to/claude-memory-mcp/src/server_fastmcp.py"],
-      "cwd": "/absolute/path/to/claude-memory-mcp"
+      "args": ["/absolute/path/to/universal-memory-mcp/src/server_fastmcp.py"],
+      "cwd": "/absolute/path/to/universal-memory-mcp"
     }
   }
 }
@@ -272,7 +272,7 @@ See `docs/json-logging.md` for detailed JSON logging documentation.
 ## File Structure
 
 ```
-claude-memory-mcp/
+universal-memory-mcp/
 ├── src/
 │   ├── server_fastmcp.py       # Main MCP server
 │   ├── conversation_memory.py  # Core memory engine + SQLite FTS5
@@ -391,7 +391,7 @@ pip install mcp[cli]  # Include CLI extras
 
 ### System Requirements
 
-- **Python**: 3.11+ (tested with 3.11.12)
+- **Python**: 3.10+ (CI runs 3.14)
 - **Disk Space**: ~10MB per 100 conversations
 - **Memory**: <100MB RAM usage
 - **OS**: Ubuntu/WSL recommended, macOS/Windows compatible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "claude-memory-mcp"
+name = "universal-memory-mcp"
 version = "0.1.0"
-description = "A Model Context Protocol server for searchable local storage of Claude conversation history"
+description = "A Model Context Protocol server for searchable local storage of AI conversation history — Claude, ChatGPT, Cursor, and custom formats"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -107,7 +107,7 @@ class CorrelationIdFilter(logging.Filter):
 # logger — never for records propagating up from a child logger to the
 # parent's handlers (Handler.handle() calls the handler's own filters, but
 # nothing re-runs the ancestor Logger.filter() chain). This app logs
-# through child loggers (get_logger("claude_memory_mcp.server") etc.), so a
+# through child loggers (get_logger("universal_memory_mcp.server") etc.), so a
 # logger-level CorrelationIdFilter silently never fires for real traffic —
 # that was the bug. A record factory is called by logging.Logger.makeRecord
 # for *every* record, on *every* logger in the process (including
@@ -201,7 +201,7 @@ class JSONFormatter(logging.Formatter):
     - context: Optional structured context data (if present in record.context)
 
     Example output:
-    {"timestamp": "2025-01-15T10:30:45.123Z", "level": "INFO", "logger": "claude_memory_mcp",
+    {"timestamp": "2025-01-15T10:30:45.123Z", "level": "INFO", "logger": "universal_memory_mcp",
      "function": "add_conversation", "line": 145, "message": "Added conversation successfully",
      "context": {"conversation_id": "abc123", "topics": ["python", "mcp"]}}
     """
@@ -307,7 +307,7 @@ def _get_log_format(config: "Config | None" = None) -> str:
     valid_formats = ["json", "text"]
     if log_format not in valid_formats:
         # Log warning for invalid value and default to text
-        logger = logging.getLogger("claude_memory_mcp")
+        logger = logging.getLogger("universal_memory_mcp")
         logger.warning(
             f"Invalid CLAUDE_MCP_LOG_FORMAT value: '{log_format}'. "
             f"Valid values are: {', '.join(valid_formats)}. Defaulting to 'text'."
@@ -359,7 +359,7 @@ def setup_logging(
         CLAUDE_MCP_LOG_FORMAT: Log format (json|text). Default: text
     """
     # Get logger
-    logger = logging.getLogger("claude_memory_mcp")
+    logger = logging.getLogger("universal_memory_mcp")
     logger.setLevel(getattr(logging, log_level.upper()))
 
     # Clear existing handlers/filters (setup_logging may be called more than
@@ -372,7 +372,7 @@ def setup_logging(
     _install_correlation_id_record_factory()
 
     # Sampling MUST be attached per-handler, not on the logger: this app
-    # logs through child loggers (get_logger("claude_memory_mcp.<name>")),
+    # logs through child loggers (get_logger("universal_memory_mcp.<name>")),
     # and a logger's own filters never run for records that reach its
     # handlers via propagation from a descendant logger. One shared
     # instance is reused across handlers to avoid double-counting.
@@ -425,7 +425,7 @@ def setup_logging(
     return logger
 
 
-def get_logger(name: str = "claude_memory_mcp") -> logging.Logger:
+def get_logger(name: str = "universal_memory_mcp") -> logging.Logger:
     """Get a logger instance with the given name"""
     return logging.getLogger(name)
 
@@ -467,7 +467,7 @@ def log_security_event(event_type: str, details: str, severity: str = "WARNING")
         import re
         from pathlib import Path
 
-        logger = get_logger("claude_memory_mcp.security")
+        logger = get_logger("universal_memory_mcp.security")
         level = getattr(logging, severity.upper())
 
         # Sanitize event_type and details to prevent log injection
@@ -515,7 +515,7 @@ def log_validation_failure(field: str, value: str, reason: str):
     try:
         import re
 
-        logger = get_logger("claude_memory_mcp.validation")
+        logger = get_logger("universal_memory_mcp.validation")
         # Comprehensive sanitization to prevent log injection
         safe_value = str(value)[:100]
         # Remove all control characters except safe whitespace
@@ -549,7 +549,7 @@ def log_file_operation(operation: str, file_path: str, success: bool, **details)
         import re
         from pathlib import Path
 
-        logger = get_logger("claude_memory_mcp.files")
+        logger = get_logger("universal_memory_mcp.files")
         status = "SUCCESS" if success else "FAILED"
 
         # Sanitize file path for logging (use relative path when possible)

--- a/src/server_fastmcp.py
+++ b/src/server_fastmcp.py
@@ -99,7 +99,7 @@ class FastMCPConversationMemoryServer(CoreMemoryServer):
         # Initialize logging using the (validated) Config so log_format /
         # log_level / console_output flow from the same source.
         init_default_logging(self.config)
-        self.fastmcp_logger = get_logger("claude_memory_mcp.server")
+        self.fastmcp_logger = get_logger("universal_memory_mcp.server")
 
         log_function_call(
             "FastMCPConversationMemoryServer.__init__",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -122,7 +122,7 @@ class TestLoggerHelpers:
     def test_get_logger_default_name(self):
         """Test get_logger with default name"""
         logger = get_logger()
-        assert logger.name == "claude_memory_mcp"
+        assert logger.name == "universal_memory_mcp"
 
     @patch("logging_config.get_logger")
     def test_log_function_call(self, mock_get_logger):

--- a/tests/test_logging_wiring.py
+++ b/tests/test_logging_wiring.py
@@ -5,8 +5,8 @@ This file exists because PR #157 (correlation IDs) and PR #160 (log
 sampling) each shipped with unit tests for their filter *classes* only
 (instantiate the filter, call .filter(record) directly) and never asserted
 that a record survives the REAL configured logger end-to-end. Both filters
-were attached to the "claude_memory_mcp" logger itself, but the app logs
-through CHILD loggers (get_logger("claude_memory_mcp.server") etc.).
+were attached to the "universal_memory_mcp" logger itself, but the app logs
+through CHILD loggers (get_logger("universal_memory_mcp.server") etc.).
 Python only consults a logger's own filters for records it emits directly —
 never for records propagating up from a descendant logger to the parent's
 handlers. The result: every child-logger record hit the default TEXT
@@ -53,7 +53,7 @@ class TestCorrelationIdEndToEnd:
         setup_logging(log_file=str(log_file), console_output=False)
 
         set_correlation_id("e2e-test-id")
-        child_logger = get_logger("claude_memory_mcp.server")
+        child_logger = get_logger("universal_memory_mcp.server")
         child_logger.info("child logger message")
 
         # No "--- Logging error ---" / traceback should have been printed
@@ -85,7 +85,7 @@ class TestSamplingEndToEnd:
         cfg = Config(log_sample_rates={"noisy": rate})
         setup_logging(config=cfg, log_file=str(log_file), console_output=False)
 
-        child_logger = get_logger("claude_memory_mcp.server")
+        child_logger = get_logger("universal_memory_mcp.server")
         total = 50
         for i in range(total):
             child_logger.info(f"noisy record {i}", extra={"context": {"type": "noisy"}})
@@ -102,7 +102,7 @@ class TestSamplingEndToEnd:
         cfg = Config(log_sample_rates={"noisy": 1000})
         setup_logging(config=cfg, log_file=str(log_file), console_output=False)
 
-        child_logger = get_logger("claude_memory_mcp.server")
+        child_logger = get_logger("universal_memory_mcp.server")
         for i in range(10):
             child_logger.warning(f"warning {i}", extra={"context": {"type": "noisy"}})
             child_logger.error(f"error {i}", extra={"context": {"type": "noisy"}})
@@ -138,7 +138,7 @@ class TestNoDoubleCountingAcrossHandlers:
         # Exactly one shared instance, not one-per-handler.
         assert len(sampling_filters) == 1
 
-        child_logger = get_logger("claude_memory_mcp.server")
+        child_logger = get_logger("universal_memory_mcp.server")
         total = 40
         for i in range(total):
             child_logger.info(f"noisy record {i}", extra={"context": {"type": "noisy"}})
@@ -158,7 +158,7 @@ def demo() -> None:
         log_file = Path(d) / "demo.log"
         setup_logging(log_file=str(log_file), console_output=False)
         set_correlation_id("demo-id")
-        get_logger("claude_memory_mcp.server").info("demo message")
+        get_logger("universal_memory_mcp.server").info("demo message")
         contents = log_file.read_text()
         assert "demo message" in contents, "child-logger record was dropped"
         assert "demo-id" in contents, "correlation id missing from output"

--- a/uv.lock
+++ b/uv.lock
@@ -202,46 +202,6 @@ wheels = [
 ]
 
 [[package]]
-name = "claude-memory-mcp"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "aiofiles" },
-    { name = "jsonschema" },
-    { name = "mcp", extra = ["cli"] },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "psutil" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "types-aiofiles" },
-]
-lint = [
-    { name = "mypy" },
-    { name = "ruff" },
-    { name = "types-aiofiles" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiofiles", specifier = "==25.1.0" },
-    { name = "jsonschema", specifier = "==4.26.0" },
-    { name = "mcp", extras = ["cli"], specifier = "==1.29.0" },
-    { name = "mypy", marker = "extra == 'lint'", specifier = "==2.3.0" },
-    { name = "psutil", marker = "extra == 'dev'", specifier = "==7.2.2" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.4.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
-    { name = "ruff", marker = "extra == 'lint'", specifier = "==0.16.1" },
-    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20260518" },
-    { name = "types-aiofiles", marker = "extra == 'lint'", specifier = "==25.1.0.20260518" },
-]
-provides-extras = ["dev", "lint"]
-
-[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1378,6 +1338,46 @@ sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
+
+[[package]]
+name = "universal-memory-mcp"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "jsonschema" },
+    { name = "mcp", extra = ["cli"] },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "psutil" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "types-aiofiles" },
+]
+lint = [
+    { name = "mypy" },
+    { name = "ruff" },
+    { name = "types-aiofiles" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiofiles", specifier = "==25.1.0" },
+    { name = "jsonschema", specifier = "==4.26.0" },
+    { name = "mcp", extras = ["cli"], specifier = "==1.29.0" },
+    { name = "mypy", marker = "extra == 'lint'", specifier = "==2.3.0" },
+    { name = "psutil", marker = "extra == 'dev'", specifier = "==7.2.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.4.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
+    { name = "ruff", marker = "extra == 'lint'", specifier = "==0.16.1" },
+    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20260518" },
+    { name = "types-aiofiles", marker = "extra == 'lint'", specifier = "==25.1.0.20260518" },
+]
+provides-extras = ["dev", "lint"]
 
 [[package]]
 name = "uvicorn"


### PR DESCRIPTION
Closes the `1.1.x` / `1.2.x` / `1.3.x` rename items in `todos.md` — **Bucket A only**, with Bucket B declined and the reasons recorded.

## Why now

Two reasons, one of them blocking:

1. The name says Claude while the project imports ChatGPT, Cursor and generic formats.
2. **It cannot be published as-is.** `claude-memory-mcp` on PyPI belongs to someone else — [`maydali28/memcp`](https://github.com/maydali28/memcp) v0.3.0, *"Persistent memory MCP server for Claude Code"*. A near-identical description in the same niche. `universal-memory-mcp` is unclaimed (404).

## Renamed — none of these are runtime identifiers

- `pyproject` `name`, plus a description that actually names the supported platforms
- Logger hierarchy `claude_memory_mcp.*` → `universal_memory_mcp.*`. Checked first: log sampling keys off `record.context["type"]`, not logger names, so no configuration depends on this.
- README / CLAUDE.md repo and clone-path references

## Deliberately NOT renamed

Each would break a working install for zero functional gain:

| kept | why |
|---|---|
| `~/claude-memory/`, `~/.claude-memory/` | would orphan existing conversations — 770 locally |
| `CLAUDE_MEMORY_PATH`, `CLAUDE_MEMORY_DISABLE_SQLITE`, 7× `CLAUDE_MCP_*` | existing setups' env vars go dead |
| `FastMCP("claude-memory")` | the key in users' `claude_desktop_config.json` |
| `sonar.projectKey=adamkwhite_claude-memory-mcp` + README badge URLs | SonarCloud-side identifier — editing it orphans the project and loses all history |
| `claude-memory-mcp-venv` | the directory exists under that name, and a venv can't be moved without breaking the absolute paths baked into its scripts |

The last two were caught during the work, not planned: a naive find-and-replace hit both.

## Also fixed

Two stale claims on the front page, both already corrected elsewhere by #162 but never propagated to the README:

- Header advertised **"sub-millisecond full-text search"** while the Performance section in the same file says mean 15–18ms and explicitly notes the sub-ms figure "was never measured". Bundled rather than deferred because leaving a known-false claim in a README I'm actively editing — on a package about to be published — isn't defensible.
- Prerequisites claimed Python 3.11+ against a 3.10 floor and 3.14 CI.

## Verification

- Builds: `universal_memory_mcp-0.1.0-py3-none-any.whl`
- Suite: **896 passed, 1 skipped, 0 failed**; ruff + mypy clean

## Follow-ups (not in this PR)

- **The GitHub repo rename is yours to make** — it's outward-facing and changes the remote on both your machines. GitHub redirects old URLs (web and git), so nothing breaks in the interim; `git remote set-url` at your convenience.
- **`pyproject` has no `license`, `authors`, `classifiers`, `keywords` or `[project.urls]`.** A `LICENSE` file exists but isn't declared. Those want filling before a first PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2ho6frj6eKmnYDqQNhZC4