### PR TITLE
docs: reconcile through #197 and pin the naming split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Claude Memory MCP - Universal AI Memory System
+# Universal Memory MCP - Universal AI Memory System
 
 ## Project Overview
 
@@ -7,8 +7,8 @@
 ## Current Status (August 11, 2026)
 
 **Branch**: `main`
-**Recent Work**: Store-integrity series (#190-#194) — see `todos.md` for the full write-up
-**Test Coverage**: 887 passed, 1 skipped (local suite, verified `pytest -q` August 11 2026); 88% overall coverage (SonarCloud); ≥80% coverage required on new code
+**Recent Work**: Store-integrity series (#190-#196) and the rename to `universal-memory-mcp` (#197) — see `todos.md`
+**Test Coverage**: 896 passed, 1 skipped (local suite, verified `pytest -q` August 11 2026); 88% overall coverage (SonarCloud); ≥80% coverage required on new code
 
 > Local benchmark tests need a generated dataset: `python scripts/generate_test_data.py --conversations 500`.
 > Without it, 6 `test_performance_benchmarks.py::test_search_performance_scaling` cases fail locally with
@@ -16,6 +16,22 @@
 > so this is a local-only papercut and not a regression.
 **Code Quality**: 9 code smells, 0 security hotspots (SonarCloud, verified via API); quality gate status OK
 **Architecture**: Importer/Exporter mirror pattern (`src/importers/` ↔ `src/exporters/`); `src/config.py` is the single source of configuration truth (env > file > profile > default)
+
+### Naming: the project was renamed, the runtime identifiers were not (#197)
+
+The repo, package and logger hierarchy are `universal-memory-mcp` / `universal_memory_mcp`.
+**Everything a running install depends on deliberately still says `claude`**, and must stay that
+way — each of these orphans working state if "tidied up" for consistency:
+
+| identifier | why it must not change |
+|---|---|
+| `~/claude-memory/`, `~/.claude-memory/` | orphans every existing install's conversations |
+| `CLAUDE_MEMORY_PATH`, `CLAUDE_MEMORY_DISABLE_SQLITE`, `CLAUDE_MCP_*` | existing setups go dead |
+| `FastMCP("claude-memory")` | the key in users' `claude_desktop_config.json` |
+| `sonar.projectKey=adamkwhite_claude-memory-mcp` + README badge URLs | SonarCloud-side identifier — editing it orphans the project and loses all history |
+| `claude-memory-mcp-venv` | the directory exists under that name; a venv cannot be moved without breaking the absolute paths inside its scripts |
+
+A find-and-replace across the repo will hit the last two. Don't.
 
 ### Store integrity — the bug class to watch for (August 2026)
 
@@ -68,7 +84,7 @@ guards this; if it fails, stop and fix it rather than working around it.
 - **aiofiles**: Async file I/O operations for proper async/await compliance
 - **SQLite FTS5**: Full-text search with relevance scoring
 - **JSON Schema**: Platform format validation with jsonschema library
-- **pytest**: Comprehensive testing framework with 887 tests (887 passed, 1 skipped, verified `pytest -q` August 11 2026)
+- **pytest**: Comprehensive testing framework with 896 tests (896 passed, 1 skipped, verified `pytest -q` August 11 2026)
 
 **AI Platform Support:**
 - **ChatGPT**: Complete OpenAI export format support
@@ -320,7 +336,7 @@ This prevents back-and-forth in PRs due to test failures.
   ```bash
   source claude-memory-mcp-venv/bin/activate && python -m pytest tests/ --cov=src --cov-report=term -v
   ```
-- [ ] **2. Verify All Tests Pass** (expect 887+ passing tests, 1 skipped — verified August 11 2026)
+- [ ] **2. Verify All Tests Pass** (expect 896+ passing tests, 1 skipped — verified August 11 2026)
 - [ ] **3. Check Coverage Baseline** (expect ≥88% coverage per SonarCloud, not local `.coverage`)
 - [ ] **4. Test Supporting Scripts** (if modified any scripts/ files)
 - [ ] **5. Validate Async Compatibility** (if modified async methods)

--- a/todos.md
+++ b/todos.md
@@ -4,9 +4,9 @@ This file maintains persistent todos across Claude Code sessions.
 
 ## Recent Session (August 10-11, 2026) ✅ COMPLETED
 
-**Store integrity — one bug class, found three times (PRs #190-#194)**
+**Store integrity — one bug class, found four times (PRs #190-#196)**
 
-All three were the same shape: **two stores agreeing on a total while disagreeing on
+All four were the same shape: **two stores agreeing on a total while disagreeing on
 contents.** Count comparisons cannot see it, which is why each hid for months.
 
 - [x] **#190** fix(search): keep the FTS5 index in sync with its external content table.
@@ -45,18 +45,37 @@ contents.** Count comparisons cannot see it, which is why each hid for months.
 - [x] Deleted 13 merged branches. Four unmerged ones deliberately left (see below).
 
 **Follow-ups this session opened**
+- [x] **#196** fix(migrate): `verify_migration` compared counts and gated `main()`'s
+  "✅ Migration verified successfully!" (exit 0) on them, so a store with equal totals and zero
+  overlap passed. Compares identities now; `contents_match` is the verdict.
+- [x] Branch fate decided — all five deleted after audit. The three closed-PR branches and the
+  orphan dependabot one were superseded; local-only `cleanup/remove-test-directories` held only
+  artifacts main had deliberately removed (SonarCloud badge SVGs, `archive/`, `scripts/bulk_import.py`
+  from #113, `standalone_test.py` from #180). Repo is down to `main` alone.
+- [x] **#197** chore: renamed to `universal-memory-mcp` — package name, logger hierarchy,
+  README/CLAUDE.md. Runtime identifiers deliberately kept: `~/claude-memory`, `~/.claude-memory`,
+  `CLAUDE_MEMORY_*` / `CLAUDE_MCP_*`, `FastMCP("claude-memory")`, `sonar.projectKey`,
+  `claude-memory-mcp-venv`. Renaming any of them orphans a working install for no functional gain.
+
+**Open**
+
+- [ ] **Publishing metadata.** `pyproject.toml` has no `license`, `authors`, `classifiers`,
+  `keywords` or `[project.urls]`, and the existing `LICENSE` file is not declared. This is the
+  last gap before a first PyPI release — worth doing soon: `claude-memory-mcp` on PyPI already
+  belongs to someone else (`maydali28/memcp` v0.3.0, same niche), and `universal-memory-mcp` is
+  currently unclaimed.
+- [ ] **Verify SonarCloud PR decoration survived the repo rename.** The project key was
+  deliberately left as `adamkwhite_claude-memory-mcp` (changing it orphans the project and its
+  history), but the GitHub app's repo binding may need refreshing. The next PR's Sonar check
+  answers this; if it fails to decorate it's a re-bind in SonarCloud settings, not a code fix.
 - [ ] Repair path for detected drift. `check_consistency()` reports only. Re-indexing an orphaned
   *file* is additive and safe; deleting a *row* whose file is missing is not — a mis-set
   `CLAUDE_MEMORY_PATH` or unmounted directory makes every file look missing, and an init-time
   repair would take the whole index with it. If built, it must be explicitly invoked, never
-  automatic. `.agent-notes/prune-stale-index-entries.py` is the throwaway version of this.
-- [ ] Decide the fate of four unmerged branches: `chore/strict-lint-manual` (#168 closed),
-  `feature/log-sampling-15` (#159 closed), `feature/staged-pipeline` (#55 closed),
-  `dependabot/sonarqube-v6` (no PR). Plus local-only `cleanup/remove-test-directories`
-  (43 commits, never pushed, 14 months old).
-- [ ] `migrate_to_sqlite.py::verify_migration` still compares counts (`counts_match`) and sits
-  behind an MCP tool disabled at `server_fastmcp.py:413`. Either point it at
-  `check_consistency()` or delete it — as written it can report a drifted store as healthy.
+  automatic. In practice `python src/migrate_to_sqlite.py --storage-path <store> --use-data-dir`
+  already *is* the orphan-file repair — it upserts every `index.json` entry into SQLite and is
+  idempotent. Used successfully on the work machine's store (5 orphans → 0). A first-class
+  `--repair` would mostly be ergonomics over that.
 
 ## Recent Session (April 18, 2026) ✅ COMPLETED
 


### PR DESCRIPTION
Session wrap-up reconciliation. Docs only.

## todos.md

Closed the three follow-ups this session opened **and** resolved:

- **#196** — `verify_migration` now compares identities, not counts
- **Branch fate** — all five audited and deleted; `cleanup/remove-test-directories` held only artifacts main had deliberately removed (badge SVGs, `archive/`, `scripts/bulk_import.py` from #113, `standalone_test.py` from #180)
- **#197** — the rename

Recorded what's actually left: publishing metadata, and confirming SonarCloud PR decoration survived the repo rename.

The drift-repair item stays open, but now records something learned today: `migrate_to_sqlite.py` **already is** the orphan-file repair. It upserts every `index.json` entry and is idempotent. Used on the work machine's store today — 5 orphans → 0. A first-class `--repair` would mostly be ergonomics over that, which is worth knowing before anyone builds one.

## CLAUDE.md

Title and counts (887 → 896), plus a table of the runtime identifiers that deliberately still say `claude` after #197.

That table earns its place: a find-and-replace across the repo hits two entries that look cosmetic and aren't —

- `sonar.projectKey` — editing it orphans the SonarCloud project and loses all its history
- `claude-memory-mcp-venv` — a venv can't be moved without breaking the absolute paths baked into its scripts

Both were caught *during* #197 rather than planned for, which is exactly why they're written down now.

## Testing

Docs only, no code touched. Suite unchanged at **896 passed, 1 skipped, 0 failed**.

This PR also answers the open SonarCloud question — if its check decorates normally, the rename didn't break the binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2ho6frj6eKmnYDqQNhZC4