### PR TITLE
refactor: clear all 5 cognitive-complexity violations (36/21/20/19/16 -> under 15)

### DIFF
--- a/src/conversation_memory.py
+++ b/src/conversation_memory.py
@@ -330,6 +330,50 @@ class ConversationMemoryServer:
 
         return found_topics[:10]  # Limit to top 10 topics
 
+    @staticmethod
+    def _resolve_conversation_date(conversation_date: str | None) -> datetime:
+        """Parse an ISO date, falling back to now() on absence or bad input."""
+        if not conversation_date:
+            return datetime.now()
+        try:
+            return datetime.fromisoformat(conversation_date.replace("Z", "+00:00"))
+        except ValueError:
+            return datetime.now()
+
+    @staticmethod
+    def _derive_title(content: str) -> str:
+        """Title from the first line, truncated to 50 chars with an ellipsis."""
+        lines = content.strip().split("\n")
+        first_line = lines[0] if lines else content
+        return first_line[:50] + "..." if len(first_line) > 50 else first_line
+
+    @staticmethod
+    def _optional_metadata(
+        *,
+        session_id: str | None,
+        user_id: str | None,
+        tags: list[str] | None,
+        conversation_type: str | None,
+        custom_fields: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Universal metadata keys, omitted when empty.
+
+        Only non-empty values are returned so legacy JSON files keep the same
+        shape for existing users.
+        """
+        metadata: dict[str, Any] = {}
+        if session_id:
+            metadata["session_id"] = session_id
+        if user_id:
+            metadata["user_id"] = user_id
+        if tags:
+            metadata["tags"] = list(tags)
+        if conversation_type:
+            metadata["conversation_type"] = conversation_type
+        if custom_fields:
+            metadata["custom_fields"] = dict(custom_fields)
+        return metadata
+
     async def add_conversation(
         self,
         content: str,
@@ -352,21 +396,9 @@ class ConversationMemoryServer:
         available.
         """
         try:
-            # Parse date or use current
-            if conversation_date:
-                try:
-                    date = datetime.fromisoformat(conversation_date.replace("Z", "+00:00"))
-                except ValueError:
-                    date = datetime.now()
-            else:
-                date = datetime.now()
-
-            # Generate title if not provided
+            date = self._resolve_conversation_date(conversation_date)
             if not title:
-                # Extract first line or first 50 characters as title
-                lines = content.strip().split("\n")
-                first_line = lines[0] if lines else content
-                title = first_line[:50] + "..." if len(first_line) > 50 else first_line
+                title = self._derive_title(content)
 
             # Create conversation record
             conversation_id = f"conv_{date.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
@@ -385,19 +417,15 @@ class ConversationMemoryServer:
                 "topics": topics,
                 "created_at": datetime.now().isoformat(),
             }
-
-            # Only persist metadata keys when non-empty so legacy JSON files
-            # stay shaped the same for existing users.
-            if session_id:
-                conversation_data["session_id"] = session_id
-            if user_id:
-                conversation_data["user_id"] = user_id
-            if tags:
-                conversation_data["tags"] = list(tags)
-            if conversation_type:
-                conversation_data["conversation_type"] = conversation_type
-            if custom_fields:
-                conversation_data["custom_fields"] = dict(custom_fields)
+            conversation_data.update(
+                self._optional_metadata(
+                    session_id=session_id,
+                    user_id=user_id,
+                    tags=tags,
+                    conversation_type=conversation_type,
+                    custom_fields=custom_fields,
+                )
+            )
 
             # Save conversation file
             async with aiofiles.open(file_path, "w", encoding="utf-8") as f:
@@ -497,6 +525,99 @@ class ConversationMemoryServer:
         file_path = month_folder / f"{conversation_id}.json"
         return file_path if file_path.exists() else None
 
+    def _resync_sqlite_for_update(
+        self,
+        conversation_data: dict[str, Any],
+        file_path: Path,
+        original_raw: str,
+    ) -> dict[str, Any] | None:
+        """Push an updated record into SQLite; None on success, error dict on failure.
+
+        INSERT OR REPLACE on the SQLite row cascades through the FTS triggers,
+        so the FTS index stays current.
+
+        Unlike add_conversation there is no new file to unlink on failure:
+        update_conversation mutates an *existing* record, so rollback means
+        restoring the file's prior content rather than deleting it.
+        index.json / topics.json have not been touched at this point, so
+        returning early is enough to keep them consistent with the restored
+        file.
+        """
+        if not (self.use_sqlite_search and self.search_db):
+            return None
+
+        relative_path = str(file_path.relative_to(self.storage_path))
+        if self.search_db.add_conversation(conversation_data, relative_path):
+            return None
+
+        self._rollback_update_conversation(file_path, original_raw)
+        return {
+            "status": "error",
+            "message": (
+                "Failed to update conversation: SQLite index update "
+                "failed; file content was restored to its prior state"
+            ),
+        }
+
+    @staticmethod
+    def _apply_scalar_updates(
+        conversation_data: dict[str, Any],
+        *,
+        title: str | None,
+        content: str | None,
+        conversation_type: str | None,
+        session_id: str | None,
+        user_id: str | None,
+    ) -> list[str]:
+        """Apply plain field updates in place; return the changed field names.
+
+        `title` is only recorded as a change when it actually differs; the rest
+        count as changed whenever a value is supplied. Order matches the order
+        the fields are reported in the audit line.
+        """
+        changes: list[str] = []
+        if title is not None and title != conversation_data.get("title"):
+            conversation_data["title"] = title
+            changes.append("title")
+        for field, value in (
+            ("content", content),
+            ("conversation_type", conversation_type),
+            ("session_id", session_id),
+            ("user_id", user_id),
+        ):
+            if value is not None:
+                conversation_data[field] = value
+                changes.append(field)
+        return changes
+
+    @staticmethod
+    def _merge_tags(
+        existing_tags: list[str],
+        *,
+        set_tags: list[str] | None,
+        add_tags: list[str] | None,
+        remove_tags: list[str] | None,
+    ) -> list[str]:
+        """Resolve tag operations into the new tag list.
+
+        `set_tags` replaces wholesale (including `[]` to clear); `add_tags` /
+        `remove_tags` mutate. Duplicates are collapsed preserving order.
+        Returns `existing_tags` unchanged when no tag op applies.
+        """
+        if set_tags is not None:
+            return list(dict.fromkeys(set_tags))
+        if not (add_tags or remove_tags):
+            return existing_tags
+
+        tags = list(dict.fromkeys(existing_tags))
+        for tag in add_tags or []:
+            if tag and tag not in tags:
+                tags.append(tag)
+        if remove_tags:
+            remove_lookup = set(remove_tags)
+            tags = [tag for tag in tags if tag not in remove_lookup]
+        return tags
+
     async def update_conversation(
         self,
         conversation_id: str,
@@ -549,41 +670,22 @@ class ConversationMemoryServer:
                 "message": f"Failed to read conversation: {str(e)}",
             }
 
-        changes: list[str] = []
-
-        if title is not None and title != conversation_data.get("title"):
-            conversation_data["title"] = title
-            changes.append("title")
-
-        if content is not None:
-            conversation_data["content"] = content
-            changes.append("content")
-
-        if conversation_type is not None:
-            conversation_data["conversation_type"] = conversation_type
-            changes.append("conversation_type")
-
-        if session_id is not None:
-            conversation_data["session_id"] = session_id
-            changes.append("session_id")
-
-        if user_id is not None:
-            conversation_data["user_id"] = user_id
-            changes.append("user_id")
+        changes = self._apply_scalar_updates(
+            conversation_data,
+            title=title,
+            content=content,
+            conversation_type=conversation_type,
+            session_id=session_id,
+            user_id=user_id,
+        )
 
         existing_tags = list(conversation_data.get("tags") or [])
-        new_tags = existing_tags
-        if set_tags is not None:
-            new_tags = list(dict.fromkeys(set_tags))
-        elif add_tags or remove_tags:
-            tags_set = list(dict.fromkeys(existing_tags))
-            for t in add_tags or []:
-                if t and t not in tags_set:
-                    tags_set.append(t)
-            if remove_tags:
-                remove_lookup = set(remove_tags)
-                tags_set = [t for t in tags_set if t not in remove_lookup]
-            new_tags = tags_set
+        new_tags = self._merge_tags(
+            existing_tags,
+            set_tags=set_tags,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
+        )
         if new_tags != existing_tags:
             conversation_data["tags"] = new_tags
             changes.append("tags")
@@ -627,18 +729,9 @@ class ConversationMemoryServer:
         # haven't been touched yet at this point (the calls below haven't
         # run), so there's nothing to revert there -- returning early is
         # enough to keep them consistent with the restored file.
-        if self.use_sqlite_search and self.search_db:
-            relative_path = str(file_path.relative_to(self.storage_path))
-            sqlite_ok = self.search_db.add_conversation(conversation_data, relative_path)
-            if not sqlite_ok:
-                self._rollback_update_conversation(file_path, original_raw)
-                return {
-                    "status": "error",
-                    "message": (
-                        "Failed to update conversation: SQLite index update "
-                        "failed; file content was restored to its prior state"
-                    ),
-                }
+        sqlite_error = self._resync_sqlite_for_update(conversation_data, file_path, original_raw)
+        if sqlite_error is not None:
+            return sqlite_error
 
         self._replace_index_entry(conversation_data, file_path)
         self._resync_topics_index(old_topics, new_topics, conversation_id)

--- a/src/exporters/json_exporter.py
+++ b/src/exporters/json_exporter.py
@@ -143,6 +143,19 @@ class JsonExporter(BaseExporter):
                 "conversation_count": 0,
             }
 
+        errors.extend(self._validate_conversation_entries(conversations))
+
+        return {
+            "valid": not errors,
+            "errors": errors,
+            "warnings": warnings,
+            "conversation_count": len(conversations),
+        }
+
+    @staticmethod
+    def _validate_conversation_entries(conversations: list[Any]) -> list[str]:
+        """Per-conversation universal-format checks. Returns error strings."""
+        errors: list[str] = []
         for idx, conv in enumerate(conversations):
             if not isinstance(conv, dict):
                 errors.append(f"Conversation {idx} is not an object")
@@ -152,13 +165,7 @@ class JsonExporter(BaseExporter):
                     errors.append(f"Conversation {idx} missing required field '{field_name}'")
             if "messages" in conv and not isinstance(conv["messages"], list):
                 errors.append(f"Conversation {idx} 'messages' must be a list")
-
-        return {
-            "valid": not errors,
-            "errors": errors,
-            "warnings": warnings,
-            "conversation_count": len(conversations),
-        }
+        return errors
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/importers/generic_importer.py
+++ b/src/importers/generic_importer.py
@@ -635,45 +635,11 @@ class GenericImporter(BaseImporter):
             # Use entire data as content
             content = json.dumps(data, indent=2)
 
-        # Process messages if they exist
-        if messages and isinstance(messages, list):
-            processed_messages = []
-            for msg in messages:
-                if isinstance(msg, dict):
-                    role = (
-                        self._extract_field(msg, ["role", "speaker", "user", "author"]) or "unknown"
-                    )
-                    msg_content = self._extract_field(msg, ["content", "text", "message"]) or str(
-                        msg
-                    )
-
-                    message = self._create_message(
-                        role=self._normalize_role(role),
-                        content=msg_content,
-                        metadata={"original": msg},
-                    )
-                    processed_messages.append(message)
-            messages = processed_messages
-        else:
-            messages = []
+        messages = self._process_raw_messages(messages)
 
         # Generate content from messages if needed
         if not content and messages:
             content = self._combine_messages_to_content(messages)
-
-        # Pass-through universal metadata extraction.
-        # Generic importer accepts arbitrary dicts so we forward any
-        # known universal-metadata keys directly.
-        session_id = self._extract_field(data, ["session_id", "conversation_id"])
-        user_id = self._extract_field(data, ["user_id", "account_id", "owner_id"])
-        explicit_tags = self._extract_field(data, ["tags", "labels"])
-        tags = [str(t) for t in explicit_tags if t] if isinstance(explicit_tags, list) else []
-        explicit_type = self._extract_field(data, ["conversation_type", "type", "category"])
-        conversation_type = (
-            explicit_type if isinstance(explicit_type, str) and explicit_type else None
-        )
-        explicit_custom = self._extract_field(data, ["custom_fields", "extra", "extras"])
-        custom_fields = explicit_custom if isinstance(explicit_custom, dict) else {}
 
         return self.create_universal_conversation(
             platform_id=f"generic_{int(datetime.now().timestamp())}",
@@ -683,12 +649,55 @@ class GenericImporter(BaseImporter):
             date=datetime.now(),
             model="unknown",
             metadata={"original_keys": list(data.keys())},
-            session_id=session_id if isinstance(session_id, str) else None,
-            user_id=user_id if isinstance(user_id, str) else None,
-            tags=tags,
-            conversation_type=conversation_type,
-            custom_fields=custom_fields,
+            **self._extract_universal_metadata(data),
         )
+
+    def _process_raw_messages(self, messages: Any) -> list[dict[str, Any]]:
+        """Normalize an arbitrary messages value into universal message dicts.
+
+        Non-list input, or entries that are not dicts, are dropped.
+        """
+        if not (messages and isinstance(messages, list)):
+            return []
+
+        processed: list[dict[str, Any]] = []
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            role = self._extract_field(msg, ["role", "speaker", "user", "author"]) or "unknown"
+            msg_content = self._extract_field(msg, ["content", "text", "message"]) or str(msg)
+            processed.append(
+                self._create_message(
+                    role=self._normalize_role(role),
+                    content=msg_content,
+                    metadata={"original": msg},
+                )
+            )
+        return processed
+
+    def _extract_universal_metadata(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Forward known universal-metadata keys out of an arbitrary dict.
+
+        The generic importer accepts any shape, so each value is type-checked
+        and falls back to a neutral default rather than being trusted.
+        """
+        session_id = self._extract_field(data, ["session_id", "conversation_id"])
+        user_id = self._extract_field(data, ["user_id", "account_id", "owner_id"])
+        explicit_tags = self._extract_field(data, ["tags", "labels"])
+        explicit_type = self._extract_field(data, ["conversation_type", "type", "category"])
+        explicit_custom = self._extract_field(data, ["custom_fields", "extra", "extras"])
+
+        return {
+            "session_id": session_id if isinstance(session_id, str) else None,
+            "user_id": user_id if isinstance(user_id, str) else None,
+            "tags": (
+                [str(t) for t in explicit_tags if t] if isinstance(explicit_tags, list) else []
+            ),
+            "conversation_type": (
+                explicit_type if isinstance(explicit_type, str) and explicit_type else None
+            ),
+            "custom_fields": explicit_custom if isinstance(explicit_custom, dict) else {},
+        }
 
     def _parse_list_as_conversation(self, data: list[Any]) -> dict[str, Any]:
         """Parse list as conversation - treat as messages array."""

--- a/src/server_fastmcp.py
+++ b/src/server_fastmcp.py
@@ -373,6 +373,33 @@ def _format_metadata_results(results: list, *, label: str, value: str) -> str:
     return response
 
 
+def _format_consistency_section(consistency: dict | None) -> str:
+    """Render the store-consistency section of the search-stats report.
+
+    Only speaks up when something is actually wrong — a healthy store gets one
+    line, not a table of zeros. Returns "" when no consistency data is present.
+    """
+    if not consistency:
+        return ""
+
+    if consistency.get("consistent", True):
+        return f"\n• Store Consistency: OK ({consistency['json_files']} files)\n"
+
+    labels = {
+        "orphan_files": "files on disk missing from the search index",
+        "dangling_rows": "indexed rows whose file is gone",
+        "index_missing": "files on disk missing from index.json",
+        "index_stale": "index.json entries whose file is gone",
+    }
+    section = "\n⚠ Store Consistency — drift detected:\n"
+    for key, label in labels.items():
+        if consistency.get(key):
+            section += f"  - {consistency[key]} {label}\n"
+    for key, paths in consistency.get("samples", {}).items():
+        section += f"    e.g. {key}: {', '.join(paths)}\n"
+    return section
+
+
 @mcp.tool()
 async def get_search_stats() -> str:
     """Get search engine statistics and performance information"""
@@ -404,24 +431,7 @@ async def get_search_stats() -> str:
         for type_info in stats["conversation_types"]:
             response += f"  - {type_info['type']}: {type_info['count']}\n"
 
-    # Only speak up about consistency when something is actually wrong — a
-    # healthy store gets one line, not a table of zeros.
-    consistency = stats.get("consistency")
-    if consistency and not consistency.get("consistent", True):
-        response += "\n⚠ Store Consistency — drift detected:\n"
-        labels = {
-            "orphan_files": "files on disk missing from the search index",
-            "dangling_rows": "indexed rows whose file is gone",
-            "index_missing": "files on disk missing from index.json",
-            "index_stale": "index.json entries whose file is gone",
-        }
-        for key, label in labels.items():
-            if consistency.get(key):
-                response += f"  - {consistency[key]} {label}\n"
-        for key, paths in consistency.get("samples", {}).items():
-            response += f"    e.g. {key}: {', '.join(paths)}\n"
-    elif consistency:
-        response += f"\n• Store Consistency: OK ({consistency['json_files']} files)\n"
+    response += _format_consistency_section(stats.get("consistency"))
 
     if "consistency_error" in stats:
         response += f"\nConsistency Check Error: {stats['consistency_error']}\n"


### PR DESCRIPTION
Clears **every** cognitive-complexity violation in this repo — 5 functions over the SonarQube S3776 threshold of 15. No behaviour changes.

| file | function | before |
|---|---|---|
| `conversation_memory.py` | `update_conversation` | **36** |
| `importers/generic_importer.py` | `_parse_dict_as_conversation` | 21 |
| `server_fastmcp.py` | `get_search_stats` | 20 |
| `conversation_memory.py` | `add_conversation` | 19 |
| `exporters/json_exporter.py` | `validate` | 16 |

## Why extraction, not shortening

In every case the cost was **nesting, not length**. S3776 charges a branch progressively by how deep it sits, so a `for` loop with an `if` inside it, sitting inside a `try`, costs several times what the same code costs at top level. Pulling the innermost block into a named function is worth far more than trimming lines.

Nine helpers, each a seam that already existed in the code:

| helper | responsibility |
|---|---|
| `_resolve_conversation_date` | ISO parse with `now()` fallback |
| `_derive_title` | first line, truncated at 50 |
| `_optional_metadata` | universal keys, omitted when empty |
| `_apply_scalar_updates` | the five plain field updates |
| `_merge_tags` | set/add/remove resolution |
| `_resync_sqlite_for_update` | SQLite push + rollback-on-failure |
| `_validate_conversation_entries` | per-conversation field checks |
| `_format_consistency_section` | the store-consistency report block |
| `_process_raw_messages` | arbitrary messages → universal dicts |
| `_extract_universal_metadata` | type-checked metadata pass-through |

## Behaviour preserved deliberately, including the subtle parts

These are the places a careless extraction would have changed semantics:

- **`_merge_tags` returns the *same list object*** when no tag op applies, so the `new_tags != existing_tags` check downstream still short-circuits exactly as before. Returning a copy would have marked every update as a tag change.
- **`_apply_scalar_updates` keeps `title`'s extra "only if different" guard** while the other four record a change on any non-`None` value — an inconsistency in the original that I preserved rather than tidied. It also keeps field ordering, so the audit line reads identically.
- **`_format_consistency_section` keeps the if/elif asymmetry**: silent when absent, one OK line when healthy, the drift table otherwise.
- **`_optional_metadata` still copies** `tags` / `custom_fields` via `list()` / `dict()` rather than aliasing the caller's objects.
- **`_process_raw_messages` drops non-dict entries silently**, as the original `if isinstance(msg, dict)` did.

If any of those behaviours are actually bugs, they deserve their own PR with their own tests — changing them inside a complexity refactor would make the diff impossible to review.

## Verification

```
pytest tests/            896 passed, 1 skipped   (identical to before)
flake8 CCR001@15 src/    clean
pre-commit run           all hooks pass
```

## Context

Part of a workspace sweep: `~/Code` had 24 cognitive-complexity violations across 7 Python repos. This repo is the actively developed one, so it's where the CI round-trip actually costs something. The canonical pre-commit template in devops now carries a blocking `CCR001@15` gate (adamkwhite/devops#27).
